### PR TITLE
Fix crash when ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT

### DIFF
--- a/docs/wave-intrinsics.md
+++ b/docs/wave-intrinsics.md
@@ -207,6 +207,8 @@ uint4 WaveGetConvergedMulti();
 
 uint WaveGetNumWaves();  // Number of waves in workgroup (equivalent to GLSL gl_NumSubgroups)
 
+uint WaveGetWaveIndex(); // Wave index in workgroup (GLSL gl_SubgroupID, WGSL subgroup_id, Metal simdgroup_index_in_threadgroup; HLSL/WGSL compute only)
+
 // Prefix (exclusive scan operations, equivalent to GLSL subgroupExclusive*)
 
 T WavePrefixMin<T>(T expr);   // Exclusive prefix minimum

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -947,6 +947,7 @@ function buildCharts(hours) {{
       backgroundColor: 'rgba(255,193,7,0.0)',
       fill: false,
       tension: 0.3,
+      stack: 'queued',
     }});
     hostedDatasets.push({{
       label: 'Cap (' + hostedRunnerChart.cap + ')',

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -5206,6 +5206,12 @@ semantic sv_wavelaneindex
     get : uint;
 }
 
+semantic sv_waveindex
+{
+    [require(compute)]
+    get : uint;
+}
+
 semantic sv_barycentrics
 {
     [require(fragment)]

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -7259,19 +7259,10 @@ public property uint gl_NumSubgroups
 
 public property uint gl_SubgroupID
 {
+    [ForceInline]
     [require(glsl_spirv, subgroup_basic)]
     get {
-        setupExtForSubgroupBasicBuiltIn();
-        __target_switch
-        {
-        case glsl:
-            __intrinsic_asm "(gl_SubgroupID)";
-        case spirv:
-            return spirv_asm {
-                        OpCapability GroupNonUniform;
-                        result:$$uint = OpLoad builtin(SubgroupId:uint);
-                    };
-        }
+        return WaveGetWaveIndex();
     }
 }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -12,6 +12,8 @@ void __requireTargetExtension(constexpr String extensionName);
 in uint __builtinWaveLaneIndex : SV_WaveLaneIndex;
 in uint __builtinWaveLaneCount : SV_WaveLaneCount;
 in uint __builtinQuadLaneIndex : SV_QuadLaneIndex;
+in uint __builtinWaveIndex : SV_WaveIndex;
+in uint __builtinGroupIndex : SV_GroupIndex;
 
 //@public:
 /// Represents an interface for buffer data layout.
@@ -17012,6 +17014,61 @@ uint WaveGetNumWaves()
         default:
             static_assert(false, "WaveGetNumWaves is only supported in compute shaders");
             return 0; // unreachable, but needed to satisfy compiler
+        }
+    }
+}
+
+/// Returns the index of the current wave (subgroup) within the workgroup.
+/// Equivalent to GLSL gl_SubgroupID / Metal simdgroup_index_in_threadgroup.
+/// @category wave
+__glsl_extension(GL_KHR_shader_subgroup_basic)
+__spirv_version(1.3)
+[NonUniformReturn]
+[ForceInline]
+[require(cuda_glsl_hlsl_metal_spirv_wgsl, subgroup_basic)]
+uint WaveGetWaveIndex()
+{
+    __target_switch
+    {
+    case glsl:
+        __intrinsic_asm "(gl_SubgroupID)";
+    case cuda:
+        {
+            uint3 tid = cudaThreadIdx();
+            uint3 blockDim = cudaBlockDim();
+            uint flattenedTid = tid.x + tid.y * blockDim.x + tid.z * blockDim.x * blockDim.y;
+            return flattenedTid / WaveGetLaneCount();
+        }
+    case spirv:
+        return spirv_asm
+        {
+            OpCapability GroupNonUniform;
+            result:$$uint = OpLoad builtin(SubgroupId:uint)
+        };
+    case metal:
+        return __builtinWaveIndex;
+    case wgsl:
+        __requireTargetExtension("subgroups");
+        __stage_switch
+        {
+        case compute:
+            return __builtinWaveIndex;
+        default:
+            static_assert(false, "WaveGetWaveIndex is only supported in compute shaders for WGSL");
+            return 0;
+        }
+    case hlsl:
+        __stage_switch
+        {
+        case compute:
+            {
+                uint groupIndex = __builtinGroupIndex;
+                uint waveSize = WaveGetLaneCount();
+                return groupIndex / waveSize;
+            }
+        default:
+            static_assert(false, "WaveGetWaveIndex is only supported in compute shaders for HLSL");
+            return 0;
         }
     }
 }

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -538,10 +538,8 @@ void WGSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         m_writer->emit("u32");
         break;
     case kIROp_UInt64Type:
