### PR TITLE
Add PR review mode to worktree helper

### DIFF
--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -415,6 +415,7 @@ else
         : >"$submoduleFailureFile"
       fi
     ) &
+    sleep 1 # Stagger background submodule updates to reduce Git lock contention.
   done
 
   wait

--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -188,6 +188,51 @@ parse_review_pr_url() {
   die "Unsupported review URL: $input. Expected https://github.com/<owner>/<repo>/pull/<number>."
 }
 
+github_repo_from_url() {
+  local input="$1"
+  local clean="$input"
+
+  clean="${clean%%#*}"
+  clean="${clean%%\?*}"
+  clean="${clean%/}"
+  clean="${clean%.git}"
+  clean="${clean#http://}"
+  clean="${clean#https://}"
+  clean="${clean#ssh://git@}"
+  clean="${clean#git@}"
+  clean="${clean#www.}"
+
+  if [[ "$clean" =~ ^github\.com[:/]([^/]+)/([^/]+)$ ]]; then
+    printf '%s/%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return
+  fi
+
+  return 1
+}
+
+review_repo_matches_configured_remote() {
+  local remoteName
+  local remoteUrl
+  local remoteRepo
+  local reviewRepoFull="$reviewOwner/$reviewRepo"
+
+  while IFS= read -r remoteName; do
+    remoteName="${remoteName%$'\r'}"
+    if ! remoteUrl="$(git_run remote get-url "$remoteName" </dev/null 2>/dev/null)"; then
+      continue
+    fi
+    remoteUrl="${remoteUrl%$'\r'}"
+    if ! remoteRepo="$(github_repo_from_url "$remoteUrl")"; then
+      continue
+    fi
+    if [[ "${remoteRepo,,}" == "${reviewRepoFull,,}" ]]; then
+      return 0
+    fi
+  done < <(git_run remote)
+
+  return 1
+}
+
 branchInput=""
 baseRef=""
 dstDirInput=""
@@ -286,6 +331,9 @@ branchName=""
 if [[ -n "$reviewInput" ]]; then
   parse_review_pr_url "$reviewInput"
   baseRef="refs/pr/$reviewNumber/head"
+  if ! review_repo_matches_configured_remote; then
+    die "Review URL repository does not match any configured GitHub remote: $reviewOwner/$reviewRepo"
+  fi
   branchName="$branchInput"
   if [[ -z "$branchName" ]]; then
     branchName="review-pr-$reviewNumber"

