### PR TITLE
Fix crash when ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT

### DIFF
--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2610,11 +2610,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto elementType = constantBufferType->getElementType();
                 SLANG_ASSERT(as<IRStructType>(elementType));
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                auto dataLayout = constantBufferType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
                     AccessQualifier::Immutable,
                     AddressSpace::Uniform,
-                    constantBufferType->getDataLayout()));
+                    dataLayout));
             }
         }
         for (auto t : textureFootprintTypes)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -24,6 +24,7 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-util.h"
 #include "slang-ir-validate.h"
+#include "slang-ir-wrap-cbuffer-element.h"
 #include "slang-ir.h"
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
@@ -2601,6 +2602,40 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             t->replaceUsesWith(lowered);
         }
 
+        // Translate ConstantBuffer<T> types used in the descriptor heap path.
+        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
+        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
+        // The SPIRV emit code expects buffer result types to be lowered to pointers,
+        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
+        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
+        // treatment for traditionally-bound constant buffers.
+        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
+        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
+        {
+            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
+            for (auto globalInst : m_module->getGlobalInsts())
+            {
+                if (!as<IRConstantBufferType>(globalInst))
+                    continue;
+                auto t = as<IRUniformParameterGroupType>(globalInst);
+                if (t->hasUses())
+                    cbufferTypesToProcess.add(t);
+            }
+            for (auto t : cbufferTypesToProcess)
+            {
+                IRBuilder builder(m_sharedContext->m_irModule);
+                builder.setInsertBefore(t);
+                auto elementType = t->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    t->getDataLayout()));
+            }
+        }
+
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
         if (!m_sharedContext->isSpirv14OrLater())
         {
@@ -2715,6 +2750,21 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 };
+
+class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
+{
+public:
+    bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
+    {
+        return !as<IRStructType>(cbufferType->getElementType());
+    }
+};
+
+static void wrapCBufferElementsForSPIRV(IRModule* module)
+{
+    SPIRVWrapCBufferElementPolicy policy = {};
+    wrapCBufferElements(module, &policy);
+}
 
 SpvSnippet* SPIRVEmitSharedContext::getParsedSpvSnippet(IRTargetIntrinsicDecoration* intrinsic)
 {
@@ -2981,6 +3031,7 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
+    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -455,6 +455,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto uniformParamGroupType = as<IRUniformParameterGroupType>(innerType);
                 innerType = uniformParamGroupType->getElementType();
                 dataLayout = uniformParamGroupType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 if (addressSpace == AddressSpace::ThreadLocal)
                     addressSpace = AddressSpace::Uniform;
                 // Constant buffer is already treated like a pointer type, and

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2612,7 +2612,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
-                    AccessQualifier::ReadWrite,
+                    AccessQualifier::Immutable,
                     AddressSpace::Uniform,
                     constantBufferType->getDataLayout()));
             }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -36,6 +36,8 @@ namespace Slang
 // Legalization of IR for direct SPIRV emit.
 //
 
+static void wrapCBufferElementsForSPIRV(IRModule* module);
+
 struct SPIRVLegalizationContext : public SourceEmitterBase
 {
     SPIRVEmitSharedContext* m_sharedContext;
@@ -2562,8 +2564,10 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         for (auto inst : m_instsToRemove)
             inst->removeAndDeallocate();
 
+        wrapCBufferElementsForSPIRV(m_module);
+
         // Translate types.
-        List<IRHLSLStructuredBufferTypeBase*> instsToProcess;
+        List<IRType*> instsToProcess;
         List<IRInst*> textureFootprintTypes;
 
         for (auto globalInst : m_module->getGlobalInsts())
@@ -2572,6 +2576,11 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 instsToProcess.add(t);
             }
