### PR TITLE
Add fp16 vector atomic capability

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1721,9 +1721,7 @@ A capability describes an optional feature that a target may or may not support.
 * `texture_shadowgrad` 
 * `atomic_glsl_float1` 
 * `atomic_glsl_float2` 
-* `atomic_glsl_halfscalar` 
 * `atomic_glsl_halfvec` 
-* `atomic_glsl_halfadd` 
 * `atomic_glsl` 
 * `atomic_glsl_int64` 
 * `GLSL_430_SPIRV_1_0_compute` : enables the GLSL_430_SPIRV_1_0_compute extension 

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1314,6 +1314,7 @@ A capability describes an optional feature that a target may or may not support.
 * `SPV_EXT_descriptor_indexing` : enables the SPV_EXT_descriptor_indexing extension 
 * `SPV_EXT_shader_atomic_float_add` : enables the SPV_EXT_shader_atomic_float_add extension 
 * `SPV_EXT_shader_atomic_float16_add` : enables the SPV_EXT_shader_atomic_float16_add extension 
+* `SPV_NV_shader_atomic_fp16_vector` : enables the SPV_NV_shader_atomic_fp16_vector extension 
 * `SPV_EXT_shader_atomic_float_min_max` : enables the SPV_EXT_shader_atomic_float_min_max extension 
 * `SPV_EXT_mesh_shader` : enables the SPV_EXT_mesh_shader extension 
 * `SPV_EXT_demote_to_helper_invocation` : enables the SPV_EXT_demote_to_helper_invocation extension 
@@ -1351,6 +1352,7 @@ A capability describes an optional feature that a target may or may not support.
 * `spvDeviceGroup` 
 * `spvAtomicFloat32AddEXT` 
 * `spvAtomicFloat16AddEXT` 
+* `spvAtomicFloat16VectorNV` 
 * `spvAtomicFloat64AddEXT` 
 * `spvInt64Atomics` 
 * `spvAtomicFloat32MinMaxEXT` 
@@ -1719,7 +1721,9 @@ A capability describes an optional feature that a target may or may not support.
 * `texture_shadowgrad` 
 * `atomic_glsl_float1` 
 * `atomic_glsl_float2` 
+* `atomic_glsl_halfscalar` 
 * `atomic_glsl_halfvec` 
+* `atomic_glsl_halfadd` 
 * `atomic_glsl` 
 * `atomic_glsl_int64` 
 * `GLSL_430_SPIRV_1_0_compute` : enables the GLSL_430_SPIRV_1_0_compute extension 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -968,7 +968,7 @@ Compound Capabilities
 > (SPIRV) Capabilities required to use either native or halfvec-emulated fp16 atomic add
 
 `atomic_glsl_halfscalar`
