### PR TITLE
Reject oversized replay strings

### DIFF
--- a/source/slang-record-replay/replay-context-record.cpp
+++ b/source/slang-record-replay/replay-context-record.cpp
@@ -244,14 +244,13 @@ void ReplayContext::record(RecordFlag flags, const char*& str)
         {
             uint32_t length;
             recordRaw(RecordFlag::None, &length, sizeof(length));
-            if (length > kMaxReplayStringLength)
-                throw Slang::Exception("Replay string length exceeds maximum");
+            SLANG_RELEASE_ASSERT(length <= kMaxReplayStringLength);
 
             size_t stringSize = size_t(length);
             size_t streamPosition = m_stream.getPosition();
             size_t streamSize = m_stream.getSize();
-            if (streamPosition > streamSize || stringSize > streamSize - streamPosition)
-                throw Slang::Exception("Replay string length exceeds remaining stream data");
+            SLANG_RELEASE_ASSERT(
+                streamPosition <= streamSize && stringSize <= streamSize - streamPosition);
 
             char* buf = m_arena.allocateArray<char>(stringSize + 1);
             if (length > 0)

--- a/source/slang-record-replay/replay-context-record.cpp
+++ b/source/slang-record-replay/replay-context-record.cpp
@@ -22,6 +22,7 @@ namespace SlangRecord
 using Slang::File;
 using Slang::Path;
 
+static constexpr uint32_t kMaxReplayStringLength = 64 * 1024 * 1024;
 
 void ReplayContext::recordRaw(RecordFlag flags, void* data, size_t size)
 {
@@ -243,10 +244,19 @@ void ReplayContext::record(RecordFlag flags, const char*& str)
         {
             uint32_t length;
             recordRaw(RecordFlag::None, &length, sizeof(length));
-            char* buf = m_arena.allocateArray<char>(length + 1);
+            if (length > kMaxReplayStringLength)
+                throw Slang::Exception("Replay string length exceeds maximum");
+
+            size_t stringSize = size_t(length);
+            size_t streamPosition = m_stream.getPosition();
+            size_t streamSize = m_stream.getSize();
+            if (streamPosition > streamSize || stringSize > streamSize - streamPosition)
+                throw Slang::Exception("Replay string length exceeds remaining stream data");
+
+            char* buf = m_arena.allocateArray<char>(stringSize + 1);
             if (length > 0)
-                recordRaw(RecordFlag::None, buf, length);
-            buf[length] = '\0';
+                recordRaw(RecordFlag::None, buf, stringSize);
+            buf[stringSize] = '\0';
             if (hasFlag(flags, RecordFlag::Output))
             {
                 if (strcmp(str, buf) != 0)

--- a/tools/slang-unit-test/unit-test-replay-serialization.cpp
+++ b/tools/slang-unit-test/unit-test-replay-serialization.cpp
@@ -184,6 +184,37 @@ SLANG_UNIT_TEST(replayContextRejectsOversizedStringLength)
     SLANG_CHECK(caughtException);
 }
 
+SLANG_UNIT_TEST(replayContextRejectsTruncatedStringPayload)
+{
+    REPLAY_TEST;
+    SLANG_UNUSED(unitTestContext);
+
+    ctx().reset();
+    ctx().setMode(Mode::Record);
+
+    uint8_t typeId = uint8_t(TypeId::String);
+    uint32_t length = 16;
+    const char payload[4] = {'t', 'e', 's', 't'};
+    ctx().getStream().write(&typeId, sizeof(typeId));
+    ctx().getStream().write(&length, sizeof(length));
+    ctx().getStream().write(payload, sizeof(payload));
+
+    ctx().switchToPlayback();
+
+    bool caughtException = false;
+    try
+    {
+        const char* readStr = nullptr;
+        ctx().record(RecordFlag::None, readStr);
+    }
+    catch (const Slang::Exception&)
+    {
+        caughtException = true;
+    }
+
+    SLANG_CHECK(caughtException);
+}
+
 // =============================================================================
 // Slang Enums
 // =============================================================================

--- a/tools/slang-unit-test/unit-test-replay-serialization.cpp
+++ b/tools/slang-unit-test/unit-test-replay-serialization.cpp
@@ -155,6 +155,35 @@ SLANG_UNIT_TEST(replayContextString)
     SLANG_CHECK(testString("Unicode test: こんにちは"));
 }
 
+SLANG_UNIT_TEST(replayContextRejectsOversizedStringLength)
+{
+    REPLAY_TEST;
+    SLANG_UNUSED(unitTestContext);
+
+    ctx().reset();
+    ctx().setMode(Mode::Record);
+
+    uint8_t typeId = uint8_t(TypeId::String);
+    uint32_t length = 0xFFFFFFFFu;
+    ctx().getStream().write(&typeId, sizeof(typeId));
+    ctx().getStream().write(&length, sizeof(length));
+
+    ctx().switchToPlayback();
+
+    bool caughtException = false;
+    try
+    {
+        const char* readStr = nullptr;
+        ctx().record(RecordFlag::None, readStr);
+    }
+    catch (const Slang::Exception&)
+    {
+        caughtException = true;
+    }
+
+    SLANG_CHECK(caughtException);
+}
+
 // =============================================================================
 // Slang Enums
 // =============================================================================


### PR DESCRIPTION
Automated review PR created by /review-on-fork-repo skill.

## Summary
- Fix integer overflow in replay string handling by rejecting oversized replay strings before they can wrap around.

## Test plan
- [ ] Existing record/replay tests pass
- [ ] LLM review feedback addressed