### PR TITLE
Validate replay blob hashes

### DIFF
--- a/source/slang-record-replay/replay-context-record.cpp
+++ b/source/slang-record-replay/replay-context-record.cpp
@@ -22,6 +22,27 @@ namespace SlangRecord
 using Slang::File;
 using Slang::Path;
 
+static bool isSHA1DigestChar(char c)
+{
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+static bool isValidSHA1DigestString(const char* str)
+{
+    static const size_t kSHA1DigestStringLength = 40;
+
+    if (!str)
+        return false;
+
+    size_t length = 0;
+    for (; str[length]; ++length)
+    {
+        if (!isSHA1DigestChar(str[length]))
+            return false;
+    }
+
+    return length == kSHA1DigestStringLength;
+}
 
 void ReplayContext::recordRaw(RecordFlag flags, void* data, size_t size)
 {
@@ -320,6 +341,12 @@ void ReplayContext::recordBlobByHash(RecordFlag flags, ISlangBlob*& blob)
         record(RecordFlag::None, hashCStr);
 
         if (!hashCStr || hashCStr[0] == '\0')
+        {
+            blob = nullptr;
+            return;
+        }
+
+        if (!isValidSHA1DigestString(hashCStr))
         {
             blob = nullptr;
             return;

--- a/source/slang-record-replay/replay-context-record.cpp
+++ b/source/slang-record-replay/replay-context-record.cpp
@@ -34,14 +34,13 @@ static bool isValidSHA1DigestString(const char* str)
     if (!str)
         return false;
 
-    size_t length = 0;
-    for (; str[length]; ++length)
+    for (size_t i = 0; i < kSHA1DigestStringLength; ++i)
     {
-        if (!isSHA1DigestChar(str[length]))
+        if (!str[i] || !isSHA1DigestChar(str[i]))
             return false;
     }
 
-    return length == kSHA1DigestStringLength;
+    return str[kSHA1DigestStringLength] == '\0';
 }
 
 void ReplayContext::recordRaw(RecordFlag flags, void* data, size_t size)

--- a/tools/slang-unit-test/unit-test-replay-integration.cpp
+++ b/tools/slang-unit-test/unit-test-replay-integration.cpp
@@ -18,6 +18,12 @@ static TypeId readTypeIdFromStream(ReplayStream& stream)
     return static_cast<TypeId>(byte);
 }
 
+static void writeTypeIdToStream(ReplayStream& stream, TypeId typeId)
+{
+    uint8_t byte = static_cast<uint8_t>(typeId);
+    stream.write(&byte, 1);
+}
+
 SLANG_UNIT_TEST(replayContextRecordFindProfileCall)
 {
     REPLAY_TEST;
@@ -312,6 +318,49 @@ SLANG_UNIT_TEST(replayContextFindLatestFolder)
 
     // Clean up
     ctx().reset();
+    ctx().setReplayDirectory(".slang-replays");
+}
+
+SLANG_UNIT_TEST(replayContextRejectsInvalidBlobHash)
+{
+    REPLAY_TEST;
+    SLANG_UNUSED(unitTestContext);
+
+    const char* replayDirectory = ".slang-replays-security-test";
+    const char* sensitiveFileName = "sensitive-blob.bin";
+    const char* sensitiveContent = "content outside the replay blob store";
+    const char* invalidHash = "../../sensitive-blob.bin";
+
+    ctx().setReplayDirectory(replayDirectory);
+    ctx().setMode(Mode::Record);
+
+    const char* replayPath = ctx().getCurrentReplayPath();
+    SLANG_CHECK(replayPath != nullptr);
+
+    String filesDir = Path::combine(String(replayPath), "files");
+    SLANG_CHECK(Path::createDirectoryRecursive(filesDir));
+
+    String sensitivePath = Path::combine(String(replayDirectory), sensitiveFileName);
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        File::writeAllBytes(sensitivePath, sensitiveContent, strlen(sensitiveContent))));
+
+    writeTypeIdToStream(ctx().getStream(), TypeId::Blob);
+    const char* recordedHash = invalidHash;
+    ctx().record(RecordFlag::None, recordedHash);
+
+    ctx().switchToPlayback();
+
+    ISlangBlob* replayedBlobRaw = nullptr;
+    ctx().record(RecordFlag::Output, replayedBlobRaw);
+    ComPtr<ISlangBlob> replayedBlob;
+    replayedBlob.attach(replayedBlobRaw);
+
+    SLANG_CHECK(replayedBlob == nullptr);
+    SLANG_CHECK(ctx().getStream().atEnd());
+
+    ctx().reset();
+    File::remove(sensitivePath);
+    Path::removeNonEmpty(String(replayDirectory));
     ctx().setReplayDirectory(".slang-replays");
 }
 


### PR DESCRIPTION
## Summary
- Add SHA-1 digest validation in `ReplayContext::recordBlobByHash` to reject malformed hash strings (including path-traversal payloads like `../../sensitive-blob.bin`) before they can be used to construct a replay file path.
- Add a unit test (`replayContextRejectsInvalidBlobHash`) that records an invalid hash, switches to playback, and verifies the blob is rejected (`nullptr`) and the stream is fully consumed.

## Test plan
- [ ] `slang-test slang-unit-test-tool/replay/replayContextRejectsInvalidBlobHash`
- [ ] Full unit-test suite for `slang-record-replay`

Automated review PR created by /review-on-fork-repo skill.