-> (SPIRV) Capabilities required to use single-lane fp16 float-atomic operations
+> (SPIRV) Capabilities required to use scalar fp16 float-atomic operations
 
 `atomic_glsl_halfvec`
 > (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -964,12 +964,6 @@ Compound Capabilities
 `atomic_glsl_float2`
 > (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
 
-`atomic_glsl_halfadd`
-> (SPIRV) Capabilities required to use either native or halfvec-emulated fp16 atomic add
-
-`atomic_glsl_halfscalar`
-> (SPIRV) Capabilities required to use scalar fp16 float-atomic operations
-
 `atomic_glsl_halfvec`
 > (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations
 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -701,6 +701,9 @@ Extensions
 `SPV_NV_ray_tracing_motion_blur`
 > Represents the SPIR-V extension for ray tracing motion blur.
 
+`SPV_NV_shader_atomic_fp16_vector`
+> Represents the SPIR-V extension for vector atomic float16 operations.
+
 `SPV_NV_shader_image_footprint`
 > Represents the SPIR-V extension for shader image footprint.
 
@@ -722,6 +725,9 @@ Extensions
 
 `spvAtomicFloat16MinMaxEXT`
 > Represents the SPIR-V capability for atomic float 16 min/max operations.
+
+`spvAtomicFloat16VectorNV`
+> Represents the SPIR-V capability for vector atomic float16 operations.
 
 `spvAtomicFloat32AddEXT`
 > Represents the SPIR-V capability for atomic float 32 add operations.
@@ -957,6 +963,12 @@ Compound Capabilities
 
 `atomic_glsl_float2`
 > (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
+
+`atomic_glsl_halfadd`
+> (SPIRV) Capabilities required to use either native or halfvec-emulated fp16 atomic add
+
+`atomic_glsl_halfscalar`
+> (SPIRV) Capabilities required to use single-lane fp16 float-atomic operations
 
 `atomic_glsl_halfvec`
 > (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6493,7 +6493,8 @@ $}
     /// @return The 2 16-bit floating point values packed into a 32-bit unsigned integer.
     [__requiresNVAPI]
     [ForceInline]
-    [require(cuda_hlsl_spirv)]
+    [require(cuda_hlsl, sm_5_0)]
+    [require(spirv, spvAtomicFloat16VectorNV)]
     uint _NvInterlockedAddFp16x2(uint byteAddress, uint fp16x2Value)
     {
         __target_switch
@@ -6511,14 +6512,17 @@ $}
     /// @param byteAddress The address at which to perform the atomic add operation.
     /// @param value The value to add to the value at `byteAddress`.
     /// @param originalValue The original value at `byteAddress` before the add operation.
-    /// @remarks For SPIR-V, this function maps to `OpAtomicFAdd` and requires `SPV_EXT_shader_atomic_float16_add` extension.
+    /// @remarks For SPIR-V, this function maps to `OpAtomicFAdd` on a `half` when
+    /// `SPV_EXT_shader_atomic_float16_add` is available, and falls back to a `half2`
+    /// atomic when `SPV_NV_shader_atomic_fp16_vector` is available.
     ///
     /// For HLSL, this function translates to an NVAPI call
     /// due to lack of native HLSL intrinsic for floating point atomic add. For CUDA, this function
     /// maps to `atomicAdd`.
     [__requiresNVAPI]
     [ForceInline]
-    [require(cuda_hlsl_spirv, sm_5_0)]
+    [require(cuda_hlsl, sm_5_0)]
+    [require(spirv, atomic_glsl_halfadd)]
     void InterlockedAddF16(uint byteAddress, half value, out half originalValue)
     {
         __target_switch
@@ -6536,10 +6540,26 @@ $}
                 originalValue = asfloat16((uint16_t)(_NvInterlockedAddFp16x2(byteAddress, packedInput) >> 16));
             }
             return;
+        case cuda:
+            __intrinsic_asm "(*$3 = atomicAdd($0._getPtrAt<half>($1), $2))";
+        case spvAtomicFloat16AddEXT:
         default:
             {
                 let buf = __getEquivalentStructuredBuffer<half>(this);
                 originalValue = __atomic_add(buf[byteAddress/2], value);
+                return;
+            }
+        case spvAtomicFloat16VectorNV:
+            {
+                let buf = __getEquivalentStructuredBuffer<half2>(this);
+                if ((byteAddress & 2) == 0)
+                {
+                    originalValue = __atomic_add(buf[byteAddress/4], half2(value, half(0.0))).x;
+                }
+                else
+                {
+                    originalValue = __atomic_add(buf[byteAddress/4], half2(half(0.0), value)).y;
+                }
                 return;
             }
         }
@@ -6558,7 +6578,8 @@ $}
     /// maps to `atomicAdd`.
     [__requiresNVAPI]
     [ForceInline]
-    [require(cuda_hlsl_spirv, sm_5_0)]
+    [require(cuda_hlsl, sm_5_0)]
+    [require(spirv, spvAtomicFloat16VectorNV)]
     void InterlockedAddF16Emulated(uint byteAddress, half value, out half originalValue)
     {
         __target_switch
@@ -33741,7 +33762,7 @@ uint packHalf2x16(half2 unpackedValue)
     return packHalf2x16(float2(unpackedValue));
 }
 
-[require(spirv)]
+[require(spirv, spvAtomicFloat16VectorNV)]
 void InterlockedAddF16Emulated(half* dest, half value, out half originalValue)
 {
     let buf = (half2*)(dest);
@@ -33756,7 +33777,7 @@ void InterlockedAddF16Emulated(half* dest, half value, out half originalValue)
     }
 }
 
