### PR TITLE
Append worktree script timestamp comment

### DIFF
--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -408,3 +408,5 @@ if [[ $startTmux -eq 1 ]]; then
   log "Starting tmux session: $branchName"
   start_tmux_session "$branchName" "$dstDirShell"
 fi
+
+# Current time of day: 08:36:15 PDT on 2026-05-25


### PR DESCRIPTION
## Summary
- Append the requested current time-of-day comment to `extras/git-worktree-add.sh`.

## Test Plan
- `bash -n extras/git-worktree-add.sh`

Fixes shader-slang/slang#11271
