### PR TITLE
Guard offset container allocation overflow

### DIFF
--- a/source/core/slang-offset-container.cpp
+++ b/source/core/slang-offset-container.cpp
@@ -141,6 +141,13 @@ void* OffsetContainer::allocate(size_t size, size_t alignment)
     // but prevents silent truncation when offsets are converted to uint32_t.
     const size_t kMaxDataSize = size_t(0xFFFFFFFFu);
     const size_t alignmentMask = alignment - 1;
+    // On 64-bit hosts a caller can request an alignment larger than the 32-bit offset
+    // domain (e.g., 2^33). That would make alignmentMask > kMaxDataSize and cause the
+    // subtraction in the next guard to underflow, silently bypassing the check.
+    if (alignmentMask > kMaxDataSize)
+    {
+        return nullptr;
+    }
     if (m_dataSize > kMaxDataSize - alignmentMask)
     {
         return nullptr;
@@ -202,9 +209,11 @@ Offset32Ptr<OffsetString> OffsetContainer::newString(const UnownedStringSlice& s
     size_t stringSize = slice.getLength();
 
     // OffsetString encodes the size in at most 4 bytes (kSizeBase + 4-byte little-endian),
-    // so the string itself must fit in 32 bits. Reject anything larger to avoid wrapping in
-    // the headSize + stringSize + 1 computation below.
-    if (stringSize > size_t(0xFFFFFFFFu))
+    // so the string itself must fit in 32 bits. Subtract kMaxSizeEncodeSize + 1 (the
+    // encoded header plus the trailing null terminator) to also prevent
+    // headSize + stringSize + 1 from wrapping on 32-bit hosts where
+    // size_t == uint32_t.
+    if (stringSize > size_t(0xFFFFFFFFu) - OffsetString::kMaxSizeEncodeSize - 1)
     {
         return Offset32Ptr<OffsetString>();
     }

--- a/source/core/slang-offset-container.cpp
+++ b/source/core/slang-offset-container.cpp
@@ -129,19 +129,25 @@ void OffsetContainer::fixAlignment(size_t alignment)
 
 void* OffsetContainer::allocate(size_t size, size_t alignment)
 {
-    if (alignment == 0)
+    // Alignment must be a non-zero power of two for the bitwise alignment math below.
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0)
     {
         return nullptr;
     }
 
+    // The container addresses memory via 32-bit offsets (Offset32Ptr), so reject any
+    // allocation that would grow the data beyond the 32-bit addressable range. Using the
+    // 32-bit limit (rather than SIZE_MAX) is tighter than required for size_t arithmetic,
+    // but prevents silent truncation when offsets are converted to uint32_t.
+    const size_t kMaxDataSize = size_t(0xFFFFFFFFu);
     const size_t alignmentMask = alignment - 1;
-    if (m_dataSize > SIZE_MAX - alignmentMask)
+    if (m_dataSize > kMaxDataSize - alignmentMask)
     {
         return nullptr;
     }
 
     size_t offset = (m_dataSize + alignmentMask) & ~alignmentMask;
-    if (size > SIZE_MAX - offset)
+    if (size > kMaxDataSize - offset)
     {
         return nullptr;
     }
@@ -195,11 +201,23 @@ Offset32Ptr<OffsetString> OffsetContainer::newString(const UnownedStringSlice& s
 {
     size_t stringSize = slice.getLength();
 
+    // OffsetString encodes the size in at most 4 bytes (kSizeBase + 4-byte little-endian),
+    // so the string itself must fit in 32 bits. Reject anything larger to avoid wrapping in
+    // the headSize + stringSize + 1 computation below.
+    if (stringSize > size_t(0xFFFFFFFFu))
+    {
+        return Offset32Ptr<OffsetString>();
+    }
+
     uint8_t head[OffsetString::kMaxSizeEncodeSize];
     size_t headSize = OffsetString::calcEncodedSize(stringSize, head);
 
     size_t allocSize = headSize + stringSize + 1;
     uint8_t* bytes = (uint8_t*)allocate(allocSize);
+    if (!bytes)
+    {
+        return Offset32Ptr<OffsetString>();
+    }
 
     ::memcpy(bytes, head, headSize);
     ::memcpy(bytes + headSize, slice.begin(), stringSize);

--- a/source/core/slang-offset-container.cpp
+++ b/source/core/slang-offset-container.cpp
@@ -129,12 +129,27 @@ void OffsetContainer::fixAlignment(size_t alignment)
 
 void* OffsetContainer::allocate(size_t size, size_t alignment)
 {
-    size_t offset = (m_dataSize + alignment - 1) & ~(alignment - 1);
-
-    if (offset + size > m_capacity)
+    if (alignment == 0)
     {
-        const size_t minSize = offset + size;
+        return nullptr;
+    }
 
+    const size_t alignmentMask = alignment - 1;
+    if (m_dataSize > SIZE_MAX - alignmentMask)
+    {
+        return nullptr;
+    }
+
+    size_t offset = (m_dataSize + alignmentMask) & ~alignmentMask;
+    if (size > SIZE_MAX - offset)
+    {
+        return nullptr;
+    }
+
+    const size_t minSize = offset + size;
+
+    if (minSize > m_capacity)
+    {
         size_t calcSize = m_capacity;
         if (calcSize < 2048)
         {
@@ -150,19 +165,28 @@ void* OffsetContainer::allocate(size_t size, size_t alignment)
         size_t newSize = (calcSize < minSize) ? minSize : calcSize;
 
         // Reallocate space
-        m_data = (uint8_t*)::realloc(m_data, newSize);
+        uint8_t* newData = (uint8_t*)::realloc(m_data, newSize);
+        if (!newData)
+        {
+            return nullptr;
+        }
+        m_data = newData;
         m_capacity = newSize;
     }
 
-    SLANG_ASSERT(offset + size <= m_capacity);
+    SLANG_ASSERT(minSize <= m_capacity);
 
-    m_dataSize = offset + size;
+    m_dataSize = minSize;
     return m_data + offset;
 }
 
 void* OffsetContainer::allocateAndZero(size_t size, size_t alignment)
 {
     void* data = allocate(size, alignment);
+    if (!data)
+    {
+        return nullptr;
+    }
     memset(data, 0, size);
     return data;
 }

--- a/source/core/slang-offset-container.h
+++ b/source/core/slang-offset-container.h
@@ -446,6 +446,10 @@ public:
     Offset32Ptr<T> newObject()
     {
         void* data = allocate(sizeof(T), alignof(T));
+        if (!data)
+        {
+            return Offset32Ptr<T>();
+        }
         new (data) T();
         return Offset32Ptr<T>(getOffset(data));
     }
@@ -457,7 +461,17 @@ public:
         {
             return Offset32Array<T>();
         }
+        // Reject counts that don't fit in the 32-bit count stored in Offset32Array, or whose
+        // byte size would overflow size_t when computing sizeof(T) * size.
+        if (size > size_t(0xFFFFFFFFu) || size > SIZE_MAX / sizeof(T))
+        {
+            return Offset32Array<T>();
+        }
         T* data = (T*)allocate(sizeof(T) * size, alignof(T));
+        if (!data)
+        {
+            return Offset32Array<T>();
+        }
         for (size_t i = 0; i < size; ++i)
         {
             new (data + i) T();

--- a/tools/slang-unit-test/unit-test-offset-container.cpp
+++ b/tools/slang-unit-test/unit-test-offset-container.cpp
@@ -65,6 +65,13 @@ SLANG_UNIT_TEST(offsetContainer)
     _checkAllocateOverflowDoesNotWrap(0, 1, 5);
     _checkAllocateOverflowDoesNotWrap(0, 1, 6);
 
+#if SIZE_MAX > 0xFFFFFFFFu
+    // On 64-bit hosts a power-of-two alignment larger than the 32-bit offset domain must be
+    // rejected before alignmentMask = alignment - 1 underflows kMaxDataSize - alignmentMask.
+    _checkAllocateOverflowDoesNotWrap(0, 1, size_t(1) << 33);
+    _checkAllocateOverflowDoesNotWrap(8, 1, size_t(1) << 40);
+#endif
+
     {
         OffsetContainer container;
 

--- a/tools/slang-unit-test/unit-test-offset-container.cpp
+++ b/tools/slang-unit-test/unit-test-offset-container.cpp
@@ -53,6 +53,18 @@ SLANG_UNIT_TEST(offsetContainer)
     _checkAllocateOverflowDoesNotWrap(SIZE_MAX - 7, 16, 1);
     _checkAllocateOverflowDoesNotWrap(SIZE_MAX - 3, 1, 8);
 
+    // Exceed the 32-bit offset limit (the container addresses memory via Offset32Ptr, so
+    // allocations beyond the 4GB boundary must be rejected even when size_t arithmetic does
+    // not overflow on a 64-bit host).
+    _checkAllocateOverflowDoesNotWrap(size_t(0xFFFFFFFFu) - 7, 16, 1);
+    _checkAllocateOverflowDoesNotWrap(size_t(0xFFFFFFFFu) - 3, 1, 8);
+    _checkAllocateOverflowDoesNotWrap(size_t(0x80000000u), size_t(0x80000000u), 1);
+
+    // Non-power-of-two alignments must be rejected (the bitwise alignment math relies on it).
+    _checkAllocateOverflowDoesNotWrap(0, 1, 3);
+    _checkAllocateOverflowDoesNotWrap(0, 1, 5);
+    _checkAllocateOverflowDoesNotWrap(0, 1, 6);
+
     {
         OffsetContainer container;
 

--- a/tools/slang-unit-test/unit-test-offset-container.cpp
+++ b/tools/slang-unit-test/unit-test-offset-container.cpp
@@ -18,6 +18,17 @@ static void _checkEncodeDecode(uint32_t size)
     SLANG_CHECK(chars - (const char*)encode == encodeSize);
 }
 
+static void _checkAllocateOverflowDoesNotWrap(size_t dataSize, size_t size, size_t alignment)
+{
+    OffsetContainer container;
+    container.m_dataSize = dataSize;
+
+    void* data = container.allocate(size, alignment);
+
+    SLANG_CHECK(data == nullptr);
+    SLANG_CHECK(container.getDataCount() == dataSize);
+}
+
 namespace
 { // anonymous
 
@@ -38,6 +49,9 @@ SLANG_UNIT_TEST(offsetContainer)
     {
         _checkEncodeDecode(uint32_t(i));
     }
+
+    _checkAllocateOverflowDoesNotWrap(SIZE_MAX - 7, 16, 1);
+    _checkAllocateOverflowDoesNotWrap(SIZE_MAX - 3, 1, 8);
 
     {
         OffsetContainer container;


### PR DESCRIPTION
Automated review PR created by /review-on-fork-repo skill.

## Summary
- Adds overflow guards in `OffsetContainer` allocation paths to prevent integer overflow when computing new buffer sizes.
- Extends the offset container unit test to cover the new overflow handling.