-[require(spirv)]
+[require(spirv, spvAtomicFloat16VectorNV)]
 void InterlockedAddF16x2(half2* dest, half2 value, out half2 originalValue)
 {
     originalValue = __atomic_add(*dest, value);

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6522,7 +6522,8 @@ $}
     [__requiresNVAPI]
     [ForceInline]
     [require(cuda_hlsl, sm_5_0)]
-    [require(spirv, atomic_glsl_halfadd)]
+    [require(spirv, spvAtomicFloat16VectorNV)]
+    [require(spirv, spvAtomicFloat16AddEXT)]
     void InterlockedAddF16(uint byteAddress, half value, out half originalValue)
     {
         __target_switch
@@ -6578,8 +6579,7 @@ $}
     /// maps to `atomicAdd`.
     [__requiresNVAPI]
     [ForceInline]
-    [require(cuda_hlsl, sm_5_0)]
-    [require(spirv, spvAtomicFloat16VectorNV)]
+    [require(cuda_hlsl_spirv, sm_5_0)]
     void InterlockedAddF16Emulated(uint byteAddress, half value, out half originalValue)
     {
         __target_switch
@@ -33762,7 +33762,7 @@ uint packHalf2x16(half2 unpackedValue)
     return packHalf2x16(float2(unpackedValue));
 }
 
-[require(spirv, spvAtomicFloat16VectorNV)]
+[require(spirv)]
 void InterlockedAddF16Emulated(half* dest, half value, out half originalValue)
 {
     let buf = (half2*)(dest);
@@ -33777,7 +33777,7 @@ void InterlockedAddF16Emulated(half* dest, half value, out half originalValue)
     }
 }
 