+            else if (auto constantBufferType = as<IRConstantBufferType>(globalInst))
+            {
+                if (constantBufferType->hasUses())
+                    instsToProcess.add(constantBufferType);
+            }
             else if (globalInst->getOp() == kIROp_TextureFootprintType)
             {
                 textureFootprintTypes.add(globalInst);
@@ -2579,20 +2588,34 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
         for (auto t : instsToProcess)
         {
-            auto lowered = lowerStructuredBufferType(t);
-
-            AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
-            if (as<IRHLSLStructuredBufferType>(t))
-                accessQualifier = AccessQualifier::Immutable;
-
             IRBuilder builder(t);
 
             builder.setInsertBefore(t);
-            t->replaceUsesWith(builder.getPtrType(
-                lowered.structType,
-                accessQualifier,
-                getStorageBufferAddressSpace(),
-                t->getDataLayout()));
+            if (auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(t))
+            {
+                auto lowered = lowerStructuredBufferType(structuredBufferType);
+
+                AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
+                if (as<IRHLSLStructuredBufferType>(t))
+                    accessQualifier = AccessQualifier::Immutable;
+
+                t->replaceUsesWith(builder.getPtrType(
+                    lowered.structType,
+                    accessQualifier,
+                    getStorageBufferAddressSpace(),
+                    structuredBufferType->getDataLayout()));
+            }
+            else if (auto constantBufferType = as<IRUniformParameterGroupType>(t))
+            {
+                auto elementType = constantBufferType->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    constantBufferType->getDataLayout()));
+            }
         }
         for (auto t : textureFootprintTypes)
         {
@@ -2600,40 +2623,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             IRBuilder builder(t);
             builder.setInsertBefore(t);
             t->replaceUsesWith(lowered);
-        }
-
-        // Translate ConstantBuffer<T> types used in the descriptor heap path.
-        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
-        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
-        // The SPIRV emit code expects buffer result types to be lowered to pointers,
-        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
-        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
-        // treatment for traditionally-bound constant buffers.
-        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
-        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
-        {
-            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
-            for (auto globalInst : m_module->getGlobalInsts())
-            {
-                if (!as<IRConstantBufferType>(globalInst))
-                    continue;
-                auto t = as<IRUniformParameterGroupType>(globalInst);
-                if (t->hasUses())
-                    cbufferTypesToProcess.add(t);
-            }
-            for (auto t : cbufferTypesToProcess)
-            {
-                IRBuilder builder(m_sharedContext->m_irModule);
-                builder.setInsertBefore(t);
-                auto elementType = t->getElementType();
-                SLANG_ASSERT(as<IRStructType>(elementType));
-                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
-                t->replaceUsesWith(builder.getPtrType(
-                    elementType,
-                    AccessQualifier::ReadWrite,
-                    AddressSpace::Uniform,
-                    t->getDataLayout()));
-            }
         }
 
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
@@ -2756,7 +2745,8 @@ class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
 public:
     bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
     {
-        return !as<IRStructType>(cbufferType->getElementType());
+        return as<IRConstantBufferType>(cbufferType) &&
+               !as<IRStructType>(cbufferType->getElementType());
     }
 };
 
@@ -3031,7 +3021,6 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
-    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -1,0 +1,47 @@
+// Regression test: ConstantBuffer<T>.Handle with a non-struct element type and
+// spvDescriptorHeapEXT should compile by wrapping T in a SPIR-V block struct.
+// Tests vector, scalar, and matrix element types.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main1 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main2 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main1(
+    uniform DescriptorHandle<ConstantBuffer<float2>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main2(
+    uniform DescriptorHandle<ConstantBuffer<float>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main3(
+    uniform DescriptorHandle<ConstantBuffer<float4x4>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float4x4>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+// The synthesized wrapper must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Access to the wrapped element must use Uniform storage class, not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
@@ -1,0 +1,23 @@
+// Regression test: verifies that an explicitly wrapped element type still compiles
+// successfully and produces correct Uniform-storage-class SPIRV.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct MyConstants {
+    float2 value;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<MyConstants>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input).value;
+}
+
+// CHECK: OpDecorate {{.*}}MyConstants{{.*}} Block
+// CHECK: OpTypePointer Uniform
+// CHECK: OpBufferPointerEXT
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer.slang
@@ -1,0 +1,33 @@
+// Regression test for #11037: segmentation fault (assertion failure) when
+// ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT.
+//
+// The SPIRV legalize pass was not lowering ConstantBuffer<T> to a Uniform pointer,
+// so the SPIRV emitter's getDescriptorHeapBufferStorageClass hit an assertion.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms {
+    uint x;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}
+
+// The struct must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}}Uniforms{{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Field access must use Uniform storage class — not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-parameter-block-error.slang
+++ b/tests/spirv/descriptor-heap-parameter-block-error.slang
@@ -1,0 +1,18 @@
+// Verify that DescriptorHandle<ParameterBlock<T>> is rejected at the front end
+// because ParameterBlock<T> does not conform to IOpaqueDescriptor.
+// This ensures that if IOpaqueDescriptor conformance rules change, CI catches
+// whether ParameterBlock would then need to be handled in the legalize pass.
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms { uint x; }
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    // CHECK: error[E38029]
+    uniform DescriptorHandle<ParameterBlock<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}


### PR DESCRIPTION
Automated review PR created by /review-on-fork-repo skill.