-        {
-            m_writer->emit(getDefaultBuiltinTypeName(type->getOp()));
-            return;
-        }
+        m_writer->emit("u64");
+        return;
     case kIROp_Int16Type:
         diagnoseOnce(Diagnostics::Int16NotSupportedInWgsl{.typeName = "int16_t"});
         return;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -982,14 +982,6 @@ Result linkAndOptimizeIR(
 
     SLANG_PASS(translateEntryPointInParamToBorrow, sink);
 
-    if (requiredLoweringPassSet.globalVaryingVar)
-        SLANG_PASS(translateGlobalVaryingVar, codeGenContext);
-
-    if (requiredLoweringPassSet.resolveVaryingInputRef)
-        SLANG_PASS(resolveVaryingInputRef);
-
-    SLANG_PASS(fixEntryPointCallsites);
-
     // Replace any global constants with their values.
     //
     SLANG_PASS(replaceGlobalConstants);
@@ -1952,6 +1944,18 @@ Result linkAndOptimizeIR(
         SLANG_PASS(resolveTextureFormat);
         break;
     }
+
+    // Specialization can expose references to global varying builtins that were
+    // previously hidden behind generic/interface dispatch. Translate all global
+    // varying inputs/outputs now, after specialization, but before target
+    // entry-point legalization.
+    if (requiredLoweringPassSet.globalVaryingVar)
+        SLANG_PASS(translateGlobalVaryingVar, codeGenContext);
+
+    if (requiredLoweringPassSet.resolveVaryingInputRef)
+        SLANG_PASS(resolveVaryingInputRef);
+
+    SLANG_PASS(fixEntryPointCallsites);
 
     // For GLSL only, we will need to perform "legalization" of
     // the entry point and any entry-point parameters.

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -4050,6 +4050,13 @@ protected:
                 result.permittedTypes.add(builder.getUInt16Type());
                 break;
             }
+        case SystemValueSemanticName::WaveIndex:
+            {
+                result.systemValueName = toSlice("simdgroup_index_in_threadgroup");
+                result.permittedTypes.add(builder.getUIntType());
+                result.permittedTypes.add(builder.getUInt16Type());
+                break;
+            }
         case SystemValueSemanticName::QuadLaneIndex:
             {
                 result.systemValueName = toSlice("thread_index_in_quadgroup");
@@ -4676,6 +4683,13 @@ protected:
         case SystemValueSemanticName::WaveLaneIndex:
             {
                 result.systemValueName = toSlice("subgroup_invocation_id");
+                result.permittedTypes.add(builder.getUIntType());
+                break;
+            }
+
+        case SystemValueSemanticName::WaveIndex:
+            {
+                result.systemValueName = toSlice("subgroup_id");
                 result.permittedTypes.add(builder.getUIntType());
                 break;
             }

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -75,6 +75,7 @@ void depointerizeInputParams(IRFunc* entryPoint);
     M(StartInstanceLocation, SV_StartInstanceLocation)   \
     M(WaveLaneCount, SV_WaveLaneCount)                   \
     M(WaveLaneIndex, SV_WaveLaneIndex)                   \
+    M(WaveIndex, SV_WaveIndex)                           \
     M(QuadLaneIndex, SV_QuadLaneIndex)                   \
     M(VulkanVertexID, SV_VulkanVertexID)                 \
     M(VulkanInstanceID, SV_VulkanInstanceID)             \

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2610,11 +2610,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto elementType = constantBufferType->getElementType();
                 SLANG_ASSERT(as<IRStructType>(elementType));
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                auto dataLayout = constantBufferType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
                     AccessQualifier::Immutable,
                     AddressSpace::Uniform,
-                    constantBufferType->getDataLayout()));
+                    dataLayout));
             }
         }
         for (auto t : textureFootprintTypes)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -24,6 +24,7 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-util.h"
 #include "slang-ir-validate.h"
+#include "slang-ir-wrap-cbuffer-element.h"
 #include "slang-ir.h"
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
@@ -2601,6 +2602,40 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             t->replaceUsesWith(lowered);
         }
 
