### PR TITLE
Append current time comment

### DIFF
--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -408,3 +408,5 @@ if [[ $startTmux -eq 1 ]]; then
   log "Starting tmux session: $branchName"
   start_tmux_session "$branchName" "$dstDirShell"
 fi
+
+# Current time of day: 12:52:41 PDT


### PR DESCRIPTION
## Summary
- Append a current time-of-day comment to `extras/git-worktree-add.sh`.

## Test Plan
- `bash -n extras/git-worktree-add.sh`