--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -173,8 +173,11 @@ parse_review_pr_url() {
   clean="${clean%%#*}"
   clean="${clean%%\?*}"
   clean="${clean%/}"
+  clean="${clean#http://}"
+  clean="${clean#https://}"
+  clean="${clean#www.}"
 
-  if [[ "$clean" =~ ^https?://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)(/.*)?$ ]]; then
+  if [[ "$clean" =~ ^github\.com/([^/]+)/([^/]+)/pull/([0-9]+)(/.*)?$ ]]; then
     reviewOwner="${BASH_REMATCH[1]}"
     reviewRepo="${BASH_REMATCH[2]%.git}"
     reviewNumber="${BASH_REMATCH[3]}"
@@ -287,12 +290,6 @@ if [[ -n "$reviewInput" ]]; then
   if [[ -z "$branchName" ]]; then
     branchName="review-pr-$reviewNumber"
   fi
-  worktreeName="$branchName"
-  worktreeName="${worktreeName//\//-}"
-  sessionName="$worktreeName"
-
-  log "Fetching PR #$reviewNumber from $reviewRepoUrl..."
-  git_run fetch -q "$reviewRepoUrl" "+pull/$reviewNumber/head:$baseRef"
 
   if ! git_run check-ref-format --branch "$branchName" >/dev/null 2>&1; then
     die "Invalid branch name: $branchName"
@@ -301,6 +298,12 @@ if [[ -n "$reviewInput" ]]; then
   if git_run show-ref --verify --quiet "refs/heads/$branchName"; then
     die "Branch already exists: $branchName"
   fi
+  worktreeName="$branchName"
+  worktreeName="${worktreeName//\//-}"
+  sessionName="$worktreeName"
+
+  log "Fetching PR #$reviewNumber from $reviewRepoUrl..."
+  git_run fetch -q "$reviewRepoUrl" "+pull/$reviewNumber/head:$baseRef"
 else
   branchName="$branchInput"
 
@@ -415,7 +418,7 @@ else
         : >"$submoduleFailureFile"
       fi
     ) &
-    sleep 1 # Stagger background submodule updates to reduce Git lock contention.
+    sleep 0.2 # Stagger background submodule updates to reduce Git lock contention.
   done
 
   wait

--- a/extras/git-worktree-add.sh
+++ b/extras/git-worktree-add.sh
@@ -30,19 +30,24 @@ TMUX_EXE="${TMUX_EXE:-tmux}"
 show_usage() {
   me=$(basename "$0")
   cat <<EOF
-Usage: $me [options] <branch-name>
+Usage:
+  $me [options] <branch-name>
+  $me --review <pull-request-url> [options] [branch-name]
 
-Create a sibling git worktree for a new branch.
+Create a sibling git worktree for a new branch or GitHub pull request review.
 
 Options:
   --base <ref>       Base branch or commit for the new worktree.
                      Defaults to the current branch, which must be master,
                      main, or release/*.
+  --review <url>     Fetch a GitHub pull request head and create a review
+                     branch/worktree. Defaults to review-pr-<number>.
   --dir <path>       Destination directory. Defaults to ../<branch-name>.
                      If the branch name contains slashes, they are replaced
-                     by dashes.
-  --tmux             Start a tmux session named after the branch in the new
-                     worktree after setup completes.
+                     by dashes. In review mode, defaults to
+                     ../review-pr-<number>.
+  --tmux             Start a tmux session named after the branch or review in
+                     the new worktree after setup completes.
   --no-submodules    Skip submodule initialization.
   -h, --help         Show this help.
 
@@ -50,6 +55,8 @@ Examples:
   $me git-worktree-add
   $me --tmux git-worktree-add
   $me --base release/2026.1 --dir ../descriptor-fix descriptor-heap-access
+  $me --review https://github.com/shader-slang/slang/pull/11267
+  $me --review https://github.com/shader-slang/slang/pull/11267 review-11267
 
 Prefer branch names without slashes for predictable worktree directory names.
 Use --dir when creating a worktree for an existing branch name that contains slashes.
@@ -159,11 +166,35 @@ start_tmux_session() {
   fi
 }
 
+parse_review_pr_url() {
+  local input="$1"
+  local clean="$input"
+
+  clean="${clean%%#*}"
+  clean="${clean%%\?*}"
+  clean="${clean%/}"
+
+  if [[ "$clean" =~ ^https?://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)(/.*)?$ ]]; then
+    reviewOwner="${BASH_REMATCH[1]}"
+    reviewRepo="${BASH_REMATCH[2]%.git}"
+    reviewNumber="${BASH_REMATCH[3]}"
+    reviewRepoUrl="https://github.com/$reviewOwner/$reviewRepo.git"
+    return
+  fi
+
+  die "Unsupported review URL: $input. Expected https://github.com/<owner>/<repo>/pull/<number>."
+}
+
 branchInput=""
 baseRef=""
 dstDirInput=""
 initSubmodules=1
 startTmux=0
+reviewInput=""
+reviewOwner=""
+reviewRepo=""
+reviewNumber=""
+reviewRepoUrl=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -176,6 +207,13 @@ while [[ $# -gt 0 ]]; do
       die "--base requires a value."
     fi
     baseRef="$2"
+    shift
+    ;;
+  --review)
+    if [[ $# -lt 2 || -z "${2:-}" ]]; then
+      die "--review requires a pull request URL."
+    fi
+    reviewInput="$2"
     shift
     ;;
   --dir | -d)
@@ -216,7 +254,11 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ -z "$branchInput" ]]; then
+if [[ -n "$reviewInput" && -n "$baseRef" ]]; then
+  die "Cannot use --base with --review."
+fi
+
+if [[ -z "$reviewInput" && -z "$branchInput" ]]; then
   show_usage >&2
   exit 1
 fi
@@ -236,39 +278,65 @@ fi
 repoRootShell="$(to_shell_path "$repoRootGit")"
 cd "$repoRootShell"
 
-branchName="$branchInput"
+branchName=""
 
-if ! git_run check-ref-format --branch "$branchName" >/dev/null 2>&1; then
-  die "Invalid branch name: $branchName"
-fi
-
-if git_run show-ref --verify --quiet "refs/heads/$branchName"; then
-  die "Branch already exists: $branchName"
-fi
-
-if [[ $startTmux -eq 1 ]] && "$TMUX_EXE" has-session -t "=$branchName" 2>/dev/null; then
-  die "tmux session already exists: $branchName"
-fi
-
-if [[ -z "$baseRef" ]]; then
-  baseRef="$(git_run branch --show-current)"
-  if [[ -z "$baseRef" ]]; then
-    die "Cannot infer a base branch from detached HEAD. Use --base <ref>."
+if [[ -n "$reviewInput" ]]; then
+  parse_review_pr_url "$reviewInput"
+  baseRef="refs/pr/$reviewNumber/head"
+  branchName="$branchInput"
+  if [[ -z "$branchName" ]]; then
+    branchName="review-pr-$reviewNumber"
   fi
-  case "$baseRef" in
-  master | main | release | release/*) ;;
-  *)
-    die "Current branch must be master, main, or release/*. Current branch: $baseRef"
-    ;;
-  esac
+  worktreeName="$branchName"
+  worktreeName="${worktreeName//\//-}"
+  sessionName="$worktreeName"
+
+  log "Fetching PR #$reviewNumber from $reviewRepoUrl..."
+  git_run fetch -q "$reviewRepoUrl" "+pull/$reviewNumber/head:$baseRef"
+
+  if ! git_run check-ref-format --branch "$branchName" >/dev/null 2>&1; then
+    die "Invalid branch name: $branchName"
+  fi
+
+  if git_run show-ref --verify --quiet "refs/heads/$branchName"; then
+    die "Branch already exists: $branchName"
+  fi
+else
+  branchName="$branchInput"
+
+  if ! git_run check-ref-format --branch "$branchName" >/dev/null 2>&1; then
+    die "Invalid branch name: $branchName"
+  fi
+
+  if git_run show-ref --verify --quiet "refs/heads/$branchName"; then
+    die "Branch already exists: $branchName"
+  fi
+
+  if [[ -z "$baseRef" ]]; then
+    baseRef="$(git_run branch --show-current)"
+    if [[ -z "$baseRef" ]]; then
+      die "Cannot infer a base branch from detached HEAD. Use --base <ref>."
+    fi
+    case "$baseRef" in
+    master | main | release | release/*) ;;
+    *)
+      die "Current branch must be master, main, or release/*. Current branch: $baseRef"
+      ;;
+    esac
+  fi
+
+  worktreeName="$branchName"
+  worktreeName="${worktreeName//\//-}"
+  sessionName="$branchName"
 fi
 
 if ! git_run rev-parse --verify --quiet "$baseRef^{commit}" >/dev/null; then
   die "Base ref does not resolve to a commit: $baseRef"
 fi
 
-worktreeName="$branchName"
-worktreeName="${worktreeName//\//-}"
+if [[ $startTmux -eq 1 ]] && "$TMUX_EXE" has-session -t "=$sessionName" 2>/dev/null; then
+  die "tmux session already exists: $sessionName"
+fi
 
 maxWorktreeNameLength=50
 if [[ -n "$dstDirInput" ]]; then
@@ -291,6 +359,9 @@ if [[ ! -d "$dstParent" ]]; then
 fi
 
 log "Repository: $repoRootShell"
+if [[ -n "$reviewInput" ]]; then
+  log "Review: $reviewInput"
+fi
 log "Base ref: $baseRef"
 log "Branch: $branchName"
 log "Worktree: $dstDirShell"
@@ -368,6 +439,6 @@ else
 fi
 
 if [[ $startTmux -eq 1 ]]; then
-  log "Starting tmux session: $branchName"
-  start_tmux_session "$branchName" "$dstDirShell"
+  log "Starting tmux session: $sessionName"
+  start_tmux_session "$sessionName" "$dstDirShell"
 fi


### PR DESCRIPTION
## Summary of the problem from the end user perspective

Creating a local worktree to review a GitHub PR required manually fetching the PR ref and choosing branch, directory, and tmux names. That setup was repetitive and easy to get slightly wrong.

## Root cause

The worktree helper only handled local branch creation from an existing base ref. It had no review-specific path for parsing PR URLs, fetching PR heads, or naming review worktrees consistently.

## Solution in this PR

Add a `--review` mode that accepts GitHub PR URLs for configured GitHub remotes, fetches `pull/<number>/head`, and creates a review branch/worktree with sensible defaults. The helper also keeps tmux session naming consistent for review worktrees and staggers background submodule updates to reduce Git lock contention.

### Notes to the reviewers; where to focus on

Please focus on the `--review` argument flow, `parse_review_pr_url`, branch/worktree naming defaults, configured-remote validation, and the interaction with Windows/WSL path handling and submodule initialization.

## Related PRs in the past

- shader-slang/slang#11264 added the worktree helper.
- shader-slang/slang#11268 added tmux support.
- shader-slang/slang#11269 initialized worktree submodules concurrently.
- shader-slang/slang#11283 and shader-slang/slang#11288 refined submodule update behavior.