-[require(spirv, spvAtomicFloat16VectorNV)]
+[require(spirv)]
 void InterlockedAddF16x2(half2* dest, half2 value, out half2 originalValue)
 {
     originalValue = __atomic_add(*dest, value);

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2384,15 +2384,9 @@ alias atomic_glsl_float1 = GL_EXT_shader_atomic_float;
 /// (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
 /// [Compound]
 alias atomic_glsl_float2 = GL_EXT_shader_atomic_float2;
-/// (SPIRV) Capabilities required to use scalar fp16 float-atomic operations
-/// [Compound]
-alias atomic_glsl_halfscalar = spvAtomicFloat16AddEXT;
 /// (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations
 /// [Compound]
 alias atomic_glsl_halfvec = GL_NV_shader_atomic_fp16_vector;
-/// (SPIRV) Capabilities required to use either native or halfvec-emulated fp16 atomic add
-/// [Compound]
-alias atomic_glsl_halfadd = atomic_glsl_halfscalar | atomic_glsl_halfvec;
 /// (GLSL/SPIRV) Capabilities required to use GLSL-400 atomic operations
 /// [Compound]
 alias atomic_glsl = spirv_1_0 | _GLSL_400;

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -543,6 +543,10 @@ def SPV_EXT_shader_atomic_float_add : _spirv_1_0;
 /// [EXT]
 def SPV_EXT_shader_atomic_float16_add : SPV_EXT_shader_atomic_float_add;
 
+/// Represents the SPIR-V extension for vector atomic float16 operations.
+/// [EXT]
+def SPV_NV_shader_atomic_fp16_vector : _spirv_1_0;
+
 /// Represents the SPIR-V extension for atomic float min/max operations.
 /// [EXT]
 def SPV_EXT_shader_atomic_float_min_max : _spirv_1_0;
@@ -699,6 +703,10 @@ def spvAtomicFloat32AddEXT : SPV_EXT_shader_atomic_float_add;
 /// Represents the SPIR-V capability for atomic float 16 add operations.
 /// [EXT]
 def spvAtomicFloat16AddEXT : SPV_EXT_shader_atomic_float16_add;
+
+/// Represents the SPIR-V capability for vector atomic float16 operations.
+/// [EXT]
+def spvAtomicFloat16VectorNV : SPV_NV_shader_atomic_fp16_vector;
 
 /// Represents the SPIR-V capability for atomic float 64 add operations.
 /// [EXT]
@@ -1261,7 +1269,7 @@ alias GL_NV_ray_tracing_motion_blur = _GL_NV_ray_tracing_motion_blur | spvRayTra
 
 /// Represents the GL_NV_shader_atomic_fp16_vector extension.
 /// [EXT]
-alias GL_NV_shader_atomic_fp16_vector = _GL_NV_shader_atomic_fp16_vector + _GL_NV_gpu_shader5 | _spirv_1_0;
+alias GL_NV_shader_atomic_fp16_vector = _GL_NV_shader_atomic_fp16_vector + _GL_NV_gpu_shader5 | spvAtomicFloat16VectorNV;
 
 /// Represents the GL_NV_shader_invocation_reorder extension (NVIDIA-specific).
 /// [EXT]
@@ -2376,9 +2384,15 @@ alias atomic_glsl_float1 = GL_EXT_shader_atomic_float;
 /// (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
 /// [Compound]
 alias atomic_glsl_float2 = GL_EXT_shader_atomic_float2;
+/// (SPIRV) Capabilities required to use single-lane fp16 float-atomic operations
+/// [Compound]
+alias atomic_glsl_halfscalar = spvAtomicFloat16AddEXT;
 /// (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations
 /// [Compound]
 alias atomic_glsl_halfvec = GL_NV_shader_atomic_fp16_vector;
+/// (SPIRV) Capabilities required to use either native or halfvec-emulated fp16 atomic add
+/// [Compound]
+alias atomic_glsl_halfadd = atomic_glsl_halfscalar | atomic_glsl_halfvec;
 /// (GLSL/SPIRV) Capabilities required to use GLSL-400 atomic operations
 /// [Compound]
 alias atomic_glsl = spirv_1_0 | _GLSL_400;

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2384,7 +2384,7 @@ alias atomic_glsl_float1 = GL_EXT_shader_atomic_float;
 /// (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
 /// [Compound]
 alias atomic_glsl_float2 = GL_EXT_shader_atomic_float2;
-/// (SPIRV) Capabilities required to use single-lane fp16 float-atomic operations
+/// (SPIRV) Capabilities required to use scalar fp16 float-atomic operations
 /// [Compound]
 alias atomic_glsl_halfscalar = spvAtomicFloat16AddEXT;
 /// (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
@@ -13,7 +13,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 // SCALAR: OpCapability AtomicFloat16AddEXT
 // SCALAR: OpExtension "SPV_EXT_shader_atomic_float16_add"
 // SCALAR-NOT: OpCapability AtomicFloat16VectorNV
+// SCALAR-NOT: OpExtension "SPV_NV_shader_atomic_fp16_vector"
 
 // VECTOR: OpCapability AtomicFloat16VectorNV
 // VECTOR: OpExtension "SPV_NV_shader_atomic_fp16_vector"
 // VECTOR-NOT: OpCapability AtomicFloat16AddEXT
+// VECTOR-NOT: OpExtension "SPV_EXT_shader_atomic_float16_add"

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability spvAtomicFloat16AddEXT
-//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability GL_NV_shader_atomic_fp16_vector
+//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability spvAtomicFloat16VectorNV
 
 RWByteAddressBuffer tmpBuffer;
 

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -capability spvAtomicFloat16AddEXT
-//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -capability spvAtomicFloat16VectorNV
+//TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -capability spvAtomicFloat16AddEXT
+//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -capability spvAtomicFloat16VectorNV
 
 RWByteAddressBuffer tmpBuffer;
 

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability spvAtomicFloat16AddEXT
-//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability spvAtomicFloat16VectorNV
+//TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -capability spvAtomicFloat16AddEXT
+//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -capability spvAtomicFloat16VectorNV
 
 RWByteAddressBuffer tmpBuffer;
 

--- a/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
+++ b/tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=SCALAR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability spvAtomicFloat16AddEXT
+//TEST:SIMPLE(filecheck=VECTOR): -target spirv -entry computeMain -stage compute -emit-spirv-directly -skip-spirv-validation -ignore-capabilities -capability GL_NV_shader_atomic_fp16_vector
+
+RWByteAddressBuffer tmpBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    half originalValue;
+    tmpBuffer.InterlockedAddF16(2, 1.0h, originalValue);
+}
+
+// SCALAR: OpCapability AtomicFloat16AddEXT
+// SCALAR: OpExtension "SPV_EXT_shader_atomic_float16_add"
+// SCALAR-NOT: OpCapability AtomicFloat16VectorNV
+
+// VECTOR: OpCapability AtomicFloat16VectorNV
+// VECTOR: OpExtension "SPV_NV_shader_atomic_fp16_vector"
+// VECTOR-NOT: OpCapability AtomicFloat16AddEXT


