### PR TITLE
Validate VM bytecode offsets

### DIFF
--- a/source/slang/slang-vm-bytecode.cpp
+++ b/source/slang/slang-vm-bytecode.cpp
@@ -37,6 +37,24 @@ static SlangResult readUInt32(MemoryStreamBase& stream, uint32_t& value)
     return readValue(stream, value);
 }
 
+static bool isRangeInBounds(uint32_t offset, uint64_t size, uint32_t bufferSize)
+{
+    return uint64_t(offset) <= bufferSize && size <= uint64_t(bufferSize) - offset;
+}
+
+static bool isNullTerminatedStringInBounds(
+    const uint8_t* buffer,
+    uint32_t offset,
+    uint32_t bufferSize)
+{
+    for (uint32_t i = offset; i < bufferSize; ++i)
+    {
+        if (buffer[i] == 0)
+            return true;
+    }
+    return false;
+}
+
 SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleView)
 {
     MemoryStreamBase stream(FileAccess::Read, code, codeSize);
@@ -58,16 +76,30 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeFunctionsFourCC));
     uint32_t functionSectionSize = 0;
     SLANG_RETURN_ON_FAIL(readUInt32(stream, functionSectionSize));
-    auto funcDataStart = stream.getPosition();
+    auto funcDataStart = (uint32_t)stream.getPosition();
     if (functionSectionSize < sizeof(uint32_t)) // At least the function count
+    {
+        return SLANG_FAIL; // Invalid section size
+    }
+    if (!isRangeInBounds(funcDataStart, functionSectionSize, codeSize))
     {
         return SLANG_FAIL; // Invalid section size
     }
 
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->functionCount));
-    moduleView->functionOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
+    uint64_t functionOffsetsSize = uint64_t(moduleView->functionCount) * sizeof(uint32_t);
+    if (functionOffsetsSize > functionSectionSize - sizeof(uint32_t))
+    {
+        return SLANG_FAIL; // Invalid function offset table size
+    }
+    auto functionOffsetsStart = (uint32_t)stream.getPosition();
+    if (!isRangeInBounds(functionOffsetsStart, functionOffsetsSize, codeSize))
+    {
+        return SLANG_FAIL; // Invalid function offset table
+    }
+    moduleView->functionOffsets = reinterpret_cast<uint32_t*>(code + functionOffsetsStart);
 
-    stream.seek(SeekOrigin::Start, funcDataStart + functionSectionSize);
+    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Start, funcDataStart + functionSectionSize));
 
     // Read the kernel blob section
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeKernelBlobFourCC));
@@ -77,27 +109,65 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
         return SLANG_FAIL; // Invalid kernel blob size
     }
     moduleView->kernelBlob = code + stream.getPosition();
-    stream.seek(SeekOrigin::Current, moduleView->kernelBlobSize);
+    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, moduleView->kernelBlobSize));
 
     // Read the constants section
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeConstantsFourCC));
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->constantBlobSize));
-    if (moduleView->constantBlobSize < sizeof(uint32_t)) // At least the constant count
-    {
-        return SLANG_FAIL; // Invalid section size
-    }
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->stringCount));
-    moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
-    stream.seek(SeekOrigin::Current, moduleView->stringCount * sizeof(uint32_t));
+    uint64_t stringOffsetsSize = uint64_t(moduleView->stringCount) * sizeof(uint32_t);
+    auto stringOffsetsStart = (uint32_t)stream.getPosition();
+    if (!isRangeInBounds(stringOffsetsStart, stringOffsetsSize, codeSize))
+    {
+        return SLANG_FAIL; // Invalid string offset table
+    }
+    moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stringOffsetsStart);
+    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, (Int64)stringOffsetsSize));
+    auto constantsStart = (uint32_t)stream.getPosition();
+    if (!isRangeInBounds(constantsStart, moduleView->constantBlobSize, codeSize))
+    {
+        return SLANG_FAIL; // Invalid constant blob size
+    }
     moduleView->constants = code + stream.getPosition();