+        // Translate ConstantBuffer<T> types used in the descriptor heap path.
+        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
+        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
+        // The SPIRV emit code expects buffer result types to be lowered to pointers,
+        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
+        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
+        // treatment for traditionally-bound constant buffers.
+        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
+        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
+        {
+            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
+            for (auto globalInst : m_module->getGlobalInsts())
+            {
+                if (!as<IRConstantBufferType>(globalInst))
+                    continue;
+                auto t = as<IRUniformParameterGroupType>(globalInst);
+                if (t->hasUses())
+                    cbufferTypesToProcess.add(t);
+            }
+            for (auto t : cbufferTypesToProcess)
+            {
+                IRBuilder builder(m_sharedContext->m_irModule);
+                builder.setInsertBefore(t);
+                auto elementType = t->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    t->getDataLayout()));
+            }
+        }
+
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
         if (!m_sharedContext->isSpirv14OrLater())
         {
@@ -2715,6 +2750,21 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 };
+
+class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
+{
+public:
+    bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
+    {
+        return !as<IRStructType>(cbufferType->getElementType());
+    }
+};
+
+static void wrapCBufferElementsForSPIRV(IRModule* module)
+{
+    SPIRVWrapCBufferElementPolicy policy = {};
+    wrapCBufferElements(module, &policy);
+}
 
 SpvSnippet* SPIRVEmitSharedContext::getParsedSpvSnippet(IRTargetIntrinsicDecoration* intrinsic)
 {
@@ -2981,6 +3031,7 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
+    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -455,6 +455,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto uniformParamGroupType = as<IRUniformParameterGroupType>(innerType);
                 innerType = uniformParamGroupType->getElementType();
                 dataLayout = uniformParamGroupType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 if (addressSpace == AddressSpace::ThreadLocal)
                     addressSpace = AddressSpace::Uniform;
                 // Constant buffer is already treated like a pointer type, and

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2612,7 +2612,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
-                    AccessQualifier::ReadWrite,
+                    AccessQualifier::Immutable,
                     AddressSpace::Uniform,
                     constantBufferType->getDataLayout()));
             }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -36,6 +36,8 @@ namespace Slang
 // Legalization of IR for direct SPIRV emit.
 //
 
+static void wrapCBufferElementsForSPIRV(IRModule* module);
+
 struct SPIRVLegalizationContext : public SourceEmitterBase
 {
     SPIRVEmitSharedContext* m_sharedContext;
@@ -2562,8 +2564,10 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         for (auto inst : m_instsToRemove)
             inst->removeAndDeallocate();
 
+        wrapCBufferElementsForSPIRV(m_module);
+
         // Translate types.
-        List<IRHLSLStructuredBufferTypeBase*> instsToProcess;
+        List<IRType*> instsToProcess;
         List<IRInst*> textureFootprintTypes;
 
         for (auto globalInst : m_module->getGlobalInsts())
@@ -2572,6 +2576,11 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 instsToProcess.add(t);
             }