### PR DESCRIPTION
Fixes shader-slang/slang#11083

## Summary of the problem from the end user perspective

Targets can expose different SPIR-V fp16 atomic support: scalar half atomic add and half-vector atomics are covered by separate extensions. Slang needs to pick the matching operation and capability for `RWByteAddressBuffer.InterlockedAddF16` instead of treating all fp16 atomic add support as one capability.

### Minimal repro shader; if applicable

```hlsl
RWByteAddressBuffer tmpBuffer;

[numthreads(1, 1, 1)]
void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
{
    half originalValue;
    tmpBuffer.InterlockedAddF16(2, 1.0h, originalValue);
}
```

## Root cause

Slang's capability model did not have a distinct `SPV_NV_shader_atomic_fp16_vector` / `AtomicFloat16VectorNV` capability path for the NV half-vector extension. That made the scalar `SPV_EXT_shader_atomic_float16_add` path and the vector fallback path too easy to collapse into one requirement.

## Solution in this PR

This PR adds `spvAtomicFloat16VectorNV`, wires `GL_NV_shader_atomic_fp16_vector` to it, and updates `InterlockedAddF16` so it can use scalar half atomic add when `spvAtomicFloat16AddEXT` is available or a half2 vector atomic fallback when `spvAtomicFloat16VectorNV` is available.

The focused capability test checks that the scalar path declares `AtomicFloat16AddEXT` / `SPV_EXT_shader_atomic_float16_add` without the NV vector extension, and that the vector path declares `AtomicFloat16VectorNV` / `SPV_NV_shader_atomic_fp16_vector` without the scalar EXT extension.

### Notes to the reviewers; where to focus on

The SPIR-V extension split is intentional:

- `SPV_EXT_shader_atomic_float_add` defines `OpAtomicFAddEXT` for scalar fp32/fp64 via `AtomicFloat32AddEXT` and `AtomicFloat64AddEXT`.
- `SPV_EXT_shader_atomic_float16_add` extends that scalar add extension for fp16 via `AtomicFloat16AddEXT`; the SPIR-V spec says scalar fp16 add modules need both `SPV_EXT_shader_atomic_float16_add` and the base `SPV_EXT_shader_atomic_float_add` extension declared.
- `SPV_NV_shader_atomic_fp16_vector` adds `AtomicFloat16VectorNV` for fp16 vectors with 2 or 4 components, including add, min, max, and exchange. It reuses instructions from the EXT add/minmax extensions but does not require those EXT extensions to be supported or enabled.

Please focus review on the capability definitions and aliases in `source/slang/slang-capabilities.capdef`, the overload requirements and selection logic in `source/slang/hlsl.meta.slang`, and the SPIR-V extension/capability checks in `tests/hlsl-intrinsic/byte-address-buffer/byte-address-half-atomics-capability.slang`.

## Related PRs in the past

None identified.