+
+    for (uint32_t i = 0; i < moduleView->stringCount; i++)
+    {
+        auto stringOffset = moduleView->stringOffsets[i];
+        if (stringOffset >= moduleView->constantBlobSize)
+        {
+            return SLANG_FAIL; // Invalid string offset
+        }
+        if (!isNullTerminatedStringInBounds(
+                moduleView->constants,
+                stringOffset,
+                moduleView->constantBlobSize))
+        {
+            return SLANG_FAIL; // Invalid string literal
+        }
+    }
 
     for (uint32_t i = 0; i < moduleView->functionCount; i++)
     {
-        auto functionStart = code + moduleView->functionOffsets[i];
+        auto functionOffset = moduleView->functionOffsets[i];
+        if (!isRangeInBounds(functionOffset, sizeof(VMFuncHeader), codeSize))
+        {
+            return SLANG_FAIL; // Invalid function offset
+        }
+        auto functionStart = code + functionOffset;
         auto header = (VMFuncHeader*)(functionStart);
+        uint64_t paramOffsetsSize = uint64_t(header->parameterCount) * sizeof(uint32_t);
+        uint64_t functionSize = sizeof(VMFuncHeader) + paramOffsetsSize + header->codeSize;
+        if (!isRangeInBounds(functionOffset, functionSize, codeSize))
+        {
+            return SLANG_FAIL; // Invalid function size
+        }
+        if (header->name.offset >= moduleView->stringCount)
+        {
+            return SLANG_FAIL; // Invalid function name
+        }
         VMFunctionView functionView;
         functionView.moduleView = moduleView;
-        functionView.header = (VMFuncHeader*)(functionStart);
+        functionView.header = header;
         functionView.paramOffsets = (uint32_t*)(functionStart + sizeof(VMFuncHeader));
         functionView.name = (const char*)moduleView->constants +
                             moduleView->stringOffsets[functionView.header->name.offset];

--- a/tools/slang-unit-test/unit-test-slang-vm.cpp
+++ b/tools/slang-unit-test/unit-test-slang-vm.cpp
@@ -3,6 +3,7 @@
 #include "core/slang-memory-file-system.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
+#include "slang/slang-vm-bytecode.h"
 #include "unit-test/slang-unit-test.h"
 
 #include <stdio.h>
@@ -10,6 +11,77 @@
 #include <string.h>
 
 using namespace Slang;
+
+struct MinimalVMByteCode
+{
+    List<uint8_t> data;
+    uint32_t functionOffsetOffset = 0;
+    uint32_t functionHeaderOffset = 0;
+    uint32_t stringOffsetOffset = 0;
+};
+
+template<typename T>
+static void appendValue(List<uint8_t>& data, const T& value)
+{
+    data.addRange(reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+}
+
+static void patchUInt32(List<uint8_t>& data, uint32_t offset, uint32_t value)
+{
+    memcpy(data.getBuffer() + offset, &value, sizeof(value));
+}
+
+static MinimalVMByteCode makeMinimalVMByteCode()
+{
+    MinimalVMByteCode result;
+
+    appendValue(result.data, kSlangByteCodeFourCC);
+    appendValue(result.data, kSlangByteCodeVersion);
+
+    appendValue(result.data, kSlangByteCodeFunctionsFourCC);
+    uint32_t functionSectionSizeOffset = (uint32_t)result.data.getCount();
+    appendValue(result.data, uint32_t(0));
+
+    appendValue(result.data, uint32_t(1));
+    result.functionOffsetOffset = (uint32_t)result.data.getCount();
+    appendValue(result.data, uint32_t(0));
+
+    result.functionHeaderOffset = (uint32_t)result.data.getCount();
+    patchUInt32(result.data, result.functionOffsetOffset, result.functionHeaderOffset);
+
+    VMFuncHeader funcHeader = {};
+    funcHeader.name.sectionId = kSlangByteCodeSectionStrings;
+    funcHeader.name.offset = 0;
+    funcHeader.codeSize = sizeof(VMInstHeader);
+    appendValue(result.data, funcHeader);
+
+    VMInstHeader retInst = {};
+    retInst.opcode = VMOp::Ret;
+    appendValue(result.data, retInst);
+
+    uint32_t functionSectionSize =
+        (uint32_t)result.data.getCount() - functionSectionSizeOffset - sizeof(uint32_t);
+    patchUInt32(result.data, functionSectionSizeOffset, functionSectionSize);
+
+    appendValue(result.data, kSlangByteCodeKernelBlobFourCC);
+    appendValue(result.data, uint32_t(0));
+
+    const char functionName[] = "main";
+    appendValue(result.data, kSlangByteCodeConstantsFourCC);
+    appendValue(result.data, uint32_t(sizeof(functionName)));
+    appendValue(result.data, uint32_t(1));
+    result.stringOffsetOffset = (uint32_t)result.data.getCount();
+    appendValue(result.data, uint32_t(0));
+    result.data.addRange(reinterpret_cast<const uint8_t*>(functionName), sizeof(functionName));
+
+    return result;
+}
+
+static SlangResult initVMModuleForTest(List<uint8_t>& data)
+{
+    VMModuleView moduleView = {};
+    return initVMModule(data.getBuffer(), (uint32_t)data.getCount(), &moduleView);
+}
 
 SLANG_UNIT_TEST(slangVM)
 {
@@ -100,6 +172,29 @@ SLANG_UNIT_TEST(slangVM)
     int* returnVal = (int*)runner->getReturnValue(&returnValSize);
     SLANG_CHECK(returnValSize == sizeof(int));
     SLANG_CHECK(*returnVal == 100);
+}
+
+SLANG_UNIT_TEST(slangVMRejectMalformedByteCodeOffsets)
+{
+    auto validByteCode = makeMinimalVMByteCode();
+    SLANG_CHECK(initVMModuleForTest(validByteCode.data) == SLANG_OK);
+
+    auto invalidFunctionOffset = makeMinimalVMByteCode();
+    patchUInt32(
+        invalidFunctionOffset.data,
+        invalidFunctionOffset.functionOffsetOffset,
+        (uint32_t)invalidFunctionOffset.data.getCount() + sizeof(VMFuncHeader));
+    SLANG_CHECK(SLANG_FAILED(initVMModuleForTest(invalidFunctionOffset.data)));
+
+    auto invalidFunctionName = makeMinimalVMByteCode();
+    auto funcHeader = reinterpret_cast<VMFuncHeader*>(
+        invalidFunctionName.data.getBuffer() + invalidFunctionName.functionHeaderOffset);
+    funcHeader->name.offset = 1;
+    SLANG_CHECK(SLANG_FAILED(initVMModuleForTest(invalidFunctionName.data)));
+
+    auto invalidStringOffset = makeMinimalVMByteCode();
+    patchUInt32(invalidStringOffset.data, invalidStringOffset.stringOffsetOffset, UINT32_MAX);
+    SLANG_CHECK(SLANG_FAILED(initVMModuleForTest(invalidStringOffset.data)));
 }
 
 struct ExtCallState


### PR DESCRIPTION
Automated review PR created by /review-on-fork-repo skill.

## Summary
- Validate offsets read from VM bytecode in `slang-vm-bytecode.cpp` to harden the loader against malformed/malicious bytecode inputs.
- Add unit tests in `unit-test-slang-vm.cpp` covering the new validation paths.

## Test plan
- [ ] LLM review (CodeRabbit / Gemini / Greptile) — clean
- [ ] `slang-unit-test` covering VM bytecode loader passes