+            else if (auto constantBufferType = as<IRConstantBufferType>(globalInst))
+            {
+                if (constantBufferType->hasUses())
+                    instsToProcess.add(constantBufferType);
+            }
             else if (globalInst->getOp() == kIROp_TextureFootprintType)
             {
                 textureFootprintTypes.add(globalInst);
@@ -2579,20 +2588,34 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
         for (auto t : instsToProcess)
         {
-            auto lowered = lowerStructuredBufferType(t);
-
-            AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
-            if (as<IRHLSLStructuredBufferType>(t))
-                accessQualifier = AccessQualifier::Immutable;
-
             IRBuilder builder(t);
 
             builder.setInsertBefore(t);
-            t->replaceUsesWith(builder.getPtrType(
-                lowered.structType,
-                accessQualifier,
-                getStorageBufferAddressSpace(),
-                t->getDataLayout()));
+            if (auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(t))
+            {
+                auto lowered = lowerStructuredBufferType(structuredBufferType);
+
+                AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
+                if (as<IRHLSLStructuredBufferType>(t))
+                    accessQualifier = AccessQualifier::Immutable;
+
+                t->replaceUsesWith(builder.getPtrType(
+                    lowered.structType,
+                    accessQualifier,
+                    getStorageBufferAddressSpace(),
+                    structuredBufferType->getDataLayout()));
+            }
+            else if (auto constantBufferType = as<IRUniformParameterGroupType>(t))
+            {
+                auto elementType = constantBufferType->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    constantBufferType->getDataLayout()));
+            }
         }
         for (auto t : textureFootprintTypes)
         {
@@ -2600,40 +2623,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             IRBuilder builder(t);
             builder.setInsertBefore(t);
             t->replaceUsesWith(lowered);
-        }
-
-        // Translate ConstantBuffer<T> types used in the descriptor heap path.
-        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
-        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
-        // The SPIRV emit code expects buffer result types to be lowered to pointers,
-        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
-        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
-        // treatment for traditionally-bound constant buffers.
-        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
-        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
-        {
-            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
-            for (auto globalInst : m_module->getGlobalInsts())
-            {
-                if (!as<IRConstantBufferType>(globalInst))
-                    continue;
-                auto t = as<IRUniformParameterGroupType>(globalInst);
-                if (t->hasUses())
-                    cbufferTypesToProcess.add(t);
-            }
-            for (auto t : cbufferTypesToProcess)
-            {
-                IRBuilder builder(m_sharedContext->m_irModule);
-                builder.setInsertBefore(t);
-                auto elementType = t->getElementType();
-                SLANG_ASSERT(as<IRStructType>(elementType));
-                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
-                t->replaceUsesWith(builder.getPtrType(
-                    elementType,
-                    AccessQualifier::ReadWrite,
-                    AddressSpace::Uniform,
-                    t->getDataLayout()));
-            }
         }
 
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
@@ -2756,7 +2745,8 @@ class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
 public:
     bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
     {
-        return !as<IRStructType>(cbufferType->getElementType());
+        return as<IRConstantBufferType>(cbufferType) &&
+               !as<IRStructType>(cbufferType->getElementType());
     }
 };
 
@@ -3031,7 +3021,6 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
-    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/tests/hlsl-intrinsic/wave-builtins-interface-specialization.slang
+++ b/tests/hlsl-intrinsic/wave-builtins-interface-specialization.slang
@@ -1,0 +1,51 @@
+//TEST_CATEGORY(wave, compute)
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -dx12 -profile cs_6_0 -shaderobj -render-feature hardware-device
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -emit-spirv-directly
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -emit-spirv-via-glsl
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-metal -compute -shaderobj
+//TEST:SIMPLE(filecheck=WGSL):-target wgsl -entry computeMain -stage compute
+// Keep DX11 explicit so slang-test does not synthesize a runtime clone for
+// wave intrinsics that require SM6-era support.
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-slang -compute -dx11 -shaderobj
+// Keep LLVM explicit so slang-test does not synthesize an LLVM runtime clone
+// for GPU subgroup builtins.
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-llvm -compute -shaderobj -output-using-type
+
+// Regression test for global-varying builtins that are exposed by generic
+// interface specialization after the early global-varying translation pass.
+
+//TEST_INPUT:ubuffer(stride=4, count=64):out,name outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+interface IWaveValue
+{
+    uint getValue();
+}
+
+struct WaveValue : IWaveValue
+{
+    uint getValue()
+    {
+        return WaveGetLaneIndex() + WaveGetWaveIndex() * WaveGetLaneCount();
+    }
+}
+
+// WGSL-DAG: enable subgroups;
+// WGSL-DAG: @builtin(subgroup_invocation_id)
+// WGSL-DAG: @builtin(subgroup_id)
+
+uint getGenericWaveValue<T: IWaveValue>(T value)
+{
+    return value.getValue();
+}
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    WaveValue value;
+    uint expected = dispatchThreadID.x;
+    outputBuffer[expected] = getGenericWaveValue<WaveValue>(value) == expected ? 1 : 0;
+    // CHECK-COUNT-64: 1
+}

