### PR TITLE
Emit default ray payload access qualifiers

### DIFF
--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -2180,11 +2180,10 @@ void HLSLSourceEmitter::_emitStageAccessSemantic(
 
 bool HLSLSourceEmitter::_shouldEmitPayloadAccessQualifiers()
 {
-    auto profile = getTargetProgram()->getOptionSet().getProfile();
-    if (profile.getFamily() != ProfileFamily::DX)
+    if (m_effectiveProfile.getFamily() != ProfileFamily::DX)
         return false;
 
-    return profile.getVersion() >= ProfileVersion::DX_6_7;
+    return m_effectiveProfile.getVersion() >= ProfileVersion::DX_6_7;
 }
 
 void HLSLSourceEmitter::emitPostKeywordTypeAttributesImpl(IRInst* inst)

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -2183,6 +2183,7 @@ bool HLSLSourceEmitter::_shouldEmitPayloadAccessQualifiers()
     if (m_effectiveProfile.getFamily() != ProfileFamily::DX)
         return false;
 
+    // PAQs are required on [raypayload] struct members starting with SM 6.7.
     return m_effectiveProfile.getVersion() >= ProfileVersion::DX_6_7;
 }
 

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -2133,10 +2133,13 @@ void HLSLSourceEmitter::emitSemanticsImpl(IRInst* inst, bool allowOffsets)
         }
     }
 
