### PR TITLE
Fix default init for late member constructors

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3123,6 +3123,8 @@ static Expr* constructDefaultConstructorForType(
     {
         if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
         {
+            if (!structDecl->checkState.isBeingChecked())
+                visitor->ensureDecl(structDecl, DeclCheckState::AttributesChecked);
             defaultCtor = _getDefaultCtor(structDecl);
         }
     }

--- a/tests/initializer-list/default-init-late-member-explicit-ctor.slang
+++ b/tests/initializer-list/default-init-late-member-explicit-ctor.slang
@@ -1,0 +1,59 @@
+//TEST:SIMPLE:
+
+#define SPECTRAL_N 4
+
+struct SpectralSample
+{
+    float values[SPECTRAL_N];
+
+    __init(const float f = 0.0f)
+    {
+        for (uint i = 0; i < SPECTRAL_N; ++i)
+            values[i] = f;
+    }
+};
+
+typedef SpectralSample ColorSample;
+
+struct DiffuseBSDFData
+{
+    ColorSample tint;
+    float roughness;
+};
+
+struct MicrofacetBSDFData
+{
+    ColorSample tint;
+    float roughnessU;
+};
+
+struct FresnelLayerBSDFData
+{
+    MicrofacetBSDFData layer;
+    WeightedLayerBSDFData base;
+};
+
+struct WeightedLayerBSDFData
+{
+    ColorSample weight;
+    MicrofacetBSDFData layer;
+    DiffuseBSDFData base;
+};
+
+struct Outer
+{
+    FresnelLayerBSDFData data;
+};
+
+void init(inout Outer outer)
+{
+    outer = {};
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    Outer outer;
+    init(outer);
+}

--- a/tests/initializer-list/default-init-late-member-explicit-ctor.slang
+++ b/tests/initializer-list/default-init-late-member-explicit-ctor.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE:
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-cpu -shaderobj
 
 #define SPECTRAL_N 4
 
@@ -45,15 +45,55 @@ struct Outer
     FresnelLayerBSDFData data;
 };
 
+bool isZeroColorSample(ColorSample value)
+{
+    bool result = true;
+    for (uint i = 0; i < SPECTRAL_N; ++i)
+        result = result && value.values[i] == 0.0f;
+    return result;
+}
+
+bool isZeroDiffuse(DiffuseBSDFData value)
+{
+    return isZeroColorSample(value.tint) && value.roughness == 0.0f;
+}
+
+bool isZeroMicrofacet(MicrofacetBSDFData value)
+{
+    return isZeroColorSample(value.tint) && value.roughnessU == 0.0f;
+}
+
+bool isZeroWeightedLayer(WeightedLayerBSDFData value)
+{
+    return isZeroColorSample(value.weight) && isZeroMicrofacet(value.layer) &&
+           isZeroDiffuse(value.base);
+}
+
+bool isZeroFresnelLayer(FresnelLayerBSDFData value)
+{
+    return isZeroMicrofacet(value.layer) && isZeroWeightedLayer(value.base);
+}
+
+bool isZeroOuter(Outer value)
+{
+    return isZeroFresnelLayer(value.data);
+}
+
 void init(inout Outer outer)
 {
     outer = {};
 }
 
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void main()
+void computeMain()
 {
     Outer outer;
     init(outer);
+
+    outputBuffer[0] = isZeroOuter(outer) ? 1 : 0;
+    // BUFFER: 1
 }


### PR DESCRIPTION
## Summary
- Ensure late-declared member struct types reach `AttributesChecked` before probing for synthesized default constructors.
- Add a regression test for declaration-order-sensitive default initialization when a transitive member has an explicit constructor.

## Test Plan
- `cmake.exe --build --preset debug --target slangc slang-test`
- `./build/Debug/bin/slang-test.exe -v failure tests/initializer-list/default-init-late-member-explicit-ctor.slang`
- `./build/Debug/bin/slangc.exe -lang slang -target hlsl tests/initializer-list/default-init-late-member-explicit-ctor.slang`
- `./extras/formatting.sh --no-version-check -- source/slang/slang-check-decl.cpp tests/initializer-list/default-init-late-member-explicit-ctor.slang`

Fixes shader-slang/slang#11095