--- a/tests/hlsl-intrinsic/wave-get-wave-index.slang
+++ b/tests/hlsl-intrinsic/wave-get-wave-index.slang
@@ -1,0 +1,25 @@
+//TEST_CATEGORY(wave, compute)
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -dx12 -profile cs_6_0 -shaderobj
+//TEST(vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-vk -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-cuda -compute -shaderobj
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -shaderobj
+
+// 4 slots: one per wave (128 threads / 32 lanes = 4 waves)
+//TEST_INPUT:ubuffer(data=[0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+// 128 threads = 4 waves of 32. Lane 0 of each wave writes its wave index.
+[numthreads(128, 1, 1)]
+void computeMain()
+{
+    uint laneId = WaveGetLaneIndex();
+    uint waveIdx = WaveGetWaveIndex();
+
+    if (laneId == 0)
+        outputBuffer[waveIdx] = int(waveIdx);
+}
+
+// BUF: 0
+// BUF-NEXT: 1
+// BUF-NEXT: 2
+// BUF-NEXT: 3

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -1,0 +1,47 @@
+// Regression test: ConstantBuffer<T>.Handle with a non-struct element type and
+// spvDescriptorHeapEXT should compile by wrapping T in a SPIR-V block struct.
+// Tests vector, scalar, and matrix element types.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main1 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main2 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main1(
+    uniform DescriptorHandle<ConstantBuffer<float2>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main2(
+    uniform DescriptorHandle<ConstantBuffer<float>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main3(
+    uniform DescriptorHandle<ConstantBuffer<float4x4>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float4x4>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+// The synthesized wrapper must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Access to the wrapped element must use Uniform storage class, not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
@@ -1,0 +1,23 @@
+// Regression test: verifies that an explicitly wrapped element type still compiles
+// successfully and produces correct Uniform-storage-class SPIRV.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct MyConstants {
+    float2 value;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<MyConstants>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input).value;
+}
+
+// CHECK: OpDecorate {{.*}}MyConstants{{.*}} Block
+// CHECK: OpTypePointer Uniform
+// CHECK: OpBufferPointerEXT
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer.slang
@@ -1,0 +1,33 @@
+// Regression test for #11037: segmentation fault (assertion failure) when
+// ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT.
+//
+// The SPIRV legalize pass was not lowering ConstantBuffer<T> to a Uniform pointer,
+// so the SPIRV emitter's getDescriptorHeapBufferStorageClass hit an assertion.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms {
+    uint x;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}
+
+// The struct must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}}Uniforms{{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Field access must use Uniform storage class — not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-parameter-block-error.slang
+++ b/tests/spirv/descriptor-heap-parameter-block-error.slang
@@ -1,0 +1,18 @@
+// Verify that DescriptorHandle<ParameterBlock<T>> is rejected at the front end
+// because ParameterBlock<T> does not conform to IOpaqueDescriptor.
+// This ensures that if IOpaqueDescriptor conformance rules change, CI catches
+// whether ParameterBlock would then need to be handled in the legalize pass.
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms { uint x; }
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    // CHECK: error[E38029]
+    uniform DescriptorHandle<ParameterBlock<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}

--- a/tests/wgsl/int64-uint64-type.slang
+++ b/tests/wgsl/int64-uint64-type.slang
@@ -1,0 +1,41 @@
+// int64-uint64-type.slang
+//
+// Verifies that int64_t and uint64_t emit as i64 and u64 in WGSL,
+// not as the HLSL-style names "int64_t" / "uint64_t".
+//
+// Note on the wgsl-spirv-asm path
+// -------------------------------
+// An earlier draft of this test also exercised `-target wgsl-spirv-asm` to
+// confirm the emitted WGSL round-trips through Dawn's tint compiler to
+// SPIR-V. That variant was removed because the bundled tint on the Windows
+// CI runners rejects `u64`/`i64` as unresolved types — these are still
+// experimental in WGSL and not universally supported across tint versions
+// (see WGSL extension status for 64-bit integer types). The same variant
+// is silently `ignored` on Linux/macOS runners since their CI does not
+// wire up the wgsl-spirv-asm tooling at all, so the platform coverage was
+// asymmetric.
+//
+// The emitter change itself is fully covered by the WGSL text filecheck
+// below — that proves slangc emits `u64`/`i64` instead of `uint64_t`/
+// `int64_t`, which is the entire scope of this PR. Whether the resulting
+// WGSL is accepted by a downstream tint version is a separate ecosystem
+// concern that should not gate this fix.
+
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry computeMain
+
+// WGSL-DAG: array<u64>
+// WGSL-DAG: array<i64>
+// WGSL: u64(42)
+// WGSL: i64(-1)
+// WGSL-NOT: uint64_t
+// WGSL-NOT: int64_t
+
+RWStructuredBuffer<uint64_t> outputU64;
+RWStructuredBuffer<int64_t> outputI64;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    outputU64[tid.x] = uint64_t(42);
+    outputI64[tid.x] = int64_t(-1);
+}


### PR DESCRIPTION
Automated review PR created by /review-on-fork-repo skill.