-    if (auto readAccessSemantic = inst->findDecoration<IRStageReadAccessDecoration>())
-        _emitStageAccessSemantic(readAccessSemantic, "read");
-    if (auto writeAccessSemantic = inst->findDecoration<IRStageWriteAccessDecoration>())
-        _emitStageAccessSemantic(writeAccessSemantic, "write");
+    if (_shouldEmitPayloadAccessQualifiers())
+    {
+        if (auto readAccessSemantic = inst->findDecoration<IRStageReadAccessDecoration>())
+            _emitStageAccessSemantic(readAccessSemantic, "read");
+        if (auto writeAccessSemantic = inst->findDecoration<IRStageWriteAccessDecoration>())
+            _emitStageAccessSemantic(writeAccessSemantic, "write");
+    }
 
     if (auto layoutDecoration = inst->findDecoration<IRLayoutDecoration>())
     {
@@ -2175,21 +2178,19 @@ void HLSLSourceEmitter::_emitStageAccessSemantic(
     m_writer->emit(")");
 }
 
+bool HLSLSourceEmitter::_shouldEmitPayloadAccessQualifiers()
+{
+    auto profile = getTargetProgram()->getOptionSet().getProfile();
+    if (profile.getFamily() != ProfileFamily::DX)
+        return false;
+
+    return profile.getVersion() >= ProfileVersion::DX_6_7;
+}
+
 void HLSLSourceEmitter::emitPostKeywordTypeAttributesImpl(IRInst* inst)
 {
 
-    // Get the target profile to determine if PAQs are supported
-    bool enablePAQs = false;
-    auto profile = getTargetProgram()->getOptionSet().getProfile();
-    if (profile.getFamily() == ProfileFamily::DX)
-    {
-        // PAQs are default in Shader Model 6.7 and above when called with `--profile lib_6_7`
-
-        auto version = profile.getVersion();
-        enablePAQs = version >= ProfileVersion::DX_6_7;
-    }
-
-    if (enablePAQs)
+    if (_shouldEmitPayloadAccessQualifiers())
     {
         if (const auto payloadDecoration = inst->findDecoration<IRRayPayloadDecoration>();
             payloadDecoration)

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -148,6 +148,7 @@ protected:
     void _emitHLSLDecorationSingleInt(const char* name, IRFunc* entryPoint, IRIntLit* val);
     void _emitHLSLDecorationSingleFloat(const char* name, IRFunc* entryPoint, IRFloatLit* val);
 
+    bool _shouldEmitPayloadAccessQualifiers();
     void _emitStageAccessSemantic(IRStageAccessDecoration* decoration, const char* name);
 
     // HLSL prelude strings for built-in helper functions injected at the top of emitted output.

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -108,7 +108,6 @@ void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* in
 
                     builder.setInsertBefore(call->getCallee());
                     auto structType = builder.createStructType();
-                    StringBuilder structName;
                     builder.addNameHintDecoration(structType, UnownedStringSlice(typeNameHint));
                     if (isForcedRayPayloadStruct)
                         addRayPayloadDecorationIfNeeded(builder, structType);

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -17,10 +17,6 @@ static void addDefaultPayloadAccessQualifiersToField(
     IRStructKey* fieldKey,
     IRType* fieldType)
 {
-    // Nested ray-payload structs carry their own payload annotations.
-    if (fieldType->findDecoration<IRRayPayloadDecoration>())
-        return;
-
     if (fieldKey->findDecoration<IRStageReadAccessDecoration>() ||
         fieldKey->findDecoration<IRStageWriteAccessDecoration>())
     {

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -14,11 +14,10 @@ namespace Slang
 
 static void addDefaultPayloadAccessQualifiersToField(IRBuilder& builder, IRStructKey* fieldKey)
 {
-    if (fieldKey->findDecoration<IRStageReadAccessDecoration>() ||
-        fieldKey->findDecoration<IRStageWriteAccessDecoration>())
-    {
+    const bool hasReadAccess = fieldKey->findDecoration<IRStageReadAccessDecoration>() != nullptr;
+    const bool hasWriteAccess = fieldKey->findDecoration<IRStageWriteAccessDecoration>() != nullptr;
+    if (hasReadAccess && hasWriteAccess)
         return;
-    }
 
     IRInst* stageNames[] = {
         builder.getStringValue(UnownedStringSlice("caller")),
@@ -27,16 +26,23 @@ static void addDefaultPayloadAccessQualifiersToField(IRBuilder& builder, IRStruc
         builder.getStringValue(UnownedStringSlice("miss")),
     };
 
-    builder.addDecoration(
-        fieldKey,
-        kIROp_StageReadAccessDecoration,
-        stageNames,
-        SLANG_COUNT_OF(stageNames));
-    builder.addDecoration(
-        fieldKey,
-        kIROp_StageWriteAccessDecoration,
-        stageNames,
-        SLANG_COUNT_OF(stageNames));
+    if (!hasReadAccess)
+    {
+        builder.addDecoration(
+            fieldKey,
+            kIROp_StageReadAccessDecoration,
+            stageNames,
+            SLANG_COUNT_OF(stageNames));
+    }
+
+    if (!hasWriteAccess)
+    {
+        builder.addDecoration(
+            fieldKey,
+            kIROp_StageWriteAccessDecoration,
+            stageNames,
+            SLANG_COUNT_OF(stageNames));
+    }
 }
 
 static void addDefaultPayloadAccessQualifiersToStruct(IRBuilder& builder, IRStructType* structType)
@@ -229,9 +235,7 @@ void legalizeEmptyRayPayloadsForHLSL(IRModule* module)
         builder.addNameHintDecoration(dummyKey, UnownedStringSlice("_slang_dummy"));
 
         // Add stage access decorations that ray payload fields require
-        IRInst* stageName = builder.getStringValue(UnownedStringSlice("caller"));
-        builder.addDecoration(dummyKey, kIROp_StageReadAccessDecoration, &stageName, 1);
-        builder.addDecoration(dummyKey, kIROp_StageWriteAccessDecoration, &stageName, 1);
+        addDefaultPayloadAccessQualifiersToField(builder, dummyKey);
 
         builder.createStructField(structType, dummyKey, builder.getIntType());
 

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -12,6 +12,54 @@
 namespace Slang
 {
 
+static void addDefaultPayloadAccessQualifiersToField(
+    IRBuilder& builder,
+    IRStructKey* fieldKey,
+    IRType* fieldType)
+{
+    // Nested ray-payload structs carry their own payload annotations.
+    if (fieldType->findDecoration<IRRayPayloadDecoration>())
+        return;
+
+    if (fieldKey->findDecoration<IRStageReadAccessDecoration>() ||
+        fieldKey->findDecoration<IRStageWriteAccessDecoration>())
+    {
+        return;
+    }
+
+    IRInst* stageNames[] = {
+        builder.getStringValue(UnownedStringSlice("caller")),
+        builder.getStringValue(UnownedStringSlice("anyhit")),
+        builder.getStringValue(UnownedStringSlice("closesthit")),
+        builder.getStringValue(UnownedStringSlice("miss")),
+    };
+
+    builder.addDecoration(
+        fieldKey,
+        kIROp_StageReadAccessDecoration,
+        stageNames,
+        SLANG_COUNT_OF(stageNames));
+    builder.addDecoration(
+        fieldKey,
+        kIROp_StageWriteAccessDecoration,
+        stageNames,
+        SLANG_COUNT_OF(stageNames));
+}
+
+static void addDefaultPayloadAccessQualifiersToStruct(IRBuilder& builder, IRStructType* structType)
+{
+    for (auto field : structType->getFields())
+    {
+        addDefaultPayloadAccessQualifiersToField(builder, field->getKey(), field->getFieldType());
+    }
+}
+
+static void addRayPayloadDecorationIfNeeded(IRBuilder& builder, IRType* type)
+{
+    if (!type->findDecoration<IRRayPayloadDecoration>())
+        builder.addRayPayloadDecoration(type);
+}
+
 void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* inst)
 {
     for (auto child : inst->getChildren())
@@ -42,7 +90,12 @@ void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* in
                     {
                         call->setArg(i, arg->getOperand(0));
                         if (isForcedRayPayloadStruct)
-                            builder.addRayPayloadDecoration(forceStructBaseType);
+                        {
+                            addRayPayloadDecorationIfNeeded(builder, forceStructBaseType);
+                            addDefaultPayloadAccessQualifiersToStruct(
+                                builder,
+                                cast<IRStructType>(forceStructBaseType));
+                        }
                         continue;
                     }
 
@@ -65,10 +118,17 @@ void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* in
                     StringBuilder structName;
                     builder.addNameHintDecoration(structType, UnownedStringSlice(typeNameHint));
                     if (isForcedRayPayloadStruct)
-                        builder.addRayPayloadDecoration(structType);
+                        addRayPayloadDecorationIfNeeded(builder, structType);
 
                     auto elementBufferKey = builder.createStructKey();
                     builder.addNameHintDecoration(elementBufferKey, UnownedStringSlice("data"));
+                    if (isForcedRayPayloadStruct)
+                    {
+                        addDefaultPayloadAccessQualifiersToField(
+                            builder,
+                            elementBufferKey,
+                            forceStructBaseType);
+                    }
                     auto _dataField = builder.createStructField(
                         structType,
                         elementBufferKey,

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -12,10 +12,7 @@
 namespace Slang
 {
 
-static void addDefaultPayloadAccessQualifiersToField(
-    IRBuilder& builder,
-    IRStructKey* fieldKey,
-    IRType* fieldType)
+static void addDefaultPayloadAccessQualifiersToField(IRBuilder& builder, IRStructKey* fieldKey)
 {
     if (fieldKey->findDecoration<IRStageReadAccessDecoration>() ||
         fieldKey->findDecoration<IRStageWriteAccessDecoration>())
@@ -46,7 +43,7 @@ static void addDefaultPayloadAccessQualifiersToStruct(IRBuilder& builder, IRStru
 {
     for (auto field : structType->getFields())
     {
-        addDefaultPayloadAccessQualifiersToField(builder, field->getKey(), field->getFieldType());
+        addDefaultPayloadAccessQualifiersToField(builder, field->getKey());
     }
 }
 
@@ -120,10 +117,7 @@ void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* in
                     builder.addNameHintDecoration(elementBufferKey, UnownedStringSlice("data"));
                     if (isForcedRayPayloadStruct)
                     {
-                        addDefaultPayloadAccessQualifiersToField(
-                            builder,
-                            elementBufferKey,
-                            forceStructBaseType);
+                        addDefaultPayloadAccessQualifiersToField(builder, elementBufferKey);
                     }
                     auto _dataField = builder.createStructField(
                         structType,

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -15,6 +15,9 @@
 // HLSL66-DAG: float3 color_0;
 // HLSL66-DAG: struct ExplicitRayPayload
 // HLSL66-DAG: float3 normal_0;
+// HLSL66-DAG: struct PartialRayPayload
+// HLSL66-DAG: float3 readOnly_0;
+// HLSL66-DAG: float3 writeOnly_0;
 // HLSL66-DAG: struct EmptyRayPayload
 // HLSL66-DAG: int _slang_dummy_0;
 // HLSL66-NOT: : read(
@@ -23,6 +26,9 @@
 // HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // HLSL67-DAG: struct [raypayload] ExplicitRayPayload
 // HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
+// HLSL67-DAG: struct [raypayload] PartialRayPayload
+// HLSL67-DAG: float3 readOnly_0 : read(caller) : write(caller, anyhit, closesthit, miss);
+// HLSL67-DAG: float3 writeOnly_0 : read(caller, anyhit, closesthit, miss) : write(caller);
 // HLSL67-DAG: struct [raypayload] EmptyRayPayload
 // HLSL67-DAG: int _slang_dummy_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // DXIL66: define void @
@@ -47,6 +53,13 @@ struct ExplicitRayPayload
 };
 
 [raypayload]
+struct PartialRayPayload
+{
+    float3 readOnly : read(caller);
+    float3 writeOnly : write(caller);
+};
+
+[raypayload]
 struct EmptyRayPayload
 {
 };
@@ -64,10 +77,14 @@ void rgen_main()
     payload.color = float3(0, 0, 0);
     ExplicitRayPayload explicitPayload;
     explicitPayload.normal = float3(0, 0, 1);
+    PartialRayPayload partialPayload;
+    partialPayload.readOnly = float3(0, 1, 0);
+    partialPayload.writeOnly = float3(1, 0, 0);
     EmptyRayPayload emptyPayload;
 
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, explicitPayload);
+    TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, partialPayload);
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, emptyPayload);
 
     outputImage[DispatchRaysIndex().xy] = float4(payload.color, 1.0);

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -1,15 +1,26 @@
 // Regression test for:
 // https://github.com/shader-slang/slang/issues/10267
 
-//TEST:SIMPLE(filecheck=SM68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=SM66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
 
-// SM68: struct [raypayload] RayPayload_0
-// SM68: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// SM66-NOT: [raypayload]
-// SM66: struct RayPayload_0
-// SM66: float3 color_0;
-// SM66-NOT: : read(
+// Implicit ray payload (no [raypayload] attribute): Slang should add default access
+// qualifiers on SM 6.7+. Fields that already carry explicit qualifiers must be left alone.
+
+// HLSL68: struct [raypayload] RayPayload_0
+// HLSL68: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL68: float3 normal_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL66-NOT: [raypayload]
+// HLSL66: struct RayPayload_0
+// HLSL66: float3 color_0;
+// HLSL66: float3 normal_0;
+// HLSL66-NOT: : read(
+// DXIL68: define void @
+// DXIL68: !dx.dxrPayloadAnnotations
+// DXIL66: define void @
+// DXIL66-NOT: !dx.dxrPayloadAnnotations
 
 RWTexture2D<float4> outputImage;
 RaytracingAccelerationStructure topLevelAS;
@@ -17,6 +28,7 @@ RaytracingAccelerationStructure topLevelAS;
 struct RayPayload
 {
     float3 color;
+    float3 normal : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 };
 
 [shader("raygeneration")]
@@ -30,6 +42,7 @@ void rgen_main()
 
     RayPayload payload;
     payload.color = float3(0, 0, 0);
+    payload.normal = float3(0, 0, 1);
 
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
 

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -3,10 +3,8 @@
 
 //TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
 
 // Implicit ray payload (no [raypayload] attribute): Slang should add default access
 // qualifiers on SM 6.7+. Explicit payload qualifiers must be left alone.
@@ -22,16 +20,10 @@
 // HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // HLSL67-DAG: struct [raypayload] ExplicitRayPayload
 // HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
-// HLSL68-DAG: struct [raypayload] RayPayload
-// HLSL68-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// HLSL68-DAG: struct [raypayload] ExplicitRayPayload
-// HLSL68-DAG: float3 normal_0 : read(caller) : write(miss);
 // DXIL66: define void @
 // DXIL66-NOT: !dx.dxrPayloadAnnotations
 // DXIL67: define void @
 // DXIL67: !dx.dxrPayloadAnnotations
-// DXIL68: define void @
-// DXIL68: !dx.dxrPayloadAnnotations
 
 RWTexture2D<float4> outputImage;
 RaytracingAccelerationStructure topLevelAS;

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -1,0 +1,37 @@
+// Regression test for:
+// https://github.com/shader-slang/slang/issues/10267
+
+//TEST:SIMPLE(filecheck=SM68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=SM66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
+
+// SM68: struct [raypayload] RayPayload_0
+// SM68: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// SM66-NOT: [raypayload]
+// SM66: struct RayPayload_0
+// SM66: float3 color_0;
+// SM66-NOT: : read(
+
+RWTexture2D<float4> outputImage;
+RaytracingAccelerationStructure topLevelAS;
+
+struct RayPayload
+{
+    float3 color;
+};
+
+[shader("raygeneration")]
+void rgen_main()
+{
+    RayDesc ray;
+    ray.Origin = float3(0, 0, 0);
+    ray.Direction = float3(0, 0, 1);
+    ray.TMin = 0.001;
+    ray.TMax = 1000.0;
+
+    RayPayload payload;
+    payload.color = float3(0, 0, 0);
+
+    TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+
+    outputImage[DispatchRaysIndex().xy] = float4(payload.color, 1.0);
+}

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -1,29 +1,16 @@
 // Regression test for:
 // https://github.com/shader-slang/slang/issues/10267
 
-//TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=HLSLLIB): -target hlsl -profile lib_6_7 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
-//TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
 
 // Implicit ray payload (no [raypayload] attribute): Slang should add default access
 // qualifiers on SM 6.7+. Explicit payload qualifiers must be left alone.
 
-// HLSL68-DAG: struct [raypayload] RayPayload
-// HLSL68-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// HLSL68-DAG: struct [raypayload] ExplicitRayPayload
-// HLSL68-DAG: float3 normal_0 : read(caller) : write(miss);
-// HLSL67-DAG: struct [raypayload] RayPayload
-// HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// HLSL67-DAG: struct [raypayload] ExplicitRayPayload
-// HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
-// HLSLLIB-DAG: struct [raypayload] RayPayload
-// HLSLLIB-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// HLSLLIB-DAG: struct [raypayload] ExplicitRayPayload
-// HLSLLIB-DAG: float3 normal_0 : read(caller) : write(miss);
 // HLSL66-NOT: [raypayload]
 // HLSL66-DAG: struct RayPayload
 // HLSL66-DAG: float3 color_0;
@@ -31,12 +18,20 @@
 // HLSL66-DAG: float3 normal_0;
 // HLSL66-NOT: : read(
 // HLSL66-NOT: : write(
-// DXIL68: define void @
-// DXIL68: !dx.dxrPayloadAnnotations
-// DXIL67: define void @
-// DXIL67: !dx.dxrPayloadAnnotations
+// HLSL67-DAG: struct [raypayload] RayPayload
+// HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL67-DAG: struct [raypayload] ExplicitRayPayload
+// HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
+// HLSL68-DAG: struct [raypayload] RayPayload
+// HLSL68-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL68-DAG: struct [raypayload] ExplicitRayPayload
+// HLSL68-DAG: float3 normal_0 : read(caller) : write(miss);
 // DXIL66: define void @
 // DXIL66-NOT: !dx.dxrPayloadAnnotations
+// DXIL67: define void @
+// DXIL67: !dx.dxrPayloadAnnotations
+// DXIL68: define void @
+// DXIL68: !dx.dxrPayloadAnnotations
 
 RWTexture2D<float4> outputImage;
 RaytracingAccelerationStructure topLevelAS;

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -7,16 +7,19 @@
 //TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
 
 // Implicit ray payload (no [raypayload] attribute): Slang should add default access
-// qualifiers on SM 6.7+. Fields that already carry explicit qualifiers must be left alone.
+// qualifiers on SM 6.7+. Explicit payload qualifiers must be left alone.
 
-// HLSL68: struct [raypayload] RayPayload_0
-// HLSL68: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
-// HLSL68: float3 normal_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL68-DAG: struct [raypayload] RayPayload
+// HLSL68-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL68-DAG: struct [raypayload] ExplicitRayPayload
+// HLSL68-DAG: float3 normal_0 : read(caller) : write(miss);
 // HLSL66-NOT: [raypayload]
-// HLSL66: struct RayPayload_0
-// HLSL66: float3 color_0;
-// HLSL66: float3 normal_0;
+// HLSL66-DAG: struct RayPayload
+// HLSL66-DAG: float3 color_0;
+// HLSL66-DAG: struct ExplicitRayPayload
+// HLSL66-DAG: float3 normal_0;
 // HLSL66-NOT: : read(
+// HLSL66-NOT: : write(
 // DXIL68: define void @
 // DXIL68: !dx.dxrPayloadAnnotations
 // DXIL66: define void @
@@ -28,7 +31,12 @@ RaytracingAccelerationStructure topLevelAS;
 struct RayPayload
 {
     float3 color;
-    float3 normal : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+};
+
+[raypayload]
+struct ExplicitRayPayload
+{
+    float3 normal : read(caller) : write(miss);
 };
 
 [shader("raygeneration")]
@@ -42,9 +50,11 @@ void rgen_main()
 
     RayPayload payload;
     payload.color = float3(0, 0, 0);
-    payload.normal = float3(0, 0, 1);
+    ExplicitRayPayload explicitPayload;
+    explicitPayload.normal = float3(0, 0, 1);
 
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+    TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, explicitPayload);
 
     outputImage[DispatchRaysIndex().xy] = float4(payload.color, 1.0);
 }

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -2,6 +2,8 @@
 // https://github.com/shader-slang/slang/issues/10267
 
 //TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=HLSLLIB): -target hlsl -profile lib_6_7 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
@@ -13,6 +15,14 @@
 // HLSL68-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // HLSL68-DAG: struct [raypayload] ExplicitRayPayload
 // HLSL68-DAG: float3 normal_0 : read(caller) : write(miss);
+// HLSL67-DAG: struct [raypayload] RayPayload
+// HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSL67-DAG: struct [raypayload] ExplicitRayPayload
+// HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
+// HLSLLIB-DAG: struct [raypayload] RayPayload
+// HLSLLIB-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
+// HLSLLIB-DAG: struct [raypayload] ExplicitRayPayload
+// HLSLLIB-DAG: float3 normal_0 : read(caller) : write(miss);
 // HLSL66-NOT: [raypayload]
 // HLSL66-DAG: struct RayPayload
 // HLSL66-DAG: float3 color_0;

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -3,6 +3,7 @@
 
 //TEST:SIMPLE(filecheck=HLSL68): -target hlsl -profile sm_6_8 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSLLIB): -target hlsl -profile lib_6_7 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL68): -target dxil -profile sm_6_8 -stage raygeneration -entry rgen_main
@@ -32,6 +33,8 @@
 // HLSL66-NOT: : write(
 // DXIL68: define void @
 // DXIL68: !dx.dxrPayloadAnnotations
+// DXIL67: define void @
+// DXIL67: !dx.dxrPayloadAnnotations
 // DXIL66: define void @
 // DXIL66-NOT: !dx.dxrPayloadAnnotations
 

--- a/tests/hlsl/raypayload-auto-paq.slang
+++ b/tests/hlsl/raypayload-auto-paq.slang
@@ -5,6 +5,7 @@
 //TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL66): -target dxil -profile sm_6_6 -stage raygeneration -entry rgen_main
 //TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage raygeneration -entry rgen_main
+//TEST:SIMPLE(filecheck=NONSTRUCT67): -target hlsl -profile sm_6_7 -stage raygeneration -entry rgen_nonstruct
 
 // Implicit ray payload (no [raypayload] attribute): Slang should add default access
 // qualifiers on SM 6.7+. Explicit payload qualifiers must be left alone.
@@ -14,16 +15,22 @@
 // HLSL66-DAG: float3 color_0;
 // HLSL66-DAG: struct ExplicitRayPayload
 // HLSL66-DAG: float3 normal_0;
+// HLSL66-DAG: struct EmptyRayPayload
+// HLSL66-DAG: int _slang_dummy_0;
 // HLSL66-NOT: : read(
 // HLSL66-NOT: : write(
 // HLSL67-DAG: struct [raypayload] RayPayload
 // HLSL67-DAG: float3 color_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // HLSL67-DAG: struct [raypayload] ExplicitRayPayload
 // HLSL67-DAG: float3 normal_0 : read(caller) : write(miss);
+// HLSL67-DAG: struct [raypayload] EmptyRayPayload
+// HLSL67-DAG: int _slang_dummy_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 // DXIL66: define void @
 // DXIL66-NOT: !dx.dxrPayloadAnnotations
 // DXIL67: define void @
 // DXIL67: !dx.dxrPayloadAnnotations
+// NONSTRUCT67-DAG: struct [raypayload] RayPayload_t
+// NONSTRUCT67-DAG: float4 data_0 : read(caller, anyhit, closesthit, miss) : write(caller, anyhit, closesthit, miss);
 
 RWTexture2D<float4> outputImage;
 RaytracingAccelerationStructure topLevelAS;
@@ -39,6 +46,11 @@ struct ExplicitRayPayload
     float3 normal : read(caller) : write(miss);
 };
 
+[raypayload]
+struct EmptyRayPayload
+{
+};
+
 [shader("raygeneration")]
 void rgen_main()
 {
@@ -52,9 +64,27 @@ void rgen_main()
     payload.color = float3(0, 0, 0);
     ExplicitRayPayload explicitPayload;
     explicitPayload.normal = float3(0, 0, 1);
+    EmptyRayPayload emptyPayload;
 
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
     TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, explicitPayload);
+    TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, emptyPayload);
 
     outputImage[DispatchRaysIndex().xy] = float4(payload.color, 1.0);
+}
+
+[shader("raygeneration")]
+void rgen_nonstruct()
+{
+    RayDesc ray;
+    ray.Origin = float3(0, 0, 0);
+    ray.Direction = float3(0, 0, 1);
+    ray.TMin = 0.001;
+    ray.TMax = 1000.0;
+
+    float4 payload = float4(0, 0, 0, 0);
+
+    TraceRay(topLevelAS, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+
+    outputImage[DispatchRaysIndex().xy] = payload;
 }


### PR DESCRIPTION
## Summary

- Fixes an issue where HLSL codegen was emitting [raypayload] attribute without including the required per-member ead(caller) / write(caller) access qualifiers
- Emits default ray payload access qualifiers for members that lack explicit qualifiers

## Test plan
- [ ] Run existing tests related to ray tracing / ray payload codegen
- [ ] Verify that generated HLSL includes proper [raypayload] member access qualifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)