### PR TITLE
Append worktree script timestamp comment

### DIFF
--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -371,3 +371,5 @@ if [[ $startTmux -eq 1 ]]; then
   log "Starting tmux session: $branchName"
   start_tmux_session "$branchName" "$dstDirShell"
 fi
+
+# Current time of day: 21:10:59 PDT


### PR DESCRIPTION
## Summary
- Append the current time-of-day comment to `extras/git-worktree-add.sh`.

## Test Plan
- `bash -n extras/git-worktree-add.sh`
- `git.exe diff --check`
- Commit hook formatting check

Fixes shader-slang/slang#11271
