### PR TITLE
#3738 Init expressions for struct members, review

### DIFF
--- a/tests/language-feature/struct-field-initializers/struct-field-initializer-inherited.slang
+++ b/tests/language-feature/struct-field-initializers/struct-field-initializer-inherited.slang
@@ -1,0 +1,51 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain 
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-cpu -compute -entry computeMain
+//TEST(smoke,compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-dx12 -use-dxil -compute -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+static int myOne = 1;
+
+public struct DefaultStruct_base
+{
+    int data0;
+    int data1 = myOne;
+    int data2 = 1;
+    int data3 = 1;
+};
+struct DefaultStruct : DefaultStruct_base
+{
+    int data4 = 3;
+    int data5 = 0;
+    __init()
+    {
+        data3 = data3 == 1;
+        data5 = 1;
+        data4 = data3;
+    }
+};
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    DefaultStruct_base initStructBase = DefaultStruct_base();
+    initStructBase.data0 = 1;
+
+    DefaultStruct initStruct = DefaultStruct();
+    initStruct.data0 = 1;
+    // BUF: 1
+    outputBuffer[0] = true
+        && initStructBase.data0 == 1
+        && initStructBase.data1 == 1
+        && initStructBase.data2 == 1
+        && initStructBase.data3 == 1
+
+        && initStruct.data0 == 1
+        && initStruct.data1 == 1
+        && initStruct.data2 == 1
+        && initStruct.data3 == 1
+        && initStruct.data4 == 1
+        && initStruct.data5 == 1;
+        ;
+}

--- a/tests/language-feature/struct-field-initializers/struct-field-initializer.slang
+++ b/tests/language-feature/struct-field-initializers/struct-field-initializer.slang
@@ -1,0 +1,60 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain 
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-cpu -compute -entry computeMain
+//TEST(smoke,compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-dx12 -use-dxil -compute -entry computeMain
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+static int myTwo = 2;
+static int myThree = 1+2;
+
+struct DefaultStructNoInit
+{
+    int data0;
+    int data1 = myTwo;
+    int data2 = 2;
+};
+struct DefaultStructWithInit
+{
+    int data0 = 3;
+    int data1 = myThree;
+    int data2;
+    __init()
+    {
+        data2 = 3;
+    }
+};
+struct DefaultStructWithInit2
+{
+    int data0 = 4;
+    int data1 = 1;
+    int data2 = 1;
+    __init()
+    {
+        data1 = 4;
+        data2 = 4;
+    }
+};
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    DefaultStructNoInit noInit = DefaultStructNoInit();
+    noInit.data0 = 2;
+    DefaultStructWithInit withInit = DefaultStructWithInit();
+    DefaultStructWithInit2 withInit2 = DefaultStructWithInit2();
+    // BUF: 1
+    outputBuffer[0] = true
+        && noInit.data0 == 2
+        && noInit.data1 == 2
+        && noInit.data2 == 2
+
+        && withInit.data0 == 3
+        && withInit.data1 == 3
+        && withInit.data2 == 3
+
+        && withInit2.data0 == 4
+        && withInit2.data1 == 4
+        && withInit2.data2 == 4
+        ;
+}


### PR DESCRIPTION
Following commit handles init expressions of struct's.

The general implementation follows C++ init expression rules for classes & inherited classes.

The logic was implemented after type resolution (`SemanticsDeclAttributesVisitor`):
1. Create a default constructor if missing.
2. Check all member variables (`this` and `super`) for if a member has an init expression, continue to *3* if found.
3. For each constructor, insert a member varaible's init expression at the begining of a constructor. This is to follow how C++ does construction of objects.

Some important notes about implementation:
* We must handle the senario that there is inheritance. To handle the inheritance information processing `findLevelsOfInheritance` was created.
* If a user manually sets oveload rank's of constructor expression's we have no way to assume new default constructor overload ranks.