### PR TITLE
Support stdin input in slangc

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -6,7 +6,8 @@ slangc [options...] [--] <input files>
 
 Pass '-' as an input file to read source from standard input.
 -lang <language> is required when reading from stdin.
-With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.
+With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required.
+Stdin input is capped at 256 MiB.
 
 # Read source from stdin (-lang is required)
 slangc -lang slang -target spirv-asm -entry main -- -

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -285,7 +285,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; [-lang](#lang) [&lt;language&gt;](#language) is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation ([-pass-through](#pass-through) glslang/dxc/fxc), [-stage](#stage-1) [&lt;stage&gt;](#stage) is required because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Stdin input is capped at 256 MiB. Example: slangc [-lang](#lang) slang [-target](#target-2) spirv-asm [-entry](#entry) main [--](#id) - 
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; [-lang](#lang) [&lt;language&gt;](#language) is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation ([-pass-through](#pass-through) glslang/dxc/fxc), [-stage](#stage-1) [&lt;stage&gt;](#stage) is required because the shader stage cannot be inferred from a file extension; slangc emits a clean CLI diagnostic (error 35) when it is omitted. Stdin input is capped at 256 MiB. Example: slangc [-lang](#lang) slang [-target](#target-2) spirv-asm [-entry](#entry) main [--](#id) - 
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -283,7 +283,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is also required because the shader stage cannot be inferred from a file extension. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is required for pass-through compilation because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -277,7 +277,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files; use '-' to read from standard input.
+Treat the rest of the command line as input files; use '-' to read from standard input with [-lang](#lang). 
 
 
 <a id="report-downstream-time"></a>
@@ -1848,3 +1848,4 @@ Available help categories for the [-h](#h) option
 * `capability` : A capability describes an optional feature that a target may or may not support. When a [-capability](#capability-1) is specified, the compiler may assume that the target supports that capability, and generate code accordingly. 
 * `file-extension` : A [&lt;language&gt;](#language), &lt;format&gt;, and/or [&lt;stage&gt;](#stage) may be inferred from the extension of an input or [-o](#o) path 
 * `help-category` : Available help categories for the [-h](#h) option 
+

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -6,7 +6,7 @@ slangc [options...] [--] <input files>
 
 Pass '-' as an input file to read source from standard input.
 -lang <language> is required when reading from stdin.
-For -lang glsl, -stage <stage> is also required.
+With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.
 
 # Read source from stdin (-lang is required)
 slangc -lang slang -target spirv-asm -entry main -stage compute -- -

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -9,7 +9,7 @@ Pass '-' as an input file to read source from standard input.
 With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.
 
 # Read source from stdin (-lang is required)
-slangc -lang slang -target spirv-asm -entry main -stage compute -- -
+slangc -lang slang -target spirv-asm -entry main -- -
 
 # For help
 slangc -h
@@ -284,7 +284,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is required for pass-through compilation because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is required for pass-through compilation because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -- -
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -4,6 +4,9 @@
 ```
 slangc [options...] [--] <input files>
 
+Pass '-' as an input file to read source from standard input.
+-lang <language> is required when reading from stdin.
+
 # Read source from stdin (-lang is required)
 slangc -lang slang -target spirv -- -
 

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -284,7 +284,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -- -
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; [-lang](#lang) [&lt;language&gt;](#language) is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation ([-pass-through](#pass-through) glslang/dxc/fxc), [-stage](#stage-1) [&lt;stage&gt;](#stage) is required because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Stdin input is capped at 256 MiB. Example: slangc [-lang](#lang) slang [-target](#target-2) spirv-asm [-entry](#entry) main [--](#id) - 
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -6,6 +6,7 @@ slangc [options...] [--] <input files>
 
 Pass '-' as an input file to read source from standard input.
 -lang <language> is required when reading from stdin.
+For -lang glsl, -stage <stage> is also required.
 
 # Read source from stdin (-lang is required)
 slangc -lang slang -target spirv-asm -entry main -stage compute -- -

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -4,14 +4,6 @@
 ```
 slangc [options...] [--] <input files>
 
-Pass '-' as an input file to read source from standard input.
--lang <language> is required when reading from stdin.
-With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required.
-Stdin input is capped at 256 MiB.
-
-# Read source from stdin (-lang is required)
-slangc -lang slang -target spirv-asm -entry main -- -
-
 # For help
 slangc -h
 
@@ -285,7 +277,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; [-lang](#lang) [&lt;language&gt;](#language) is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation ([-pass-through](#pass-through) glslang/dxc/fxc), [-stage](#stage-1) [&lt;stage&gt;](#stage) is required because the shader stage cannot be inferred from a file extension; slangc emits a clean CLI diagnostic (error 35) when it is omitted. Stdin input is capped at 256 MiB. Example: slangc [-lang](#lang) slang [-target](#target-2) spirv-asm [-entry](#entry) main [--](#id) - 
+Treat the rest of the command line as input files; use '-' to read from standard input.
 
 
 <a id="report-downstream-time"></a>
@@ -1856,4 +1848,3 @@ Available help categories for the [-h](#h) option
 * `capability` : A capability describes an optional feature that a target may or may not support. When a [-capability](#capability-1) is specified, the compiler may assume that the target supports that capability, and generate code accordingly. 
 * `file-extension` : A [&lt;language&gt;](#language), &lt;format&gt;, and/or [&lt;stage&gt;](#stage) may be inferred from the extension of an input or [-o](#o) path 
 * `help-category` : Available help categories for the [-h](#h) option 
-

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -8,7 +8,7 @@ Pass '-' as an input file to read source from standard input.
 -lang <language> is required when reading from stdin.
 
 # Read source from stdin (-lang is required)
-slangc -lang slang -target spirv -- -
+slangc -lang slang -target spirv-asm -entry main -stage compute -- -
 
 # For help
 slangc -h
@@ -283,7 +283,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use `-` as a filename to read source from standard input; `-lang <language>` is required in that case because the source language cannot be deduced from a file extension. Example: `slangc -lang slang -target spirv -- -`
+Treat the rest of the command line as input files. Use `-` as a filename to read source from standard input; `-lang <language>` is required in that case because the source language cannot be deduced from a file extension. Example: `slangc -lang slang -target spirv-asm -entry main -stage compute -- -`
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -284,7 +284,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is required for pass-through compilation because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -- -
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required because the shader stage cannot be inferred from a file extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. Example: slangc -lang slang -target spirv-asm -entry main -- -
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -283,7 +283,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. Use `-` as a filename to read source from standard input; `-lang <language>` is required in that case because the source language cannot be deduced from a file extension. Example: `slangc -lang slang -target spirv-asm -entry main -stage compute -- -`
+Treat the rest of the command line as input files. Use '-' as a filename to read source from standard input; -lang <language> is required in that case because the source language cannot be deduced from a file extension. When -lang glsl is used with stdin, -stage <stage> is also required because the shader stage cannot be inferred from a file extension. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -
 
 
 <a id="report-downstream-time"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -4,6 +4,9 @@
 ```
 slangc [options...] [--] <input files>
 
+# Read source from stdin (-lang is required)
+slangc -lang slang -target spirv -- -
+
 # For help
 slangc -h
 
@@ -277,7 +280,7 @@ Dump to output list of warning diagnostic numeric and name ids.
 
 <a id="id"></a>
 ### --
-Treat the rest of the command line as input files. 
+Treat the rest of the command line as input files. Use `-` as a filename to read source from standard input; `-lang <language>` is required in that case because the source language cannot be deduced from a file extension. Example: `slangc -lang slang -target spirv -- -`
 
 
 <a id="report-downstream-time"></a>

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -157,7 +157,7 @@ err(
 
 err("cannot-deduce-source-language", 12, "can't deduce language for input file '~path'")
 
-err("empty-source-input", 170, "no source code found in '~path'")
+err("empty-source-input", 106, "no source code found in '~path'")
 
 err(
     "unknown-code-generation-target",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -161,6 +161,8 @@ err("empty-source-input", 106, "no source code found in '~path'")
 
 err("cannot-read-from-stdin", 107, "failed to read source from stdin")
 
+err("stdin-input-too-large", 108, "stdin input exceeds the maximum allowed size")
+
 err(
     "unknown-code-generation-target",
     13,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -159,6 +159,8 @@ err("cannot-deduce-source-language", 12, "can't deduce language for input file '
 
 err("empty-source-input", 106, "no source code found in '~path'")
 
+err("cannot-read-from-stdin", 107, "failed to read source from stdin")
+
 err(
     "unknown-code-generation-target",
     13,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -157,6 +157,8 @@ err(
 
 err("cannot-deduce-source-language", 12, "can't deduce language for input file '~path'")
 
+err("empty-source-input", 170, "no source code found in '~path'")
+
 err(
     "unknown-code-generation-target",
     13,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -157,11 +157,11 @@ err(
 
 err("cannot-deduce-source-language", 12, "can't deduce language for input file '~path'")
 
-err("empty-source-input", 106, "no source code found in '~path'")
+err("cannot-read-from-stdin", 106, "failed to read source from stdin")
 
-err("cannot-read-from-stdin", 107, "failed to read source from stdin")
+err("stdin-input-too-large", 107, "stdin input exceeds the maximum allowed size")
 
-err("stdin-input-too-large", 108, "stdin input exceeds the maximum allowed size")
+err("stdin-input-already-used", 108, "standard input can only be used once")
 
 err(
     "unknown-code-generation-target",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <limits>
+#include <sstream>
 
 namespace Slang
 {
@@ -1552,7 +1553,20 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
     // how we should handle it.
     String path = String(inPath);
 
-    if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))
+    if (strcmp(inPath, "-") == 0) {
+        std::ostringstream oss;
+        oss << std::cin.rdbuf();
+        std::string source = oss.str();
+
+        m_currentTranslationUnitIndex = addTranslationUnit(SlangSourceLanguage(langOverride), Stage::Unknown);
+        m_compileRequest->addTranslationUnitSourceString(
+            m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
+            "<stdin>",
+            source.c_str());
+
+        return SLANG_OK;
+    }
+    else if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))
     {
         return addReferencedModule(path, SourceLoc(), false);
     }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -16,10 +16,10 @@
 #include "../core/slang-char-util.h"
 #include "../core/slang-command-options-writer.h"
 #include "../core/slang-file-system.h"
-#include "../core/slang-process.h"
-#include "../core/slang-stream.h"
 #include "../core/slang-hex-dump-util.h"
 #include "../core/slang-name-value.h"
+#include "../core/slang-process.h"
+#include "../core/slang-stream.h"
 #include "../core/slang-string-slice-pool.h"
 #include "../core/slang-type-text-util.h"
 #include "slang-compiler-options.h"
@@ -1576,13 +1576,10 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             SLANG_SUCCEEDED(Process::getStdStream(StdStreamType::In, stdinStream)));
 
         List<Byte> bytes;
-        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)) ||
-            bytes.getCount() > kMaxIndex)
+        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
         {
             // The stream was opened but the read itself failed (e.g. the fd is
-            // write-only, EIO from a failing device, or a platform-level error),
-            // or the input exceeds the maximum representable source size (kMaxIndex),
-            // mirroring the guard in File::readAllBytes.
+            // write-only, EIO from a failing device, or a platform-level error).
             m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
             return SLANG_FAIL;
         }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -526,7 +526,10 @@ void initCommandOptions(CommandOptions& options)
          "Treat the rest of the command line as input files. "
          "Use '-' as a filename to read source from standard input; "
          "-lang <language> is required in that case because the source language cannot be "
-         "deduced from a file extension. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
+         "deduced from a file extension. "
+         "When -lang glsl is used with stdin, -stage <stage> is also required because "
+         "the shader stage cannot be inferred from a file extension. "
+         "Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1562,8 +1562,23 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         List<Byte> bytes;
         SLANG_RETURN_ON_FAIL(StreamUtil::readAll(stdinStream, bytes));
 
-        m_currentTranslationUnitIndex =
-            addTranslationUnit(SlangSourceLanguage(langOverride), Stage::Unknown);
+        SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
+        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
+        {
+            if (m_requestImpl->getLinkage()->m_optionSet.hasOption(CompilerOptionName::Language))
+                sourceLanguage =
+                    m_requestImpl->getLinkage()->m_optionSet.getEnumOption<SlangSourceLanguage>(
+                        CompilerOptionName::Language);
+        }
+        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
+        {
+            m_requestImpl->getSink()->diagnose(
+                Diagnostics::CannotDeduceSourceLanguage{.path = "<stdin>"});
+            return SLANG_FAIL;
+        }
+
+        m_translationUnitCount++;
+        m_currentTranslationUnitIndex = addTranslationUnit(sourceLanguage, Stage::Unknown);
         m_compileRequest->addTranslationUnitSourceStringSpan(
             m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
             "<stdin>",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1588,8 +1588,21 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             return SLANG_FAIL;
         }
 
-        m_translationUnitCount++;
-        m_currentTranslationUnitIndex = addTranslationUnit(sourceLanguage, Stage::Unknown);
+        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_SLANG)
+        {
+            if (m_slangTranslationUnitIndex == -1)
+            {
+                m_translationUnitCount++;
+                m_slangTranslationUnitIndex =
+                    addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG, Stage::Unknown);
+            }
+            m_currentTranslationUnitIndex = m_slangTranslationUnitIndex;
+        }
+        else
+        {
+            m_translationUnitCount++;
+            m_currentTranslationUnitIndex = addTranslationUnit(sourceLanguage, Stage::Unknown);
+        }
         m_compileRequest->addTranslationUnitSourceStringSpan(
             m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
             "<stdin>",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -532,7 +532,7 @@ void initCommandOptions(CommandOptions& options)
          "--",
          nullptr,
          "Treat the rest of the command line as input files; use '-' to read from standard "
-         "input."},
+         "input with -lang."},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -16,6 +16,8 @@
 #include "../core/slang-char-util.h"
 #include "../core/slang-command-options-writer.h"
 #include "../core/slang-file-system.h"
+#include "../core/slang-process.h"
+#include "../core/slang-stream.h"
 #include "../core/slang-hex-dump-util.h"
 #include "../core/slang-name-value.h"
 #include "../core/slang-string-slice-pool.h"
@@ -32,7 +34,6 @@
 
 #include <assert.h>
 #include <limits>
-#include <sstream>
 
 namespace Slang
 {
@@ -1553,16 +1554,21 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
     // how we should handle it.
     String path = String(inPath);
 
-    if (strcmp(inPath, "-") == 0) {
-        std::ostringstream oss;
-        oss << std::cin.rdbuf();
-        std::string source = oss.str();
+    if (strcmp(inPath, "-") == 0)
+    {
+        RefPtr<Stream> stdinStream;
+        SLANG_RETURN_ON_FAIL(Process::getStdStream(StdStreamType::In, stdinStream));
 
-        m_currentTranslationUnitIndex = addTranslationUnit(SlangSourceLanguage(langOverride), Stage::Unknown);
-        m_compileRequest->addTranslationUnitSourceString(
+        List<Byte> bytes;
+        SLANG_RETURN_ON_FAIL(StreamUtil::readAll(stdinStream, bytes));
+
+        m_currentTranslationUnitIndex =
+            addTranslationUnit(SlangSourceLanguage(langOverride), Stage::Unknown);
+        m_compileRequest->addTranslationUnitSourceStringSpan(
             m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
             "<stdin>",
-            source.c_str());
+            (const char*)bytes.getBuffer(),
+            (const char*)bytes.getBuffer() + bytes.getCount());
 
         return SLANG_OK;
     }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -40,9 +40,10 @@
 namespace Slang
 {
 
-// Single canonical description of the stdin feature for use in every user-facing surface
-// (_appendUsageTitle, _parseHelp, and the InputFilesRemain option description).
-// Having one definition prevents wording drift when the cap or pass-through list changes.
+// Quick-start summary of the stdin feature, shared between _appendUsageTitle and _parseHelp
+// so that the usage header and the generated markdown reference stay in sync.
+// The InputFilesRemain option description (in the options table below) is a separate,
+// more detailed prose block; keep both up-to-date when changing the cap or pass-through list.
 static const char* const kStdinUsagePreamble =
     "Pass '-' as an input file to read source from standard input.\n"
     "-lang <language> is required when reading from stdin.\n"
@@ -1588,8 +1589,19 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         // Switch stdin to binary mode on Windows so that \r\n is not silently collapsed to
         // \n and 0x1A (Ctrl-Z) is not treated as end-of-file.  File-based compilation uses
         // binary FileStream, so stdin must be consistent.
+        // The mode is restored before every return so this function does not permanently
+        // alter a host process that calls processCommandLineArguments with "-" as input.
 #ifdef _WIN32
-        _setmode(_fileno(stdin), _O_BINARY);
+        const int stdinPrevMode = _setmode(_fileno(stdin), _O_BINARY);
+        struct StdinModeGuard
+        {
+            int prev;
+            ~StdinModeGuard()
+            {
+                if (prev != -1)
+                    _setmode(_fileno(stdin), prev);
+            }
+        } stdinModeGuard{stdinPrevMode};
 #endif
 
         // Use fread rather than StreamUtil::readAll over a PipeStream.  PipeStream uses

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1576,11 +1576,13 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             SLANG_SUCCEEDED(Process::getStdStream(StdStreamType::In, stdinStream)));
 
         List<Byte> bytes;
-        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
+        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)) ||
+            bytes.getCount() > kMaxIndex)
         {
             // The stream was opened but the read itself failed (e.g. the fd is
-            // write-only, EIO from a failing device, or a platform-level error).
-            // CannotOpenFile would be misleading here — the fd was valid.
+            // write-only, EIO from a failing device, or a platform-level error),
+            // or the input exceeds the maximum representable source size (kMaxIndex),
+            // mirroring the guard in File::readAllBytes.
             m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
             return SLANG_FAIL;
         }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -18,8 +18,6 @@
 #include "../core/slang-file-system.h"
 #include "../core/slang-hex-dump-util.h"
 #include "../core/slang-name-value.h"
-#include "../core/slang-process.h"
-#include "../core/slang-stream.h"
 #include "../core/slang-string-slice-pool.h"
 #include "../core/slang-type-text-util.h"
 #include "slang-compiler-options.h"
@@ -1569,19 +1567,20 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         if (m_stdinConsumed)
             return SLANG_OK;
 
-        // Process::getStdStream for StdStreamType::In is unconditionally SLANG_OK on all
-        // implemented platforms; SLANG_RELEASE_ASSERT catches a future platform regression.
-        RefPtr<Stream> stdinStream;
-        SLANG_RELEASE_ASSERT(
-            SLANG_SUCCEEDED(Process::getStdStream(StdStreamType::In, stdinStream)));
-
+        // Use fread rather than StreamUtil::readAll over a PipeStream.  PipeStream uses
+        // poll(timeout=0), which busy-spins at 100% CPU while waiting for data.  fread
+        // is a standard blocking call that sleeps the thread until the producer writes.
         List<Byte> bytes;
-        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
         {
-            // The stream was opened but the read itself failed (e.g. the fd is
-            // write-only, EIO from a failing device, or a platform-level error).
-            m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
-            return SLANG_FAIL;
+            char buf[4096];
+            size_t n;
+            while ((n = fread(buf, 1, sizeof(buf), stdin)) > 0)
+                bytes.addRange(reinterpret_cast<const Byte*>(buf), Index(n));
+            if (ferror(stdin))
+            {
+                m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
+                return SLANG_FAIL;
+            }
         }
         if (bytes.getCount() == 0)
         {
@@ -1924,7 +1923,8 @@ void OptionsParser::_appendUsageTitle(StringBuilder& out)
 {
     out << "Usage: slangc [options...] [--] <input files>\n\n"
            "Pass '-' as an input file to read source from standard input.\n"
-           "-lang <language> is required when reading from stdin.\n\n";
+           "-lang <language> is required when reading from stdin.\n"
+           "For -lang glsl, -stage <stage> is also required.\n\n";
 }
 
 void OptionsParser::_outputMinimalUsage()
@@ -2286,7 +2286,8 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "```\n";
             buf << "slangc [options...] [--] <input files>\n\n"
                    "Pass '-' as an input file to read source from standard input.\n"
-                   "-lang <language> is required when reading from stdin.\n\n"
+                   "-lang <language> is required when reading from stdin.\n"
+                   "For -lang glsl, -stage <stage> is also required.\n\n"
                    "# Read source from stdin (-lang is required)\n"
                    "slangc -lang slang -target spirv-asm -entry main -stage compute -- -\n\n";
             buf << "# For help\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -540,7 +540,7 @@ void initCommandOptions(CommandOptions& options)
          "deduced from a file extension. "
          "When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), "
          "-stage <stage> is required because the shader stage cannot be inferred from a file "
-         "extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. "
+         "extension; slangc emits a clean CLI diagnostic (error 35) when it is omitted. "
          "Stdin input is capped at 256 MiB. "
          "Example: slangc -lang slang -target spirv-asm -entry main -- -"},
         {OptionKind::ReportDownstreamTime,

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -523,7 +523,10 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::InputFilesRemain,
          "--",
          nullptr,
-         "Treat the rest of the command line as input files."},
+         "Treat the rest of the command line as input files. "
+         "Use '-' as a filename to read source from standard input; "
+         "-lang <language> is required in that case because the source language cannot be "
+         "deduced from a file extension. Example: slangc -lang slang -target spirv -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,
@@ -1557,10 +1560,18 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
     if (strcmp(inPath, "-") == 0)
     {
         RefPtr<Stream> stdinStream;
-        SLANG_RETURN_ON_FAIL(Process::getStdStream(StdStreamType::In, stdinStream));
+        if (SLANG_FAILED(Process::getStdStream(StdStreamType::In, stdinStream)))
+        {
+            m_requestImpl->getSink()->diagnose(Diagnostics::CannotOpenFile{.path = "<stdin>"});
+            return SLANG_FAIL;
+        }
 
         List<Byte> bytes;
-        SLANG_RETURN_ON_FAIL(StreamUtil::readAll(stdinStream, bytes));
+        if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
+        {
+            m_requestImpl->getSink()->diagnose(Diagnostics::CannotOpenFile{.path = "<stdin>"});
+            return SLANG_FAIL;
+        }
 
         SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
         if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
@@ -1880,7 +1891,9 @@ SlangResult OptionsParser::_dumpDiagnostics(Severity originalSeverity)
 
 void OptionsParser::_appendUsageTitle(StringBuilder& out)
 {
-    out << "Usage: slangc [options...] [--] <input files>\n\n";
+    out << "Usage: slangc [options...] [--] <input files>\n\n"
+           "Pass '-' as an input file to read source from standard input.\n"
+           "-lang <language> is required when reading from stdin.\n\n";
 }
 
 void OptionsParser::_outputMinimalUsage()
@@ -2240,7 +2253,9 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "# Slang Command Line Options\n\n";
             buf << "*Usage:*\n";
             buf << "```\n";
-            buf << "slangc [options...] [--] <input files>\n\n";
+            buf << "slangc [options...] [--] <input files>\n\n"
+                   "Pass '-' as an input file to read source from standard input.\n"
+                   "-lang <language> is required when reading from stdin.\n\n";
             buf << "# For help\n";
             buf << "slangc -h\n\n";
             buf << "# To generate this file\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -527,8 +527,9 @@ void initCommandOptions(CommandOptions& options)
          "Use '-' as a filename to read source from standard input; "
          "-lang <language> is required in that case because the source language cannot be "
          "deduced from a file extension. "
-         "When -lang glsl is used with stdin, -stage <stage> is also required because "
-         "the shader stage cannot be inferred from a file extension. "
+         "When -lang glsl is used with stdin, -stage <stage> is required for pass-through "
+         "compilation because the shader stage cannot be inferred from a file extension; "
+         "omitting it may produce a downstream error rather than a clean CLI diagnostic. "
          "Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -532,6 +532,7 @@ void initCommandOptions(CommandOptions& options)
          "When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), "
          "-stage <stage> is required because the shader stage cannot be inferred from a file "
          "extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. "
+         "Stdin input is capped at 256 MiB. "
          "Example: slangc -lang slang -target spirv-asm -entry main -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
@@ -1586,8 +1587,9 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         // poll(timeout=0), which busy-spins at 100% CPU while waiting for data.  fread
         // is a standard blocking call that sleeps the thread until the producer writes.
         //
-        // The default cap is 256 MiB.  Tests may lower it via SLANG_TEST_MAX_STDIN_BYTES
-        // to trigger the StdinInputTooLarge diagnostic without allocating 256+ MiB.
+        // The default cap is 256 MiB.  Tests may lower it (never raise it) via
+        // SLANG_TEST_MAX_STDIN_BYTES to trigger the StdinInputTooLarge diagnostic
+        // without allocating 256+ MiB.  Values above the default are silently ignored.
         Index kMaxStdinBytes = Index(256) << 20; // 256 MiB
         if (const char* envCap = getenv("SLANG_TEST_MAX_STDIN_BYTES"))
         {
@@ -1595,7 +1597,7 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             char* end = nullptr;
             long long cap = strtoll(envCap, &end, 10);
             if (end != envCap && errno != ERANGE && cap > 0 &&
-                cap <= (long long)std::numeric_limits<Index>::max())
+                cap <= (long long)kMaxStdinBytes)
             {
                 kMaxStdinBytes = Index(cap);
             }
@@ -1606,7 +1608,7 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             size_t n;
             while ((n = fread(buf, 1, sizeof(buf), stdin)) > 0)
             {
-                if (bytes.getCount() + Index(n) > kMaxStdinBytes)
+                if (Index(n) > kMaxStdinBytes - bytes.getCount())
                 {
                     m_requestImpl->getSink()->diagnose(Diagnostics::StdinInputTooLarge{});
                     return SLANG_FAIL;

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1578,8 +1578,9 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         List<Byte> bytes;
         if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
         {
-            // The stream was opened but the read failed (e.g. a broken pipe or EIO).
-            // CannotOpenFile would be misleading here — the file descriptor was valid.
+            // The stream was opened but the read itself failed (e.g. the fd is
+            // write-only, EIO from a failing device, or a platform-level error).
+            // CannotOpenFile would be misleading here — the fd was valid.
             m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
             return SLANG_FAIL;
         }

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1568,17 +1568,18 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         if (m_stdinConsumed)
             return SLANG_OK;
 
+        // Process::getStdStream for StdStreamType::In is unconditionally SLANG_OK on all
+        // implemented platforms; SLANG_RELEASE_ASSERT catches a future platform regression.
         RefPtr<Stream> stdinStream;
-        if (SLANG_FAILED(Process::getStdStream(StdStreamType::In, stdinStream)))
-        {
-            m_requestImpl->getSink()->diagnose(Diagnostics::CannotOpenFile{.path = "<stdin>"});
-            return SLANG_FAIL;
-        }
+        SLANG_RELEASE_ASSERT(
+            SLANG_SUCCEEDED(Process::getStdStream(StdStreamType::In, stdinStream)));
 
         List<Byte> bytes;
         if (SLANG_FAILED(StreamUtil::readAll(stdinStream, bytes)))
         {
-            m_requestImpl->getSink()->diagnose(Diagnostics::CannotOpenFile{.path = "<stdin>"});
+            // The stream was opened but the read failed (e.g. a broken pipe or EIO).
+            // CannotOpenFile would be misleading here — the file descriptor was valid.
+            m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
             return SLANG_FAIL;
         }
         if (bytes.getCount() == 0)

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1392,6 +1392,7 @@ struct OptionsParser
     int m_translationUnitCount = 0;
     int m_currentTranslationUnitIndex = -1;
 
+    bool m_stdinConsumed = false;
     bool m_hasLoadedRepro = false;
     bool m_compileCoreModule = false;
     slang::CompileCoreModuleFlags m_compileCoreModuleFlags;
@@ -1559,6 +1560,11 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
 
     if (strcmp(inPath, "-") == 0)
     {
+        // Stdin can only be read once; a second '-' token is a no-op so the user
+        // does not get a confusing "no source code found" error on an already-drained pipe.
+        if (m_stdinConsumed)
+            return SLANG_OK;
+
         RefPtr<Stream> stdinStream;
         if (SLANG_FAILED(Process::getStdStream(StdStreamType::In, stdinStream)))
         {
@@ -1615,6 +1621,7 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             (const char*)bytes.getBuffer(),
             (const char*)bytes.getBuffer() + bytes.getCount());
 
+        m_stdinConsumed = true;
         return SLANG_OK;
     }
     else if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -526,7 +526,7 @@ void initCommandOptions(CommandOptions& options)
          "Treat the rest of the command line as input files. "
          "Use '-' as a filename to read source from standard input; "
          "-lang <language> is required in that case because the source language cannot be "
-         "deduced from a file extension. Example: slangc -lang slang -target spirv -- -"},
+         "deduced from a file extension. Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,
@@ -1572,6 +1572,12 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             m_requestImpl->getSink()->diagnose(Diagnostics::CannotOpenFile{.path = "<stdin>"});
             return SLANG_FAIL;
         }
+        if (bytes.getCount() == 0)
+        {
+            m_requestImpl->getSink()->diagnose(
+                Diagnostics::EmptySourceInput{.path = "<stdin>"});
+            return SLANG_FAIL;
+        }
 
         SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
         if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
@@ -2270,7 +2276,7 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
                    "Pass '-' as an input file to read source from standard input.\n"
                    "-lang <language> is required when reading from stdin.\n\n"
                    "# Read source from stdin (-lang is required)\n"
-                   "slangc -lang slang -target spirv -- -\n\n";
+                   "slangc -lang slang -target spirv-asm -entry main -stage compute -- -\n\n";
             buf << "# For help\n";
             buf << "slangc -h\n\n";
             buf << "# To generate this file\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -40,6 +40,15 @@
 namespace Slang
 {
 
+// Single canonical description of the stdin feature for use in every user-facing surface
+// (_appendUsageTitle, _parseHelp, and the InputFilesRemain option description).
+// Having one definition prevents wording drift when the cap or pass-through list changes.
+static const char* const kStdinUsagePreamble =
+    "Pass '-' as an input file to read source from standard input.\n"
+    "-lang <language> is required when reading from stdin.\n"
+    "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required.\n"
+    "Stdin input is capped at 256 MiB.\n";
+
 namespace
 { // anonymous
 
@@ -1596,7 +1605,11 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             errno = 0;
             char* end = nullptr;
             long long cap = strtoll(envCap, &end, 10);
-            if (end != envCap && errno != ERANGE && cap > 0 &&
+            // *end == '\0' rejects trailing junk (e.g. "100abc" → rejected).
+            // Raw stdlib is used here rather than PlatformUtil/stringToInt because
+            // PlatformUtil is not a dependency of this file and stringToInt returns
+            // int, which is too narrow for Index on 64-bit builds.
+            if (end != envCap && *end == '\0' && errno != ERANGE && cap > 0 &&
                 cap <= (long long)kMaxStdinBytes)
             {
                 kMaxStdinBytes = Index(cap);
@@ -1959,10 +1972,9 @@ SlangResult OptionsParser::_dumpDiagnostics(Severity originalSeverity)
 
 void OptionsParser::_appendUsageTitle(StringBuilder& out)
 {
-    out << "Usage: slangc [options...] [--] <input files>\n\n"
-           "Pass '-' as an input file to read source from standard input.\n"
-           "-lang <language> is required when reading from stdin.\n"
-           "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.\n\n";
+    out << "Usage: slangc [options...] [--] <input files>\n\n";
+    out << kStdinUsagePreamble;
+    out << "\n";
 }
 
 void OptionsParser::_outputMinimalUsage()
@@ -2322,10 +2334,9 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "# Slang Command Line Options\n\n";
             buf << "*Usage:*\n";
             buf << "```\n";
-            buf << "slangc [options...] [--] <input files>\n\n"
-                   "Pass '-' as an input file to read source from standard input.\n"
-                   "-lang <language> is required when reading from stdin.\n"
-                   "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.\n\n"
+            buf << "slangc [options...] [--] <input files>\n\n";
+            buf << kStdinUsagePreamble;
+            buf << "\n"
                    "# Read source from stdin (-lang is required)\n"
                    "slangc -lang slang -target spirv-asm -entry main -- -\n\n";
             buf << "# For help\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -528,7 +528,7 @@ void initCommandOptions(CommandOptions& options)
          "When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), "
          "-stage <stage> is required because the shader stage cannot be inferred from a file "
          "extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. "
-         "Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
+         "Example: slangc -lang slang -target spirv-asm -entry main -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,
@@ -1567,15 +1567,37 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         if (m_stdinConsumed)
             return SLANG_OK;
 
+        // Mark consumed immediately so that any early-return error path (read error, empty
+        // input, unknown language) does not trigger a second attempt on a drained pipe.
+        m_stdinConsumed = true;
+
         // Use fread rather than StreamUtil::readAll over a PipeStream.  PipeStream uses
         // poll(timeout=0), which busy-spins at 100% CPU while waiting for data.  fread
         // is a standard blocking call that sleeps the thread until the producer writes.
+        //
+        // The default cap is 256 MiB.  Tests may lower it via SLANG_TEST_MAX_STDIN_BYTES
+        // to trigger the StdinInputTooLarge diagnostic without allocating 256+ MiB.
+        Index kMaxStdinBytes = Index(256) << 20; // 256 MiB
+        if (const char* envCap = getenv("SLANG_TEST_MAX_STDIN_BYTES"))
+        {
+            char* end = nullptr;
+            long long cap = strtoll(envCap, &end, 10);
+            if (end != envCap && cap > 0)
+                kMaxStdinBytes = Index(cap);
+        }
         List<Byte> bytes;
         {
             char buf[4096];
             size_t n;
             while ((n = fread(buf, 1, sizeof(buf), stdin)) > 0)
+            {
+                if (bytes.getCount() + Index(n) > kMaxStdinBytes)
+                {
+                    m_requestImpl->getSink()->diagnose(Diagnostics::StdinInputTooLarge{});
+                    return SLANG_FAIL;
+                }
                 bytes.addRange(reinterpret_cast<const Byte*>(buf), Index(n));
+            }
             if (ferror(stdin))
             {
                 m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
@@ -1625,7 +1647,6 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
             (const char*)bytes.getBuffer(),
             (const char*)bytes.getBuffer() + bytes.getCount());
 
-        m_stdinConsumed = true;
         return SLANG_OK;
     }
     else if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))
@@ -2289,7 +2310,7 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
                    "-lang <language> is required when reading from stdin.\n"
                    "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.\n\n"
                    "# Read source from stdin (-lang is required)\n"
-                   "slangc -lang slang -target spirv-asm -entry main -stage compute -- -\n\n";
+                   "slangc -lang slang -target spirv-asm -entry main -- -\n\n";
             buf << "# For help\n";
             buf << "slangc -h\n\n";
             buf << "# To generate this file\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2268,7 +2268,9 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "```\n";
             buf << "slangc [options...] [--] <input files>\n\n"
                    "Pass '-' as an input file to read source from standard input.\n"
-                   "-lang <language> is required when reading from stdin.\n\n";
+                   "-lang <language> is required when reading from stdin.\n\n"
+                   "# Read source from stdin (-lang is required)\n"
+                   "slangc -lang slang -target spirv -- -\n\n";
             buf << "# For help\n";
             buf << "slangc -h\n\n";
             buf << "# To generate this file\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -525,9 +525,9 @@ void initCommandOptions(CommandOptions& options)
          "Use '-' as a filename to read source from standard input; "
          "-lang <language> is required in that case because the source language cannot be "
          "deduced from a file extension. "
-         "When -lang glsl is used with stdin, -stage <stage> is required for pass-through "
-         "compilation because the shader stage cannot be inferred from a file extension; "
-         "omitting it may produce a downstream error rather than a clean CLI diagnostic. "
+         "When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), "
+         "-stage <stage> is required because the shader stage cannot be inferred from a file "
+         "extension; omitting it may produce a downstream error rather than a clean CLI diagnostic. "
          "Example: slangc -lang slang -target spirv-asm -entry main -stage compute -- -"},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
@@ -1924,7 +1924,7 @@ void OptionsParser::_appendUsageTitle(StringBuilder& out)
     out << "Usage: slangc [options...] [--] <input files>\n\n"
            "Pass '-' as an input file to read source from standard input.\n"
            "-lang <language> is required when reading from stdin.\n"
-           "For -lang glsl, -stage <stage> is also required.\n\n";
+           "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.\n\n";
 }
 
 void OptionsParser::_outputMinimalUsage()
@@ -2287,7 +2287,7 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "slangc [options...] [--] <input files>\n\n"
                    "Pass '-' as an input file to read source from standard input.\n"
                    "-lang <language> is required when reading from stdin.\n"
-                   "For -lang glsl, -stage <stage> is also required.\n\n"
+                   "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is also required.\n\n"
                    "# Read source from stdin (-lang is required)\n"
                    "slangc -lang slang -target spirv-asm -entry main -stage compute -- -\n\n";
             buf << "# For help\n";

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -32,6 +32,10 @@
 
 #include <assert.h>
 #include <limits>
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
 
 namespace Slang
 {
@@ -1571,6 +1575,13 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         // input, unknown language) does not trigger a second attempt on a drained pipe.
         m_stdinConsumed = true;
 
+        // Switch stdin to binary mode on Windows so that \r\n is not silently collapsed to
+        // \n and 0x1A (Ctrl-Z) is not treated as end-of-file.  File-based compilation uses
+        // binary FileStream, so stdin must be consistent.
+#ifdef _WIN32
+        _setmode(_fileno(stdin), _O_BINARY);
+#endif
+
         // Use fread rather than StreamUtil::readAll over a PipeStream.  PipeStream uses
         // poll(timeout=0), which busy-spins at 100% CPU while waiting for data.  fread
         // is a standard blocking call that sleeps the thread until the producer writes.
@@ -1580,10 +1591,14 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
         Index kMaxStdinBytes = Index(256) << 20; // 256 MiB
         if (const char* envCap = getenv("SLANG_TEST_MAX_STDIN_BYTES"))
         {
+            errno = 0;
             char* end = nullptr;
             long long cap = strtoll(envCap, &end, 10);
-            if (end != envCap && cap > 0)
+            if (end != envCap && errno != ERANGE && cap > 0 &&
+                cap <= (long long)std::numeric_limits<Index>::max())
+            {
                 kMaxStdinBytes = Index(cap);
+            }
         }
         List<Byte> bytes;
         {

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -32,6 +32,8 @@
 
 #include <assert.h>
 #include <limits>
+#include <stdio.h>
+#include <string.h>
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
@@ -40,15 +42,9 @@
 namespace Slang
 {
 
-// Quick-start summary of the stdin feature, shared between _appendUsageTitle and _parseHelp
-// so that the usage header and the generated markdown reference stay in sync.
-// The InputFilesRemain option description (in the options table below) is a separate,
-// more detailed prose block; keep both up-to-date when changing the cap or pass-through list.
-static const char* const kStdinUsagePreamble =
-    "Pass '-' as an input file to read source from standard input.\n"
-    "-lang <language> is required when reading from stdin.\n"
-    "With pass-through compilation (-pass-through glslang/dxc/fxc), -stage <stage> is required.\n"
-    "Stdin input is capped at 256 MiB.\n";
+static const char* const kStdinDisplayPath = "<stdin>";
+static const char* const kStdinCommandLinePath = "-";
+static const Index kMaxStdinBytes = Index(256) << 20;
 
 namespace
 { // anonymous
@@ -535,15 +531,8 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::InputFilesRemain,
          "--",
          nullptr,
-         "Treat the rest of the command line as input files. "
-         "Use '-' as a filename to read source from standard input; "
-         "-lang <language> is required in that case because the source language cannot be "
-         "deduced from a file extension. "
-         "When stdin is used with pass-through compilation (-pass-through glslang/dxc/fxc), "
-         "-stage <stage> is required because the shader stage cannot be inferred from a file "
-         "extension; slangc emits a clean CLI diagnostic (error 35) when it is omitted. "
-         "Stdin input is capped at 256 MiB. "
-         "Example: slangc -lang slang -target spirv-asm -entry main -- -"},
+         "Treat the rest of the command line as input files; use '-' to read from standard "
+         "input."},
         {OptionKind::ReportDownstreamTime,
          "-report-downstream-time",
          nullptr,
@@ -1282,6 +1271,8 @@ struct OptionsParser
 
     static Profile::RawVal findGlslProfileFromPath(const String& path);
 
+    SlangResult addInputStdin(SlangSourceLanguage sourceLanguage);
+
     SlangResult addInputPath(
         char const* inPath,
         SourceLanguage langOverride = SourceLanguage::Unknown);
@@ -1376,6 +1367,7 @@ struct OptionsParser
     SlangResult _parseDebugInformation(const CommandLineArg& arg);
     SlangResult _parseProfile(const CommandLineArg& arg);
     SlangResult _parseHelp(const CommandLineArg& arg);
+    SlangResult _readStdin(List<Byte>& outSource);
 
     SlangSession* m_session = nullptr;
     SlangCompileRequest* m_compileRequest = nullptr;
@@ -1569,129 +1561,121 @@ SlangSourceLanguage findSourceLanguageFromPath(const String& path, Stage& outImp
     return SLANG_SOURCE_LANGUAGE_UNKNOWN;
 }
 
+SlangResult OptionsParser::_readStdin(List<Byte>& outSource)
+{
+    outSource.clear();
+
+#ifdef _WIN32
+    const int previousMode = _setmode(_fileno(stdin), _O_BINARY);
+    struct StdinModeGuard
+    {
+        int mode;
+        ~StdinModeGuard()
+        {
+            if (mode != -1)
+                _setmode(_fileno(stdin), mode);
+        }
+    } stdinModeGuard{previousMode};
+#endif
+
+    clearerr(stdin);
+
+    // Use blocking stdio here. The process PipeStream path is optimized for polling child
+    // process output and can spin while waiting for piped stdin.
+    char buffer[16 * 1024];
+    for (;;)
+    {
+        const size_t readByteCount = fread(buffer, 1, sizeof(buffer), stdin);
+        if (readByteCount != 0)
+        {
+            const Index readCount = Index(readByteCount);
+            if (readCount > kMaxStdinBytes - outSource.getCount())
+            {
+                m_sink->diagnose(Diagnostics::StdinInputTooLarge{});
+                return SLANG_FAIL;
+            }
+            outSource.addRange(reinterpret_cast<const Byte*>(buffer), readCount);
+            continue;
+        }
+
+        if (ferror(stdin))
+        {
+            m_sink->diagnose(Diagnostics::CannotReadFromStdin{});
+            return SLANG_FAIL;
+        }
+
+        return SLANG_OK;
+    }
+}
+
+SlangResult OptionsParser::addInputStdin(SlangSourceLanguage sourceLanguage)
+{
+    if (m_stdinConsumed)
+    {
+        m_sink->diagnose(Diagnostics::StdinInputAlreadyUsed{});
+        return SLANG_FAIL;
+    }
+
+    if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
+    {
+        m_sink->diagnose(Diagnostics::CannotDeduceSourceLanguage{.path = kStdinDisplayPath});
+        return SLANG_FAIL;
+    }
+
+    m_stdinConsumed = true;
+
+    List<Byte> source;
+    SLANG_RETURN_ON_FAIL(_readStdin(source));
+
+    if (sourceLanguage == SLANG_SOURCE_LANGUAGE_SLANG)
+    {
+        if (m_slangTranslationUnitIndex == -1)
+        {
+            m_translationUnitCount++;
+            m_slangTranslationUnitIndex =
+                addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG, Stage::Unknown);
+        }
+        m_currentTranslationUnitIndex = m_slangTranslationUnitIndex;
+    }
+    else
+    {
+        m_translationUnitCount++;
+        m_currentTranslationUnitIndex = addTranslationUnit(sourceLanguage, Stage::Unknown);
+    }
+
+    const char* sourceBegin =
+        source.getCount() != 0 ? reinterpret_cast<const char*>(source.getBuffer()) : "";
+    const char* sourceEnd = sourceBegin + source.getCount();
+    m_compileRequest->addTranslationUnitSourceStringSpan(
+        m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
+        kStdinDisplayPath,
+        sourceBegin,
+        sourceEnd);
+
+    return SLANG_OK;
+}
+
 SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langOverride)
 {
+    SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
+    if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
+    {
+        auto linkage = m_requestImpl->getLinkage();
+        if (linkage->m_optionSet.hasOption(CompilerOptionName::Language))
+        {
+            sourceLanguage = linkage->m_optionSet.getEnumOption<SlangSourceLanguage>(
+                CompilerOptionName::Language);
+        }
+    }
+
+    if (strcmp(inPath, kStdinCommandLinePath) == 0)
+        return addInputStdin(sourceLanguage);
+
     // look at the extension on the file name to determine
     // how we should handle it.
     String path = String(inPath);
 
-    if (strcmp(inPath, "-") == 0)
-    {
-        // Stdin can only be read once; a second '-' token is a no-op so the user
-        // does not get a confusing "no source code found" error on an already-drained pipe.
-        if (m_stdinConsumed)
-            return SLANG_OK;
-
-        // Mark consumed immediately so that any early-return error path (read error, empty
-        // input, unknown language) does not trigger a second attempt on a drained pipe.
-        m_stdinConsumed = true;
-
-        // Switch stdin to binary mode on Windows so that \r\n is not silently collapsed to
-        // \n and 0x1A (Ctrl-Z) is not treated as end-of-file.  File-based compilation uses
-        // binary FileStream, so stdin must be consistent.
-        // The mode is restored before every return so this function does not permanently
-        // alter a host process that calls processCommandLineArguments with "-" as input.
-#ifdef _WIN32
-        const int stdinPrevMode = _setmode(_fileno(stdin), _O_BINARY);
-        struct StdinModeGuard
-        {
-            int prev;
-            ~StdinModeGuard()
-            {
-                if (prev != -1)
-                    _setmode(_fileno(stdin), prev);
-            }
-        } stdinModeGuard{stdinPrevMode};
-#endif
-
-        // Use fread rather than StreamUtil::readAll over a PipeStream.  PipeStream uses
-        // poll(timeout=0), which busy-spins at 100% CPU while waiting for data.  fread
-        // is a standard blocking call that sleeps the thread until the producer writes.
-        //
-        // The default cap is 256 MiB.  Tests may lower it (never raise it) via
-        // SLANG_TEST_MAX_STDIN_BYTES to trigger the StdinInputTooLarge diagnostic
-        // without allocating 256+ MiB.  Values above the default are silently ignored.
-        Index kMaxStdinBytes = Index(256) << 20; // 256 MiB
-        if (const char* envCap = getenv("SLANG_TEST_MAX_STDIN_BYTES"))
-        {
-            errno = 0;
-            char* end = nullptr;
-            long long cap = strtoll(envCap, &end, 10);
-            // *end == '\0' rejects trailing junk (e.g. "100abc" → rejected).
-            // Raw stdlib is used here rather than PlatformUtil/stringToInt because
-            // PlatformUtil is not a dependency of this file and stringToInt returns
-            // int, which is too narrow for Index on 64-bit builds.
-            if (end != envCap && *end == '\0' && errno != ERANGE && cap > 0 &&
-                cap <= (long long)kMaxStdinBytes)
-            {
-                kMaxStdinBytes = Index(cap);
-            }
-        }
-        List<Byte> bytes;
-        {
-            char buf[4096];
-            size_t n;
-            while ((n = fread(buf, 1, sizeof(buf), stdin)) > 0)
-            {
-                if (Index(n) > kMaxStdinBytes - bytes.getCount())
-                {
-                    m_requestImpl->getSink()->diagnose(Diagnostics::StdinInputTooLarge{});
-                    return SLANG_FAIL;
-                }
-                bytes.addRange(reinterpret_cast<const Byte*>(buf), Index(n));
-            }
-            if (ferror(stdin))
-            {
-                m_requestImpl->getSink()->diagnose(Diagnostics::CannotReadFromStdin{});
-                return SLANG_FAIL;
-            }
-        }
-        if (bytes.getCount() == 0)
-        {
-            m_requestImpl->getSink()->diagnose(
-                Diagnostics::EmptySourceInput{.path = "<stdin>"});
-            return SLANG_FAIL;
-        }
-
-        SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
-        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
-        {
-            if (m_requestImpl->getLinkage()->m_optionSet.hasOption(CompilerOptionName::Language))
-                sourceLanguage =
-                    m_requestImpl->getLinkage()->m_optionSet.getEnumOption<SlangSourceLanguage>(
-                        CompilerOptionName::Language);
-        }
-        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
-        {
-            m_requestImpl->getSink()->diagnose(
-                Diagnostics::CannotDeduceSourceLanguage{.path = "<stdin>"});
-            return SLANG_FAIL;
-        }
-
-        if (sourceLanguage == SLANG_SOURCE_LANGUAGE_SLANG)
-        {
-            if (m_slangTranslationUnitIndex == -1)
-            {
-                m_translationUnitCount++;
-                m_slangTranslationUnitIndex =
-                    addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG, Stage::Unknown);
-            }
-            m_currentTranslationUnitIndex = m_slangTranslationUnitIndex;
-        }
-        else
-        {
-            m_translationUnitCount++;
-            m_currentTranslationUnitIndex = addTranslationUnit(sourceLanguage, Stage::Unknown);
-        }
-        m_compileRequest->addTranslationUnitSourceStringSpan(
-            m_rawTranslationUnits[m_currentTranslationUnitIndex].translationUnitID,
-            "<stdin>",
-            (const char*)bytes.getBuffer(),
-            (const char*)bytes.getBuffer() + bytes.getCount());
-
-        return SLANG_OK;
-    }
-    else if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))
+    if (path.endsWith(".slang-module") || path.endsWith(".slang-lib"))
     {
         return addReferencedModule(path, SourceLoc(), false);
     }
@@ -1705,15 +1689,9 @@ SlangResult OptionsParser::addInputPath(char const* inPath, SourceLanguage langO
     }
 
     Stage impliedStage = Stage::Unknown;
-    SlangSourceLanguage sourceLanguage = SlangSourceLanguage(langOverride);
     if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
     {
-        if (m_requestImpl->getLinkage()->m_optionSet.hasOption(CompilerOptionName::Language))
-            sourceLanguage = SlangSourceLanguage(
-                m_requestImpl->getLinkage()->m_optionSet.getEnumOption<SlangSourceLanguage>(
-                    CompilerOptionName::Language));
-        else
-            sourceLanguage = findSourceLanguageFromPath(path, impliedStage);
+        sourceLanguage = findSourceLanguageFromPath(path, impliedStage);
     }
     if (sourceLanguage == SLANG_SOURCE_LANGUAGE_UNKNOWN)
     {
@@ -1985,8 +1963,6 @@ SlangResult OptionsParser::_dumpDiagnostics(Severity originalSeverity)
 void OptionsParser::_appendUsageTitle(StringBuilder& out)
 {
     out << "Usage: slangc [options...] [--] <input files>\n\n";
-    out << kStdinUsagePreamble;
-    out << "\n";
 }
 
 void OptionsParser::_outputMinimalUsage()
@@ -2347,10 +2323,6 @@ SlangResult OptionsParser::_parseHelp(const CommandLineArg& arg)
             buf << "*Usage:*\n";
             buf << "```\n";
             buf << "slangc [options...] [--] <input files>\n\n";
-            buf << kStdinUsagePreamble;
-            buf << "\n"
-                   "# Read source from stdin (-lang is required)\n"
-                   "slangc -lang slang -target spirv-asm -entry main -- -\n\n";
             buf << "# For help\n";
             buf << "slangc -h\n\n";
             buf << "# To generate this file\n";

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -144,13 +144,13 @@ static SlangResult _testEmptyStdin(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
 
-    // Empty source with -entry main should emit the EntryPointFunctionNotFound diagnostic
-    // (error 3782: "no function found matching entry point name 'main'").
-    // Matching this specific phrase distinguishes a clean compiler error from a crash/assert.
+    // Empty stdin should emit the EmptySourceInput diagnostic (error 170:
+    // "no source code found in '<stdin>'") and fail, not silently create an
+    // empty translation unit or crash.
     if (result.resultCode == 0)
         return SLANG_FAIL;
     if (result.standardError.getUnownedSlice().indexOf(
-            toSlice("no function found matching entry point name 'main'")) < 0)
+            toSlice("no source code found in '<stdin>'")) < 0)
         return SLANG_FAIL;
     return SLANG_OK;
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -36,8 +36,9 @@ static SlangResult _spawnSlangcWithStdin(
     return SLANG_OK;
 }
 
-// Case 1: valid shader piped via stdin with -lang slang should succeed.
-static SlangResult _testStdinWithLang(UnitTestContext* context)
+// Case 1: valid Slang shader piped via stdin with -lang slang should succeed.
+// Exercises the m_slangTranslationUnitIndex (lazy-init) branch.
+static SlangResult _testStdinWithLangSlang(UnitTestContext* context)
 {
     List<String> args;
     args.add("-lang");
@@ -65,7 +66,37 @@ static SlangResult _testStdinWithLang(UnitTestContext* context)
     return SLANG_OK;
 }
 
-// Case 2: omitting -lang should produce a clean diagnostic, not a crash.
+// Case 2: valid HLSL shader piped via stdin with -lang hlsl should succeed.
+// Exercises the foreign-language else branch (addTranslationUnit with non-Slang language).
+static SlangResult _testStdinWithLangHlsl(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("hlsl");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    const char* source = "[numthreads(1,1,1)] void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Should compile successfully and produce SPIR-V assembly output.
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 3: omitting -lang should produce a clean diagnostic, not a crash.
 static SlangResult _testStdinWithoutLang(UnitTestContext* context)
 {
     List<String> args;
@@ -83,16 +114,19 @@ static SlangResult _testStdinWithoutLang(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
 
-    // Should fail with a diagnostic about unknown source language, not crash.
+    // Should fail with the CannotDeduceSourceLanguage diagnostic (error 12).
+    // Match the exact message text so a generic "<stdin>" mention from a different
+    // diagnostic does not mask a regression on this specific code path.
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>")) < 0)
+    if (result.standardError.getUnownedSlice().indexOf(
+            toSlice("can't deduce language for input file '<stdin>'")) < 0)
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 3: empty stdin should produce a diagnostic, not undefined behavior.
+// Case 4: empty stdin should fail cleanly with an explicit entry/stage.
 static SlangResult _testEmptyStdin(UnitTestContext* context)
 {
     List<String> args;
@@ -110,15 +144,55 @@ static SlangResult _testEmptyStdin(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
 
-    // Empty source with explicit entry/stage should fail cleanly.
+    // Empty source with -entry main should emit the EntryPointFunctionNotFound diagnostic
+    // (error 3782: "no function found matching entry point name 'main'").
+    // Matching this specific phrase distinguishes a clean compiler error from a crash/assert.
     if (result.resultCode == 0)
         return SLANG_FAIL;
+    if (result.standardError.getUnownedSlice().indexOf(
+            toSlice("no function found matching entry point name 'main'")) < 0)
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
+// Case 5: passing '-' twice consumes stdin on the first read; the second '-' sees EOF.
+// This pins the current behavior so any future change is intentional.
+static SlangResult _testStdinTwice(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+    args.add("-");
+
+    const char* source = "[shader(\"compute\")] void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Both '-' tokens go into the same Slang translation unit (m_slangTranslationUnitIndex
+    // reuse), so the second read appends nothing meaningful. Compilation should still
+    // succeed since the first read provided a valid entry point.
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
     return SLANG_OK;
 }
 
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLang(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangHlsl(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithoutLang(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testEmptyStdin(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTwice(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -883,6 +883,82 @@ static SlangResult _testStdinExactlyAtCap(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 14: source containing 0x1A (Ctrl-Z) mid-stream compiles correctly.
+// On Windows, text-mode stdin treats 0x1A as EOF, silently truncating the source.
+// _setmode(_fileno(stdin), _O_BINARY) prevents this; removing that call would
+// cause the entry point (which comes after the 0x1A byte) to be invisible to the
+// compiler, producing an "entry point not found" error and a non-zero exit code.
+static SlangResult _testStdinCtrlZNotTruncating(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // 0x1A sits inside a block comment — harmless to the Slang lexer in binary mode,
+    // but it would truncate the stream in Windows text mode, hiding the entry point.
+    const char* source =
+        "void foo() { /* \x1A */ }\n"
+        "[shader(\"compute\")] void main() { foo(); }\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 15: source larger than the 4096-byte fread buffer compiles correctly.
+// The read loop uses a 4096-byte stack buffer and iterates.  A regression that
+// replaces the while loop with a single-shot fread call would truncate the shader
+// at 4096 bytes.  The entry point calls tail_fn, which is declared well past the
+// 4096-byte boundary; a truncated read would produce an "undefined identifier" error.
+static SlangResult _testStdinMultipleFreads(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // Build ~8 KiB of valid Slang: 350 trivial helper functions (~24 bytes each = ~8.4 KiB)
+    // followed by tail_fn and the entry point.  tail_fn is declared well past byte 4096
+    // so a single-shot fread would never see it.
+    StringBuilder sb;
+    for (int i = 0; i < 350; i++)
+        sb << "void helper_" << i << "() {}\n";
+    sb << "void tail_fn() {}\n";
+    sb << "[shader(\"compute\")] void main() { tail_fn(); }\n";
+    const String source = sb.produceString();
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source.getBuffer(), result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -902,4 +978,6 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTooLarge(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinExactlyAtCap(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinCtrlZNotTruncating(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMultipleFreads(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -13,6 +13,9 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#elif SLANG_WINDOWS_FAMILY
+// For Case 11: CreateProcess with a write-only pipe handle as stdin.
+#include <windows.h>
 #endif
 
 using namespace Slang;
@@ -511,10 +514,118 @@ static SlangResult _testStdinReadError(UnitTestContext* context)
         return SLANG_FAIL;
 
     return SLANG_OK;
+#elif SLANG_WINDOWS_FAMILY
+    // Create an anonymous pipe and pass the write end as the child's stdin.
+    // WinPipeStream detects FILE_TYPE_PIPE and calls PeekNamedPipe; PeekNamedPipe
+    // fails on a write-only handle (ERROR_ACCESS_DENIED), which propagates through
+    // _updateState → StreamUtil::readAll as SLANG_FAIL → diagnostic 107.
+    SECURITY_ATTRIBUTES sa = {};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = TRUE;
+
+    HANDLE stdinRead = INVALID_HANDLE_VALUE;
+    HANDLE stdinWrite = INVALID_HANDLE_VALUE;
+    if (!CreatePipe(&stdinRead, &stdinWrite, &sa, 0))
+        return SLANG_FAIL;
+    CloseHandle(stdinRead); // only the write end is passed to the child
+
+    // Pipe to capture slangc's stderr.
+    HANDLE stderrRead = INVALID_HANDLE_VALUE;
+    HANDLE stderrWrite = INVALID_HANDLE_VALUE;
+    if (!CreatePipe(&stderrRead, &stderrWrite, &sa, 0))
+    {
+        CloseHandle(stdinWrite);
+        return SLANG_FAIL;
+    }
+    SetHandleInformation(stderrRead, HANDLE_FLAG_INHERIT, 0); // parent-only
+
+    HANDLE devNull =
+        CreateFileA("NUL", GENERIC_WRITE, FILE_SHARE_WRITE, &sa, OPEN_EXISTING, 0, nullptr);
+
+    const String slangcPath = String(context->executableDirectory) + "/slangc.exe";
+
+    // Build a mutable command-line buffer; CreateProcessA requires non-const lpCommandLine.
+    const String cmdStr = String("\"") + slangcPath +
+                          "\" -lang slang -target spirv-asm -entry main -stage compute -- -";
+    List<char> cmdBuf;
+    for (Index i = 0; i < cmdStr.getLength(); ++i)
+        cmdBuf.add(cmdStr[i]);
+    cmdBuf.add('\0');
+
+    STARTUPINFOA si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = stdinWrite; // write-only → PeekNamedPipe fails → diagnostic 107
+    si.hStdOutput = devNull != INVALID_HANDLE_VALUE ? devNull : GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError = stderrWrite;
+
+    PROCESS_INFORMATION pi = {};
+    const BOOL ok =
+        CreateProcessA(nullptr, cmdBuf.getBuffer(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si, &pi);
+
+    CloseHandle(stdinWrite);
+    CloseHandle(stderrWrite);
+    if (devNull != INVALID_HANDLE_VALUE)
+        CloseHandle(devNull);
+
+    if (!ok)
+    {
+        CloseHandle(stderrRead);
+        return SLANG_FAIL;
+    }
+
+    List<Byte> stderrBytes;
+    {
+        char buf[256];
+        DWORD bytesRead = 0;
+        while (ReadFile(stderrRead, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead > 0)
+            for (DWORD i = 0; i < bytesRead; ++i)
+                stderrBytes.add(Byte(buf[i]));
+    }
+    CloseHandle(stderrRead);
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exitCode = 0;
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+
+    if (exitCode == 0)
+        return SLANG_FAIL;
+
+    const UnownedStringSlice stderrSlice(
+        (const char*)stderrBytes.getBuffer(), size_t(stderrBytes.getCount()));
+    if (stderrSlice.indexOf(toSlice("failed to read source from stdin")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
 #else
     SLANG_UNUSED(context);
     return SLANG_OK;
 #endif
+}
+
+// Case 12: GLSL via stdin without -stage fails. The shader stage cannot be inferred
+// from a file extension when reading stdin, so pass-through GLSL compilation requires
+// an explicit -stage flag. This pins that omitting it does NOT silently succeed — a
+// future change that adds an implicit default stage would be caught here.
+static SlangResult _testStdinGlslWithoutStage(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("glsl");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("--");
+    args.add("-");
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "void main() {}\n", result));
+
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
 }
 
 SLANG_UNIT_TEST(SlangcReadFromStdin)
@@ -530,4 +641,5 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -1,30 +1,34 @@
 // unit-test-stdin-compile.cpp
-//
-// Tests that slangc can read shader source from stdin when '-' is passed as the input path.
 
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-process-util.h"
 #include "slang-com-ptr.h"
-#include "slang.h"
 #include "unit-test/slang-unit-test.h"
 
-#include <stdio.h>
 #include <string.h>
-
-#if SLANG_UNIX_FAMILY
-// For Case 11 (fork+exec) and Case 18 (dup/dup2 stdin redirect).
-#include <fcntl.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#elif SLANG_WINDOWS_FAMILY
-// For Case 11 (CreateProcess) and Case 18 (_dup/_dup2 stdin redirect).
-#include <io.h>
-#include <windows.h>
-#endif
 
 using namespace Slang;
 
-static SlangResult _spawnSlangcWithStdin(
+static bool _contains(const String& text, const char* expected)
+{
+    return text.getUnownedSlice().indexOf(UnownedStringSlice(expected)) >= 0;
+}
+
+static void _addStdinCompileArgs(List<String>& args, const char* language)
+{
+    args.add("-lang");
+    args.add(language);
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+}
+
+static SlangResult _runSlangcWithStdin(
     UnitTestContext* context,
     const List<String>& args,
     const char* stdinSource,
@@ -38,81 +42,57 @@ static SlangResult _spawnSlangcWithStdin(
     RefPtr<Process> process;
     SLANG_RETURN_ON_FAIL(Process::create(cmdLine, 0, process));
 
-    // Write source to slangc's stdin and close the stream so it sees EOF.
-    if (stdinSource && stdinSource[0] != '\0')
+    Stream* stdinStream = process->getStream(StdStreamType::In);
+    if (stdinSource)
     {
-        Stream* inStream = process->getStream(StdStreamType::In);
-        const Index len = Index(strlen(stdinSource));
-        SLANG_RETURN_ON_FAIL(inStream->write(stdinSource, len));
+        const Index length = Index(strlen(stdinSource));
+        if (length != 0)
+            SLANG_RETURN_ON_FAIL(stdinStream->write(stdinSource, length));
     }
-    process->getStream(StdStreamType::In)->close();
+    stdinStream->close();
 
-    SLANG_RETURN_ON_FAIL(ProcessUtil::readUntilTermination(process, outResult));
-    return SLANG_OK;
+    return ProcessUtil::readUntilTermination(process, outResult);
 }
 
-// Case 1: valid Slang shader piped via stdin with -lang slang should succeed.
-// Exercises the m_slangTranslationUnitIndex (lazy-init) branch.
-static SlangResult _testStdinWithLangSlang(UnitTestContext* context)
+static SlangResult _expectSlangcSuccess(
+    UnitTestContext* context,
+    const List<String>& args,
+    const char* stdinSource)
 {
-    List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    const char* source = "[shader(\"compute\")] void main() {}\n";
-
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(context, args, stdinSource, result));
 
-    // Should compile successfully and produce SPIR-V assembly output.
     if (result.resultCode != 0)
         return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+    if (!_contains(result.standardOutput, "OpEntryPoint"))
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 2: valid HLSL shader piped via stdin with -lang hlsl should succeed.
-// Exercises the foreign-language else branch (addTranslationUnit with non-Slang language).
-static SlangResult _testStdinWithLangHlsl(UnitTestContext* context)
+static SlangResult _testSlangStdin(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("hlsl");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
+    _addStdinCompileArgs(args, "slang");
 
-    const char* source = "[numthreads(1,1,1)] void main() {}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    // Should compile successfully and produce SPIR-V assembly output.
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
+    return _expectSlangcSuccess(
+        context,
+        args,
+        "[shader(\"compute\")] void main() {}\n");
 }
 
-// Case 3: omitting -lang should produce a clean diagnostic, not a crash.
-static SlangResult _testStdinWithoutLang(UnitTestContext* context)
+static SlangResult _testHlslStdin(UnitTestContext* context)
+{
+    List<String> args;
+    _addStdinCompileArgs(args, "hlsl");
+
+    return _expectSlangcSuccess(
+        context,
+        args,
+        "[numthreads(1, 1, 1)] void main() {}\n");
+}
+
+static SlangResult _testMissingLanguage(UnitTestContext* context)
 {
     List<String> args;
     args.add("-target");
@@ -124,745 +104,111 @@ static SlangResult _testStdinWithoutLang(UnitTestContext* context)
     args.add("--");
     args.add("-");
 
-    const char* source = "[shader(\"compute\")] void main() {}\n";
-
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(context, args, nullptr, result));
 
-    // Should fail with the CannotDeduceSourceLanguage diagnostic (error 12).
-    // Match the exact message text so a generic "<stdin>" mention from a different
-    // diagnostic does not mask a regression on this specific code path.
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (result.standardError.getUnownedSlice().indexOf(
-            toSlice("can't deduce language for input file '<stdin>'")) < 0)
+    if (!_contains(result.standardError, "can't deduce language for input file '<stdin>'"))
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 4: empty stdin should fail cleanly with an explicit entry/stage.
-static SlangResult _testEmptyStdin(UnitTestContext* context)
+static SlangResult _testDuplicateStdin(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
+    _addStdinCompileArgs(args, "slang");
     args.add("-");
 
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
+    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(
+        context,
+        args,
+        "[shader(\"compute\")] void main() {}\n",
+        result));
 
-    // Empty stdin should emit the EmptySourceInput diagnostic (error 106:
-    // "no source code found in '<stdin>'") and fail, not silently create an
-    // empty translation unit or crash.
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (result.standardError.getUnownedSlice().indexOf(
-            toSlice("no source code found in '<stdin>'")) < 0)
+    if (!_contains(result.standardError, "standard input can only be used once"))
         return SLANG_FAIL;
+
     return SLANG_OK;
 }
 
-// Case 5: passing '-' twice consumes stdin on the first read; the second '-' sees EOF.
-// This pins the current behavior so any future change is intentional.
-static SlangResult _testStdinTwice(UnitTestContext* context)
+static SlangResult _testDiagnosticLocation(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-    args.add("-");
-
-    const char* source = "[shader(\"compute\")] void main() {}\n";
+    _addStdinCompileArgs(args, "slang");
 
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    // The second '-' is a no-op (m_stdinConsumed guard short-circuits before re-reading
-    // the drained pipe). The source from the first '-' should compile to exactly one
-    // entry point — if the second '-' were incorrectly processed it could produce two.
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-
-    // Count OpEntryPoint occurrences to confirm only one entry point was compiled.
-    Index count = 0;
-    const UnownedStringSlice marker = toSlice("OpEntryPoint");
-    UnownedStringSlice remaining = result.standardOutput.getUnownedSlice();
-    while (true)
-    {
-        Index found = remaining.indexOf(marker);
-        if (found < 0)
-            break;
-        count++;
-        remaining = remaining.tail(found + marker.getLength());
-    }
-    if (count != 1)
-        return SLANG_FAIL;
-
-    // Silent no-op contract: the second '-' must produce no diagnostic.
-    // Any future change that emits a warning or error on the second '-' must
-    // update this test to reflect the new intentional behavior.
-    UnownedStringSlice err = result.standardError.getUnownedSlice();
-    if (err.indexOf(toSlice("no source code found")) >= 0)
-        return SLANG_FAIL;
-    if (err.indexOf(toSlice("can't deduce language")) >= 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 6: a deliberate syntax error in stdin source should produce a diagnostic that
-// includes both "<stdin>" as the path and a line number, confirming the SourceFile
-// path-info flows correctly through the diagnostic sink for tooling integrations.
-static SlangResult _testStdinDiagnosticLocation(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    // Line 1 is a valid declaration; line 2 references an undeclared identifier.
-    // This pins that the line number in the diagnostic refers to the stdin source.
-    const char* source =
+    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(
+        context,
+        args,
         "[shader(\"compute\")] void main() {\n"
-        "    undeclared_identifier;\n"
-        "}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+        "    undeclaredIdentifier;\n"
+        "}\n",
+        result));
 
     if (result.resultCode == 0)
         return SLANG_FAIL;
-
-    // Diagnostic format is: <stdin>(line): error N: message
-    // Assert the exact line number so a BOM or off-by-one regression in SourceLoc
-    // tracking surfaces here rather than silently passing.
-    // undeclared_identifier; is on line 2 of the stdin source.
-    UnownedStringSlice err = result.standardError.getUnownedSlice();
-    if (err.indexOf(toSlice("<stdin>(2):")) < 0)
+    if (!_contains(result.standardError, "<stdin>:2:"))
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 7a: stdin source with a UTF-8 BOM should compile correctly.
-// SourceFile does BOM detection; verify it works for the stdin blob path too.
-static SlangResult _testStdinWithBom(UnitTestContext* context)
+static SlangResult _testCrlfDiagnosticLocation(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    // UTF-8 BOM (\xEF\xBB\xBF) prepended to a valid shader.
-    const char* source = "\xEF\xBB\xBF[shader(\"compute\")] void main() {}\n";
+    _addStdinCompileArgs(args, "slang");
 
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 7b: BOM + deliberate error on line 2 should report <stdin>(2): so a
-// BOM-handling regression that treats the BOM as a newline would shift line
-// numbers and fail this assertion.
-static SlangResult _testStdinBomDiagnosticLocation(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    // BOM on byte 0, valid line 1, error on line 2.
-    const char* source =
-        "\xEF\xBB\xBF[shader(\"compute\")] void main() {\n"
-        "    undeclared_identifier;\n"
-        "}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode == 0)
-        return SLANG_FAIL;
-
-    // If the BOM were consumed as a newline, the error would appear on line 3.
-    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>(2):")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 7c: source with \r\n line endings should produce correct line numbers.
-// On Windows, stdin is opened in text mode by default; text mode converts \r\n to \n,
-// which is consistent and does NOT change line counts, but it is inconsistent with
-// file-based compilation (binary FileStream) and silently strips \r from diagnostics.
-// More critically, text mode treats 0x1A (Ctrl-Z) as EOF, silently truncating source.
-// The fix is _setmode(_fileno(stdin), _O_BINARY) before fread.
-// This test sends \r\n-terminated source with a deliberate error on line 2 and asserts
-// that <stdin>(2): appears — ensuring \r\n is not treated as two newlines (which would
-// report line 3 instead).
-static SlangResult _testStdinCrlfLineNumbers(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    // Line 1: valid.  Line 2: deliberate error.  All endings are \r\n.
-    const char* source =
+    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(
+        context,
+        args,
         "[shader(\"compute\")] void main() {\r\n"
-        "    undeclared_identifier;\r\n"
-        "}\r\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+        "    undeclaredIdentifier;\r\n"
+        "}\r\n",
+        result));
 
     if (result.resultCode == 0)
         return SLANG_FAIL;
-
-    // If \r\n were treated as two newlines the error would appear on line 3.
-    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>(2):")) < 0)
+    if (!_contains(result.standardError, "<stdin>:2:"))
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 8: GLSL shader piped via stdin with -lang glsl and -stage compute.
-// For GLSL the stage is normally inferred from the file extension (.comp, .vert, etc.);
-// stdin has no extension so -stage is always required. This pins that the path works
-// and that the documented requirement is enforced.
-static SlangResult _testStdinWithLangGlsl(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-lang");
-    args.add("glsl");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-
-    const char* source =
-        "#version 450\n"
-        "layout(local_size_x = 1) in;\n"
-        "void main() {}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 9: stdin combined with an on-disk .slang file.
-// Both inputs must have the .slang extension (or be recognised as Slang by extension) so
-// that addInputPath routes them through addInputSlangPath, which reuses
-// m_slangTranslationUnitIndex and places both sources into the same translation unit.
-// A future refactor that allocates a fresh TU for stdin would break cross-file visibility
-// and fail this test.
-static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
-{
-    // Generate a uniquely-named temp file in the OS temp directory so the test
-    // is safe in read-only cwds and parallel/re-run CI environments.
-    // We append ".slang" so the file is routed through addInputSlangPath, which is
-    // the path that sets/reuses m_slangTranslationUnitIndex.  Both the base path
-    // (created by generateTemporary) and the ".slang" path must be removed on exit.
-    String basePath;
-    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper"), basePath));
-    const String helperPath = basePath + ".slang";
-
-    // RAII guard: removes both the base inode (created by generateTemporary) and
-    // the ".slang" file written below on any return path, including early-out failures.
-    struct FileGuard
-    {
-        String base, slang;
-        ~FileGuard()
-        {
-            File::remove(base);
-            File::remove(slang);
-        }
-    } guard{basePath, helperPath};
-
-    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
-
-    List<String> args;
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add(helperPath);
-    args.add("--");
-    args.add("-");
-
-    // Entry point in stdin calls foo() defined in the on-disk file.
-    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 10a: stdin first, file second — reverse of Case 9.
-// -- - <file.slang>: stdin is processed first (initialising m_slangTranslationUnitIndex),
-// then the .slang file is processed and reuses the same translation unit.
-// The entry point is in stdin and calls a function defined in the on-disk file,
-// so cross-file visibility must hold regardless of argument order.
-static SlangResult _testStdinThenFile(UnitTestContext* context)
+struct TempSlangFile
 {
     String basePath;
-    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper2"), basePath));
-    const String helperPath = basePath + ".slang";
+    String slangPath;
 
-    struct FileGuard
+    ~TempSlangFile()
     {
-        String base, slang;
-        ~FileGuard()
-        {
-            File::remove(base);
-            File::remove(slang);
-        }
-    } guard{basePath, helperPath};
-
-    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
-
-    List<String> args;
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
-    args.add(helperPath);
-
-    // Entry point in stdin calls foo() defined in the on-disk file.
-    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 10b: file sandwiched between two '-' tokens — -- <file.slang> - -.
-// The file defines foo(); the first '-' reads stdin (entry point calling foo());
-// the second '-' hits m_stdinConsumed and is a no-op.
-// Verifies that the m_stdinConsumed guard interacts correctly with a file argument
-// between the two '-' tokens and that the single TU is used throughout.
-static SlangResult _testFileBetweenStdins(UnitTestContext* context)
-{
-    String basePath;
-    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper3"), basePath));
-    const String helperPath = basePath + ".slang";
-
-    struct FileGuard
-    {
-        String base, slang;
-        ~FileGuard()
-        {
-            File::remove(base);
-            File::remove(slang);
-        }
-    } guard{basePath, helperPath};
-
-    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
-
-    List<String> args;
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add(helperPath);
-    args.add("-");
-    args.add("-");
-
-    // Entry point in stdin calls foo() from the file; second '-' is a no-op.
-    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 11: pass a write-only fd/handle as slangc's stdin to trigger diagnostic 107.
-// The stdin read in addInputPath uses fread/ferror directly (not PipeStream/readAll).
-// POSIX: fread on an O_WRONLY fd calls read(2), which returns EBADF; fread returns 0
-//        and sets ferror(stdin), satisfying the if (ferror(stdin)) guard → diagnostic 107.
-// Windows: fread on a write-only pipe handle goes through the CRT, which calls ReadFile;
-//          ReadFile fails on a write-only handle, the CRT sets ferror(stdin) → diagnostic 107.
-static SlangResult _testStdinReadError(UnitTestContext* context)
-{
-#if SLANG_UNIX_FAMILY
-    // Create a temp file, close it, and reopen it write-only.
-    char tmpPath[] = "/tmp/slangc-stdin-err-XXXXXX";
-    const int tmpRW = mkstemp(tmpPath);
-    if (tmpRW < 0)
-        return SLANG_FAIL;
-    close(tmpRW);
-
-    const int wfd = ::open(tmpPath, O_WRONLY);
-    ::unlink(tmpPath); // delete the path; wfd keeps the inode alive until closed
-    if (wfd < 0)
-        return SLANG_FAIL;
-
-    // Pipe to capture slangc's stderr so we can inspect the diagnostic text.
-    int stderrPipe[2];
-    if (::pipe(stderrPipe) != 0)
-    {
-        ::close(wfd);
-        return SLANG_FAIL;
-    }
-
-    const String slangcPath = String(context->executableDirectory) + "/slangc";
-
-    const pid_t pid = ::fork();
-    if (pid < 0)
-    {
-        ::close(wfd);
-        ::close(stderrPipe[0]);
-        ::close(stderrPipe[1]);
-        return SLANG_FAIL;
-    }
-
-    if (pid == 0)
-    {
-        // Child: wire fds, then exec slangc.
-        // fd 0 (stdin) = write-only file fd → read(0,...) returns EBADF → diagnostic 107.
-        ::dup2(wfd, STDIN_FILENO);
-        ::dup2(stderrPipe[1], STDERR_FILENO);
-        const int devNull = ::open("/dev/null", O_WRONLY);
-        if (devNull >= 0)
-        {
-            ::dup2(devNull, STDOUT_FILENO);
-            ::close(devNull);
-        }
-        ::close(wfd);
-        ::close(stderrPipe[0]);
-        ::close(stderrPipe[1]);
-
-        ::execl(
-            slangcPath.getBuffer(),
-            slangcPath.getBuffer(),
-            "-lang",
-            "slang",
-            "-target",
-            "spirv-asm",
-            "-entry",
-            "main",
-            "-stage",
-            "compute",
-            "--",
-            "-",
-            (char*)nullptr);
-        ::_exit(127); // execl failed
-    }
-
-    // Parent: close the fds the child inherited.
-    ::close(wfd);
-    ::close(stderrPipe[1]);
-
-    // Drain slangc's stderr.
-    List<Byte> stderrBytes;
-    {
-        char buf[256];
-        ssize_t n;
-        while ((n = ::read(stderrPipe[0], buf, sizeof(buf))) > 0)
-            for (ssize_t i = 0; i < n; ++i)
-                stderrBytes.add(Byte(buf[i]));
-    }
-    ::close(stderrPipe[0]);
-
-    int status = 0;
-    ::waitpid(pid, &status, 0);
-    const int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-
-    if (exitCode == 0)
-        return SLANG_FAIL;
-
-    const UnownedStringSlice stderrSlice(
-        (const char*)stderrBytes.getBuffer(), size_t(stderrBytes.getCount()));
-    if (stderrSlice.indexOf(toSlice("failed to read source from stdin")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-#elif SLANG_WINDOWS_FAMILY
-    // Create an anonymous pipe and pass the write end as the child's stdin.
-    // fread in slangc calls ReadFile via the CRT; ReadFile fails on a write-only
-    // pipe handle, the CRT sets the stdio error indicator, and ferror(stdin)
-    // fires in addInputPath → diagnostic 107.
-    SECURITY_ATTRIBUTES sa = {};
-    sa.nLength = sizeof(sa);
-    sa.bInheritHandle = TRUE;
-
-    HANDLE stdinRead = INVALID_HANDLE_VALUE;
-    HANDLE stdinWrite = INVALID_HANDLE_VALUE;
-    if (!CreatePipe(&stdinRead, &stdinWrite, &sa, 0))
-        return SLANG_FAIL;
-    CloseHandle(stdinRead); // only the write end is passed to the child
-
-    // Pipe to capture slangc's stderr.
-    HANDLE stderrRead = INVALID_HANDLE_VALUE;
-    HANDLE stderrWrite = INVALID_HANDLE_VALUE;
-    if (!CreatePipe(&stderrRead, &stderrWrite, &sa, 0))
-    {
-        CloseHandle(stdinWrite);
-        return SLANG_FAIL;
-    }
-    SetHandleInformation(stderrRead, HANDLE_FLAG_INHERIT, 0); // parent-only
-
-    HANDLE devNull =
-        CreateFileA("NUL", GENERIC_WRITE, FILE_SHARE_WRITE, &sa, OPEN_EXISTING, 0, nullptr);
-
-    const String slangcPath = String(context->executableDirectory) + "/slangc.exe";
-
-    // Build a mutable command-line buffer; CreateProcessA requires non-const lpCommandLine.
-    const String cmdStr = String("\"") + slangcPath +
-                          "\" -lang slang -target spirv-asm -entry main -stage compute -- -";
-    List<char> cmdBuf;
-    for (Index i = 0; i < cmdStr.getLength(); ++i)
-        cmdBuf.add(cmdStr[i]);
-    cmdBuf.add('\0');
-
-    STARTUPINFOA si = {};
-    si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESTDHANDLES;
-    si.hStdInput = stdinWrite; // write-only → PeekNamedPipe fails → diagnostic 107
-    si.hStdOutput = devNull != INVALID_HANDLE_VALUE ? devNull : GetStdHandle(STD_OUTPUT_HANDLE);
-    si.hStdError = stderrWrite;
-
-    PROCESS_INFORMATION pi = {};
-    const BOOL ok =
-        CreateProcessA(nullptr, cmdBuf.getBuffer(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si, &pi);
-
-    CloseHandle(stdinWrite);
-    CloseHandle(stderrWrite);
-    if (devNull != INVALID_HANDLE_VALUE)
-        CloseHandle(devNull);
-
-    if (!ok)
-    {
-        CloseHandle(stderrRead);
-        return SLANG_FAIL;
-    }
-
-    List<Byte> stderrBytes;
-    {
-        char buf[256];
-        DWORD bytesRead = 0;
-        while (ReadFile(stderrRead, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead > 0)
-            for (DWORD i = 0; i < bytesRead; ++i)
-                stderrBytes.add(Byte(buf[i]));
-    }
-    CloseHandle(stderrRead);
-
-    WaitForSingleObject(pi.hProcess, INFINITE);
-    DWORD exitCode = 0;
-    GetExitCodeProcess(pi.hProcess, &exitCode);
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-
-    if (exitCode == 0)
-        return SLANG_FAIL;
-
-    const UnownedStringSlice stderrSlice(
-        (const char*)stderrBytes.getBuffer(), size_t(stderrBytes.getCount()));
-    if (stderrSlice.indexOf(toSlice("failed to read source from stdin")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-#else
-    SLANG_UNUSED(context);
-    return SLANG_OK;
-#endif
-}
-
-// Case 12: GLSL via stdin without -stage fails. The shader stage cannot be inferred
-// from a file extension when reading stdin, so pass-through GLSL compilation requires
-// an explicit -stage flag. This pins that omitting it does NOT silently succeed — a
-// future change that adds an implicit default stage would be caught here.
-static SlangResult _testStdinGlslWithoutStage(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-lang");
-    args.add("glsl");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("--");
-    args.add("-");
-
-    // Use the same source that Case 8 proves compiles when -stage compute is given.
-    // This ensures the failure here is due to the missing stage, not invalid source.
-    const char* source =
-        "#version 450\n"
-        "layout(local_size_x = 1) in;\n"
-        "void main() {}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode == 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Helper: set an environment variable for the duration of a scope, then restore it.
-struct ScopedEnvVar
-{
-    const char* key;
-    bool hadOld;
-    String oldVal;
-
-    ScopedEnvVar(const char* k, const char* v) : key(k), hadOld(false)
-    {
-        if (const char* cur = getenv(k))
-        {
-            hadOld = true;
-            oldVal = cur;
-        }
-#ifdef _WIN32
-        String s = String(k) + "=" + v;
-        _putenv(s.getBuffer());
-#else
-        setenv(k, v, 1);
-#endif
-    }
-    ~ScopedEnvVar()
-    {
-#ifdef _WIN32
-        String s = String(key) + "=" + (hadOld ? oldVal.getBuffer() : "");
-        _putenv(s.getBuffer());
-#else
-        if (hadOld)
-            setenv(key, oldVal.getBuffer(), 1);
-        else
-            unsetenv(key);
-#endif
+        File::remove(basePath);
+        File::remove(slangPath);
     }
 };
 
-// Case 13: stdin input exceeds the cap → StdinInputTooLarge diagnostic (error 108).
-// The production cap is 256 MiB; we lower it to 10 bytes via SLANG_TEST_MAX_STDIN_BYTES
-// so the test can trigger the diagnostic without allocating hundreds of megabytes.
-static SlangResult _testStdinTooLarge(UnitTestContext* context)
+static SlangResult _createTempSlangFile(
+    const char* prefix,
+    const char* contents,
+    TempSlangFile& out)
 {
-    ScopedEnvVar capEnv("SLANG_TEST_MAX_STDIN_BYTES", "10");
-
-    List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("--");
-    args.add("-");
-
-    // 11 bytes — one more than the cap set above.
-    const char* source = "12345678901";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    // Must fail with a non-zero exit code.
-    if (result.resultCode == 0)
-        return SLANG_FAIL;
-
-    // The StdinInputTooLarge message must appear in the output.
-    if (result.standardError.getUnownedSlice().indexOf(
-            toSlice("stdin input exceeds the maximum allowed size")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(UnownedStringSlice(prefix), out.basePath));
+    out.slangPath = out.basePath + ".slang";
+    return File::writeAllText(out.slangPath, contents);
 }
 
-// Case 13b: exactly at the cap should succeed; this pins the check as > not >=.
-// A regression that changes > to >= would reject input of exactly kMaxStdinBytes bytes,
-// and this test would fail.
-static SlangResult _testStdinExactlyAtCap(UnitTestContext* context)
+static SlangResult _testStdinAndFileShareSlangTranslationUnit(
+    UnitTestContext* context,
+    bool stdinFirst)
 {
-    const char* source = "[shader(\"compute\")] void main() {}\n";
-    const Index sourceLen = Index(strlen(source));
-
-    // Set the cap to exactly the source length so the check sits on the boundary.
-    char capStr[32];
-    snprintf(capStr, sizeof(capStr), "%lld", (long long)sourceLen);
-    ScopedEnvVar capEnv("SLANG_TEST_MAX_STDIN_BYTES", capStr);
+    TempSlangFile helper;
+    SLANG_RETURN_ON_FAIL(
+        _createTempSlangFile("slangc-stdin-helper", "void helper() {}\n", helper));
 
     List<String> args;
     args.add("-lang");
@@ -874,134 +220,51 @@ static SlangResult _testStdinExactlyAtCap(UnitTestContext* context)
     args.add("-stage");
     args.add("compute");
     args.add("--");
-    args.add("-");
+    if (stdinFirst)
+    {
+        args.add("-");
+        args.add(helper.slangPath);
+    }
+    else
+    {
+        args.add(helper.slangPath);
+        args.add("-");
+    }
 
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
+    return _expectSlangcSuccess(
+        context,
+        args,
+        "[shader(\"compute\")] void main() { helper(); }\n");
 }
 
-// Case 14: source containing 0x1A (Ctrl-Z) mid-stream compiles correctly.
-// On Windows, text-mode stdin treats 0x1A as EOF, silently truncating the source.
-// _setmode(_fileno(stdin), _O_BINARY) prevents this; removing that call would
-// cause the entry point (which comes after the 0x1A byte) to be invisible to the
-// compiler, producing an "entry point not found" error and a non-zero exit code.
-static SlangResult _testStdinCtrlZNotTruncating(UnitTestContext* context)
+static SlangResult _testCtrlZIsNotEndOfFile(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
+    _addStdinCompileArgs(args, "slang");
 
-    // 0x1A sits inside a block comment — harmless to the Slang lexer in binary mode,
-    // but it would truncate the stream in Windows text mode, hiding the entry point.
-    const char* source =
-        "void foo() { /* \x1A */ }\n"
-        "[shader(\"compute\")] void main() { foo(); }\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
+    return _expectSlangcSuccess(
+        context,
+        args,
+        "void helper() { /* \x1A */ }\n"
+        "[shader(\"compute\")] void main() { helper(); }\n");
 }
 
-// Case 15: source larger than the 4096-byte fread buffer compiles correctly.
-// The read loop uses a 4096-byte stack buffer and iterates.  A regression that
-// replaces the while loop with a single-shot fread call would truncate the shader
-// at 4096 bytes.  The entry point calls tail_fn, which is declared well past the
-// 4096-byte boundary; a truncated read would produce an "undefined identifier" error.
-static SlangResult _testStdinMultipleFreads(UnitTestContext* context)
+static SlangResult _testInputLargerThanReadBuffer(UnitTestContext* context)
 {
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
-    args.add("-target");
-    args.add("spirv-asm");
-    args.add("-entry");
-    args.add("main");
-    args.add("-stage");
-    args.add("compute");
-    args.add("--");
-    args.add("-");
+    _addStdinCompileArgs(args, "slang");
 
-    // Build ~8 KiB of valid Slang: 350 trivial helper functions (~24 bytes each = ~8.4 KiB)
-    // followed by tail_fn and the entry point.  tail_fn is declared well past byte 4096
-    // so a single-shot fread would never see it.
-    StringBuilder sb;
-    for (int i = 0; i < 350; i++)
-        sb << "void helper_" << i << "() {}\n";
-    sb << "void tail_fn() {}\n";
-    sb << "[shader(\"compute\")] void main() { tail_fn(); }\n";
-    const String source = sb.produceString();
+    StringBuilder source;
+    for (int i = 0; i < 900; ++i)
+        source << "void helper" << i << "() {}\n";
+    source << "void tail() {}\n";
+    source << "[shader(\"compute\")] void main() { tail(); }\n";
 
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source.getBuffer(), result));
-
-    if (result.resultCode != 0)
-        return SLANG_FAIL;
-    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
+    const String sourceString = source.produceString();
+    return _expectSlangcSuccess(context, args, sourceString.getBuffer());
 }
 
-// Case 16: stdin + -pass-through dxc without -stage emits NoStageSpecifiedInPassThroughMode
-// (error 35) from slangc itself — not from dxc.  The check at _passThroughRequiresStage in
-// slang-options.cpp fires before any downstream compiler is invoked, so this test works even
-// when dxc is not installed.  It also serves as the regression test for the doc claim in the
-// -- option description: "slangc emits a clean CLI diagnostic (error 35) when it is omitted."
-static SlangResult _testStdinPassThroughMissingStage(UnitTestContext* context)
-{
-    List<String> args;
-    args.add("-pass-through");
-    args.add("dxc");
-    args.add("-entry");
-    args.add("main");
-    // Deliberately no -stage.
-    args.add("--");
-    args.add("-");
-
-    const char* source = "void main() {}\n";
-
-    ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
-
-    // Must fail — slangc catches the missing stage with a clean diagnostic.
-    if (result.resultCode == 0)
-        return SLANG_FAIL;
-
-    // Verify the specific diagnostic text (error 35: no-stage-specified-in-pass-through-mode).
-    if (result.standardError.getUnownedSlice().indexOf(
-            toSlice("no stage was specified for entry point")) < 0)
-        return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 17: slangc -h output contains the stdin usage preamble.
-// kStdinUsagePreamble is injected into _appendUsageTitle and _parseHelp; a regression
-// that drops one of those calls compiles cleanly but silently removes the help text.
-// This test runs slangc -h and asserts the first sentence of the preamble is present
-// on stdout, covering the _appendUsageTitle path.
-static SlangResult _testHelpContainsStdinPreamble(UnitTestContext* context)
+static SlangResult _testHelpMentionsStdin(UnitTestContext* context)
 {
     CommandLine cmdLine;
     cmdLine.setExecutableLocation(ExecutableLocation(context->executableDirectory, "slangc"));
@@ -1010,120 +273,9 @@ static SlangResult _testHelpContainsStdinPreamble(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(ProcessUtil::execute(cmdLine, result));
 
-    if (result.standardOutput.getUnownedSlice().indexOf(
-            toSlice("Pass '-' as an input file to read source from standard input.")) < 0)
+    if (result.resultCode != 0)
         return SLANG_FAIL;
-
-    return SLANG_OK;
-}
-
-// Case 18: session-level Language fallback in addInputPath.
-// When -lang <lang> appears before -- in argv, two things happen at option-parse time:
-//   (a) the per-file langOverride is NOT passed to addInputPath for - (which comes after --,
-//       processed by InputFilesRemain with langOverride=UNKNOWN), and
-//   (b) the session-level CompilerOptionName::Language is set on the linkage's OptionSet.
-// addInputPath("-", UNKNOWN) therefore falls through to the session-level branch to deduce
-// the language.  This test makes that path explicit: it calls processCommandLineArguments
-// twice on the same request — first with "-lang slang" only (sets session Language, reads
-// no files) and then with "-- -" only (addInputPath receives langOverride=UNKNOWN, must
-// use the session-level Language).  A regression that flips to a different OptionSet in
-// the fallback check would compile clean and pass every subprocess test while silently
-// producing cannot-deduce-source-language for embedders using this call pattern.
-//
-// Stdin is redirected from a temp file for the second call so the unit-test process does
-// not stall waiting for interactive input.
-static SlangResult _testSessionLanguageFallback(UnitTestContext* context)
-{
-    // Write valid Slang source to a temp file that will be used as stdin.
-    const char* source = "[shader(\"compute\")] void main() {}\n";
-    String tempBase;
-    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-lang-test"), tempBase));
-    struct TempGuard
-    {
-        String path;
-        ~TempGuard() { File::remove(path); }
-    } guard{tempBase};
-    SLANG_RETURN_ON_FAIL(File::writeAllText(tempBase, source));
-
-    // Redirect the C runtime's stdin to the temp file.  fread inside addInputPath reads
-    // directly from the C FILE* stdin so this is the only way to inject source without
-    // spawning a subprocess.  We use dup2/fileno to redirect the underlying file descriptor,
-    // then restore it to a null device before returning.
-#ifdef _WIN32
-    FILE* srcFile = fopen(tempBase.getBuffer(), "rb");
-    if (!srcFile)
-        return SLANG_FAIL;
-    const int savedStdinFd = _dup(_fileno(stdin));
-    _dup2(_fileno(srcFile), _fileno(stdin));
-    fclose(srcFile);
-    struct StdinRestoreGuard
-    {
-        int saved;
-        ~StdinRestoreGuard()
-        {
-            if (saved >= 0)
-            {
-                _dup2(saved, _fileno(stdin));
-                _close(saved);
-            }
-        }
-    } stdinRestoreGuard{savedStdinFd};
-#else
-    FILE* srcFile = fopen(tempBase.getBuffer(), "rb");
-    if (!srcFile)
-        return SLANG_FAIL;
-    const int savedStdinFd = dup(fileno(stdin));
-    dup2(fileno(srcFile), fileno(stdin));
-    fclose(srcFile);
-    struct StdinRestoreGuard
-    {
-        int saved;
-        ~StdinRestoreGuard()
-        {
-            if (saved >= 0)
-            {
-                dup2(saved, fileno(stdin));
-                close(saved);
-            }
-        }
-    } stdinRestoreGuard{savedStdinFd};
-#endif
-
-    // Create a session and compile request.
-    SlangSession* session = spCreateSession();
-    if (!session)
-        return SLANG_FAIL;
-    struct SessionGuard
-    {
-        SlangSession* s;
-        ~SessionGuard() { spDestroySession(s); }
-    } sessionGuard{session};
-
-    SlangCompileRequest* req = spCreateCompileRequest(session);
-    if (!req)
-        return SLANG_FAIL;
-    struct RequestGuard
-    {
-        SlangCompileRequest* r;
-        ~RequestGuard() { spDestroyCompileRequest(r); }
-    } requestGuard{req};
-
-    spAddCodeGenTarget(req, SLANG_SPIRV);
-
-    // First call: "-lang slang" with no adjacent files.  The InputFilesRemain while loop
-    // in the option parser stops before any file args (there are none), so addInputPath is
-    // NOT called here.  Only the session-level Language option is set on the linkage.
-    const char* langArgv[] = {"-lang", "slang"};
-    if (SLANG_FAILED(spProcessCommandLineArguments(req, langArgv, 2)))
-        return SLANG_FAIL;
-
-    // Second call: "-- -" without -lang.  addInputPath("-", UNKNOWN) falls through to the
-    // session-level Language option (set above) to deduce SLANG_SOURCE_LANGUAGE_SLANG.
-    const char* stdinArgv[] = {"-entry", "main", "-stage", "compute", "--", "-"};
-    if (SLANG_FAILED(spProcessCommandLineArguments(req, stdinArgv, 6)))
-        return SLANG_FAIL;
-
-    if (SLANG_FAILED(spCompile(req)))
+    if (!_contains(result.standardOutput, "use '-' to read from standard input"))
         return SLANG_FAIL;
 
     return SLANG_OK;
@@ -1131,26 +283,17 @@ static SlangResult _testSessionLanguageFallback(UnitTestContext* context)
 
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangHlsl(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithoutLang(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testEmptyStdin(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTwice(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinDiagnosticLocation(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithBom(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinBomDiagnosticLocation(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinCrlfLineNumbers(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinThenFile(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testFileBetweenStdins(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTooLarge(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinExactlyAtCap(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinCtrlZNotTruncating(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMultipleFreads(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinPassThroughMissingStage(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testHelpContainsStdinPreamble(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_testSessionLanguageFallback(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSlangStdin(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testHlslStdin(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testMissingLanguage(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testDuplicateStdin(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testDiagnosticLocation(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testCrlfDiagnosticLocation(unitTestContext)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testStdinAndFileShareSlangTranslationUnit(unitTestContext, false)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testStdinAndFileShareSlangTranslationUnit(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testCtrlZIsNotEndOfFile(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testInputLargerThanReadBuffer(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testHelpMentionsStdin(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -75,10 +75,7 @@ static SlangResult _testSlangStdin(UnitTestContext* context)
     List<String> args;
     _addStdinCompileArgs(args, "slang");
 
-    return _expectSlangcSuccess(
-        context,
-        args,
-        "[shader(\"compute\")] void main() {}\n");
+    return _expectSlangcSuccess(context, args, "[shader(\"compute\")] void main() {}\n");
 }
 
 static SlangResult _testHlslStdin(UnitTestContext* context)
@@ -86,10 +83,7 @@ static SlangResult _testHlslStdin(UnitTestContext* context)
     List<String> args;
     _addStdinCompileArgs(args, "hlsl");
 
-    return _expectSlangcSuccess(
-        context,
-        args,
-        "[numthreads(1, 1, 1)] void main() {}\n");
+    return _expectSlangcSuccess(context, args, "[numthreads(1, 1, 1)] void main() {}\n");
 }
 
 static SlangResult _testMissingLanguage(UnitTestContext* context)
@@ -122,11 +116,8 @@ static SlangResult _testDuplicateStdin(UnitTestContext* context)
     args.add("-");
 
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_runSlangcWithStdin(
-        context,
-        args,
-        "[shader(\"compute\")] void main() {}\n",
-        result));
+    SLANG_RETURN_ON_FAIL(
+        _runSlangcWithStdin(context, args, "[shader(\"compute\")] void main() {}\n", result));
 
     if (result.resultCode == 0)
         return SLANG_FAIL;
@@ -207,8 +198,7 @@ static SlangResult _testStdinAndFileShareSlangTranslationUnit(
     bool stdinFirst)
 {
     TempSlangFile helper;
-    SLANG_RETURN_ON_FAIL(
-        _createTempSlangFile("slangc-stdin-helper", "void helper() {}\n", helper));
+    SLANG_RETURN_ON_FAIL(_createTempSlangFile("slangc-stdin-helper", "void helper() {}\n", helper));
 
     List<String> args;
     args.add("-lang");
@@ -231,10 +221,7 @@ static SlangResult _testStdinAndFileShareSlangTranslationUnit(
         args.add("-");
     }
 
-    return _expectSlangcSuccess(
-        context,
-        args,
-        "[shader(\"compute\")] void main() { helper(); }\n");
+    return _expectSlangcSuccess(context, args, "[shader(\"compute\")] void main() { helper(); }\n");
 }
 
 static SlangResult _testCtrlZIsNotEndOfFile(UnitTestContext* context)
@@ -291,8 +278,7 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testCrlfDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(
         SLANG_SUCCEEDED(_testStdinAndFileShareSlangTranslationUnit(unitTestContext, false)));
-    SLANG_CHECK(
-        SLANG_SUCCEEDED(_testStdinAndFileShareSlangTranslationUnit(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinAndFileShareSlangTranslationUnit(unitTestContext, true)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testCtrlZIsNotEndOfFile(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testInputLargerThanReadBuffer(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testHelpMentionsStdin(unitTestContext)));

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -4,17 +4,21 @@
 
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-process-util.h"
+#include "slang-com-ptr.h"
+#include "slang.h"
 #include "unit-test/slang-unit-test.h"
 
+#include <stdio.h>
 #include <string.h>
 
 #if SLANG_UNIX_FAMILY
-// For Case 11: fork+exec with a custom stdin fd.
+// For Case 11 (fork+exec) and Case 18 (dup/dup2 stdin redirect).
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #elif SLANG_WINDOWS_FAMILY
-// For Case 11: CreateProcess with a write-only pipe handle as stdin.
+// For Case 11 (CreateProcess) and Case 18 (_dup/_dup2 stdin redirect).
+#include <io.h>
 #include <windows.h>
 #endif
 
@@ -1013,6 +1017,118 @@ static SlangResult _testHelpContainsStdinPreamble(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 18: session-level Language fallback in addInputPath.
+// When -lang <lang> appears before -- in argv, two things happen at option-parse time:
+//   (a) the per-file langOverride is NOT passed to addInputPath for - (which comes after --,
+//       processed by InputFilesRemain with langOverride=UNKNOWN), and
+//   (b) the session-level CompilerOptionName::Language is set on the linkage's OptionSet.
+// addInputPath("-", UNKNOWN) therefore falls through to the session-level branch to deduce
+// the language.  This test makes that path explicit: it calls processCommandLineArguments
+// twice on the same request — first with "-lang slang" only (sets session Language, reads
+// no files) and then with "-- -" only (addInputPath receives langOverride=UNKNOWN, must
+// use the session-level Language).  A regression that flips to a different OptionSet in
+// the fallback check would compile clean and pass every subprocess test while silently
+// producing cannot-deduce-source-language for embedders using this call pattern.
+//
+// Stdin is redirected from a temp file for the second call so the unit-test process does
+// not stall waiting for interactive input.
+static SlangResult _testSessionLanguageFallback(UnitTestContext* context)
+{
+    // Write valid Slang source to a temp file that will be used as stdin.
+    const char* source = "[shader(\"compute\")] void main() {}\n";
+    String tempBase;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-lang-test"), tempBase));
+    struct TempGuard
+    {
+        String path;
+        ~TempGuard() { File::remove(path); }
+    } guard{tempBase};
+    SLANG_RETURN_ON_FAIL(File::writeAllText(tempBase, source));
+
+    // Redirect the C runtime's stdin to the temp file.  fread inside addInputPath reads
+    // directly from the C FILE* stdin so this is the only way to inject source without
+    // spawning a subprocess.  We use dup2/fileno to redirect the underlying file descriptor,
+    // then restore it to a null device before returning.
+#ifdef _WIN32
+    FILE* srcFile = fopen(tempBase.getBuffer(), "rb");
+    if (!srcFile)
+        return SLANG_FAIL;
+    const int savedStdinFd = _dup(_fileno(stdin));
+    _dup2(_fileno(srcFile), _fileno(stdin));
+    fclose(srcFile);
+    struct StdinRestoreGuard
+    {
+        int saved;
+        ~StdinRestoreGuard()
+        {
+            if (saved >= 0)
+            {
+                _dup2(saved, _fileno(stdin));
+                _close(saved);
+            }
+        }
+    } stdinRestoreGuard{savedStdinFd};
+#else
+    FILE* srcFile = fopen(tempBase.getBuffer(), "rb");
+    if (!srcFile)
+        return SLANG_FAIL;
+    const int savedStdinFd = dup(fileno(stdin));
+    dup2(fileno(srcFile), fileno(stdin));
+    fclose(srcFile);
+    struct StdinRestoreGuard
+    {
+        int saved;
+        ~StdinRestoreGuard()
+        {
+            if (saved >= 0)
+            {
+                dup2(saved, fileno(stdin));
+                close(saved);
+            }
+        }
+    } stdinRestoreGuard{savedStdinFd};
+#endif
+
+    // Create a session and compile request.
+    SlangSession* session = spCreateSession();
+    if (!session)
+        return SLANG_FAIL;
+    struct SessionGuard
+    {
+        SlangSession* s;
+        ~SessionGuard() { spDestroySession(s); }
+    } sessionGuard{session};
+
+    SlangCompileRequest* req = spCreateCompileRequest(session);
+    if (!req)
+        return SLANG_FAIL;
+    struct RequestGuard
+    {
+        SlangCompileRequest* r;
+        ~RequestGuard() { spDestroyCompileRequest(r); }
+    } requestGuard{req};
+
+    spAddCodeGenTarget(req, SLANG_SPIRV);
+
+    // First call: "-lang slang" with no adjacent files.  The InputFilesRemain while loop
+    // in the option parser stops before any file args (there are none), so addInputPath is
+    // NOT called here.  Only the session-level Language option is set on the linkage.
+    const char* langArgv[] = {"-lang", "slang"};
+    if (SLANG_FAILED(spProcessCommandLineArguments(req, langArgv, 2)))
+        return SLANG_FAIL;
+
+    // Second call: "-- -" without -lang.  addInputPath("-", UNKNOWN) falls through to the
+    // session-level Language option (set above) to deduce SLANG_SOURCE_LANGUAGE_SLANG.
+    const char* stdinArgv[] = {"-entry", "main", "-stage", "compute", "--", "-"};
+    if (SLANG_FAILED(spProcessCommandLineArguments(req, stdinArgv, 6)))
+        return SLANG_FAIL;
+
+    if (SLANG_FAILED(spCompile(req)))
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -1036,4 +1152,5 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMultipleFreads(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinPassThroughMissingStage(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testHelpContainsStdinPreamble(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSessionLanguageFallback(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -371,9 +371,11 @@ static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
 {
     // Generate a uniquely-named temp file in the OS temp directory so the test
     // is safe in read-only cwds and parallel/re-run CI environments.
+    // No suffix is appended: the test passes -lang slang explicitly so the extension
+    // is irrelevant, and keeping the generateTemporary path ensures the FileGuard
+    // below removes the same inode that was atomically created here.
     String helperPath;
     SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper"), helperPath));
-    helperPath = helperPath + ".slang";
 
     // RAII guard: removes the file on any return path, including early-out failures.
     struct FileGuard
@@ -411,14 +413,12 @@ static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
     return SLANG_OK;
 }
 
-// Case 11 (POSIX only): pass a write-only regular-file fd as slangc's stdin.
-// On POSIX, poll(2) always reports POLLIN for regular files regardless of the fd's
-// access mode.  UnixPipeStream therefore calls read(2), which returns EBADF because
-// the fd was opened O_WRONLY.  EBADF is not EAGAIN/EWOULDBLOCK, so read() returns
-// SLANG_FAIL, which propagates out of StreamUtil::readAll and causes slangc to emit
-// CannotReadFromStdin (error 107: "failed to read source from stdin").
-// On non-POSIX platforms the test is a no-op: triggering a genuine readAll failure
-// requires platform-specific handle manipulation outside the test framework's reach.
+// Case 11: pass a write-only fd/handle as slangc's stdin to trigger diagnostic 107.
+// The stdin read in addInputPath uses fread/ferror directly (not PipeStream/readAll).
+// POSIX: fread on an O_WRONLY fd calls read(2), which returns EBADF; fread returns 0
+//        and sets ferror(stdin), satisfying the if (ferror(stdin)) guard → diagnostic 107.
+// Windows: fread on a write-only pipe handle goes through the CRT, which calls ReadFile;
+//          ReadFile fails on a write-only handle, the CRT sets ferror(stdin) → diagnostic 107.
 static SlangResult _testStdinReadError(UnitTestContext* context)
 {
 #if SLANG_UNIX_FAMILY
@@ -516,9 +516,9 @@ static SlangResult _testStdinReadError(UnitTestContext* context)
     return SLANG_OK;
 #elif SLANG_WINDOWS_FAMILY
     // Create an anonymous pipe and pass the write end as the child's stdin.
-    // WinPipeStream detects FILE_TYPE_PIPE and calls PeekNamedPipe; PeekNamedPipe
-    // fails on a write-only handle (ERROR_ACCESS_DENIED), which propagates through
-    // _updateState → StreamUtil::readAll as SLANG_FAIL → diagnostic 107.
+    // fread in slangc calls ReadFile via the CRT; ReadFile fails on a write-only
+    // pipe handle, the CRT sets the stdio error indicator, and ferror(stdin)
+    // fires in addInputPath → diagnostic 107.
     SECURITY_ATTRIBUTES sa = {};
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -1,0 +1,124 @@
+// unit-test-stdin-compile.cpp
+//
+// Tests that slangc can read shader source from stdin when '-' is passed as the input path.
+
+#include "../../source/core/slang-process-util.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <string.h>
+
+using namespace Slang;
+
+static SlangResult _spawnSlangcWithStdin(
+    UnitTestContext* context,
+    const List<String>& args,
+    const char* stdinSource,
+    ExecuteResult& outResult)
+{
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(context->executableDirectory, "slangc"));
+    for (const auto& arg : args)
+        cmdLine.addArg(arg);
+
+    RefPtr<Process> process;
+    SLANG_RETURN_ON_FAIL(Process::create(cmdLine, 0, process));
+
+    // Write source to slangc's stdin and close the stream so it sees EOF.
+    if (stdinSource && stdinSource[0] != '\0')
+    {
+        Stream* inStream = process->getStream(StdStreamType::In);
+        const Index len = Index(strlen(stdinSource));
+        SLANG_RETURN_ON_FAIL(inStream->write(stdinSource, len));
+    }
+    process->getStream(StdStreamType::In)->close();
+
+    SLANG_RETURN_ON_FAIL(ProcessUtil::readUntilTermination(process, outResult));
+    return SLANG_OK;
+}
+
+// Case 1: valid shader piped via stdin with -lang slang should succeed.
+static SlangResult _testStdinWithLang(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    const char* source = "[shader(\"compute\")] void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Should compile successfully and produce SPIR-V assembly output.
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 2: omitting -lang should produce a clean diagnostic, not a crash.
+static SlangResult _testStdinWithoutLang(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    const char* source = "[shader(\"compute\")] void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Should fail with a diagnostic about unknown source language, not crash.
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 3: empty stdin should produce a diagnostic, not undefined behavior.
+static SlangResult _testEmptyStdin(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
+
+    // Empty source is valid to parse but has no entry point — should fail cleanly.
+    // The important thing is it doesn't crash (resultCode is defined).
+    (void)result.resultCode;
+    return SLANG_OK;
+}
+
+SLANG_UNIT_TEST(SlangcReadFromStdin)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLang(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithoutLang(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testEmptyStdin(unitTestContext)));
+}

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -959,6 +959,60 @@ static SlangResult _testStdinMultipleFreads(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 16: stdin + -pass-through dxc without -stage emits NoStageSpecifiedInPassThroughMode
+// (error 35) from slangc itself — not from dxc.  The check at _passThroughRequiresStage in
+// slang-options.cpp fires before any downstream compiler is invoked, so this test works even
+// when dxc is not installed.  It also serves as the regression test for the doc claim in the
+// -- option description: "slangc emits a clean CLI diagnostic (error 35) when it is omitted."
+static SlangResult _testStdinPassThroughMissingStage(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-pass-through");
+    args.add("dxc");
+    args.add("-entry");
+    args.add("main");
+    // Deliberately no -stage.
+    args.add("--");
+    args.add("-");
+
+    const char* source = "void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Must fail — slangc catches the missing stage with a clean diagnostic.
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    // Verify the specific diagnostic text (error 35: no-stage-specified-in-pass-through-mode).
+    if (result.standardError.getUnownedSlice().indexOf(
+            toSlice("no stage was specified for entry point")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 17: slangc -h output contains the stdin usage preamble.
+// kStdinUsagePreamble is injected into _appendUsageTitle and _parseHelp; a regression
+// that drops one of those calls compiles cleanly but silently removes the help text.
+// This test runs slangc -h and asserts the first sentence of the preamble is present
+// on stdout, covering the _appendUsageTitle path.
+static SlangResult _testHelpContainsStdinPreamble(UnitTestContext* context)
+{
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(context->executableDirectory, "slangc"));
+    cmdLine.addArg("-h");
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(ProcessUtil::execute(cmdLine, result));
+
+    if (result.standardOutput.getUnownedSlice().indexOf(
+            toSlice("Pass '-' as an input file to read source from standard input.")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -980,4 +1034,6 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinExactlyAtCap(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinCtrlZNotTruncating(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMultipleFreads(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinPassThroughMissingStage(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testHelpContainsStdinPreamble(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -199,6 +199,15 @@ static SlangResult _testStdinTwice(UnitTestContext* context)
     if (count != 1)
         return SLANG_FAIL;
 
+    // Silent no-op contract: the second '-' must produce no diagnostic.
+    // Any future change that emits a warning or error on the second '-' must
+    // update this test to reflect the new intentional behavior.
+    UnownedStringSlice err = result.standardError.getUnownedSlice();
+    if (err.indexOf(toSlice("no source code found")) >= 0)
+        return SLANG_FAIL;
+    if (err.indexOf(toSlice("can't deduce language")) >= 0)
+        return SLANG_FAIL;
+
     return SLANG_OK;
 }
 

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -110,9 +110,9 @@ static SlangResult _testEmptyStdin(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
 
-    // Empty source is valid to parse but has no entry point — should fail cleanly.
-    // The important thing is it doesn't crash (resultCode is defined).
-    (void)result.resultCode;
+    // Empty source with explicit entry/stage should fail cleanly.
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
     return SLANG_OK;
 }
 

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -145,7 +145,7 @@ static SlangResult _testEmptyStdin(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "", result));
 
-    // Empty stdin should emit the EmptySourceInput diagnostic (error 170:
+    // Empty stdin should emit the EmptySourceInput diagnostic (error 106:
     // "no source code found in '<stdin>'") and fail, not silently create an
     // empty translation unit or crash.
     if (result.resultCode == 0)
@@ -233,16 +233,17 @@ static SlangResult _testStdinDiagnosticLocation(UnitTestContext* context)
         return SLANG_FAIL;
 
     // Diagnostic format is: <stdin>(line): error N: message
-    // Verify both the path token and a line-number marker are present so that
-    // IDE/tooling consumers can parse stdin errors the same way as file errors.
+    // Assert the exact line number so a BOM or off-by-one regression in SourceLoc
+    // tracking surfaces here rather than silently passing.
+    // undeclared_identifier; is on line 2 of the stdin source.
     UnownedStringSlice err = result.standardError.getUnownedSlice();
-    if (err.indexOf(toSlice("<stdin>(")) < 0)
+    if (err.indexOf(toSlice("<stdin>(2):")) < 0)
         return SLANG_FAIL;
 
     return SLANG_OK;
 }
 
-// Case 7: stdin source with a UTF-8 BOM should compile correctly.
+// Case 7a: stdin source with a UTF-8 BOM should compile correctly.
 // SourceFile does BOM detection; verify it works for the stdin blob path too.
 static SlangResult _testStdinWithBom(UnitTestContext* context)
 {
@@ -267,6 +268,42 @@ static SlangResult _testStdinWithBom(UnitTestContext* context)
     if (result.resultCode != 0)
         return SLANG_FAIL;
     if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 7b: BOM + deliberate error on line 2 should report <stdin>(2): so a
+// BOM-handling regression that treats the BOM as a newline would shift line
+// numbers and fail this assertion.
+static SlangResult _testStdinBomDiagnosticLocation(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // BOM on byte 0, valid line 1, error on line 2.
+    const char* source =
+        "\xEF\xBB\xBF[shader(\"compute\")] void main() {\n"
+        "    undeclared_identifier;\n"
+        "}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    // If the BOM were consumed as a newline, the error would appear on line 3.
+    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>(2):")) < 0)
         return SLANG_FAIL;
 
     return SLANG_OK;
@@ -313,8 +350,19 @@ static SlangResult _testStdinWithLangGlsl(UnitTestContext* context)
 // and fail this test.
 static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
 {
-    // Write a helper file containing a function the stdin entry point will call.
-    String helperPath = String("slangc-stdin-helper-") + String(Process::getId()) + ".slang";
+    // Generate a uniquely-named temp file in the OS temp directory so the test
+    // is safe in read-only cwds and parallel/re-run CI environments.
+    String helperPath;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper"), helperPath));
+    helperPath = helperPath + ".slang";
+
+    // RAII guard: removes the file on any return path, including early-out failures.
+    struct FileGuard
+    {
+        String path;
+        ~FileGuard() { File::remove(path); }
+    } guard{helperPath};
+
     SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
 
     List<String> args;
@@ -334,12 +382,7 @@ static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
     const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
 
     ExecuteResult result;
-    SlangResult spawnRes = _spawnSlangcWithStdin(context, args, source, result);
-
-    // Clean up the temp file regardless of outcome.
-    File::remove(helperPath);
-
-    SLANG_RETURN_ON_FAIL(spawnRes);
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
 
     if (result.resultCode != 0)
         return SLANG_FAIL;

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -401,6 +401,7 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTwice(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithBom(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinBomDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -363,32 +363,37 @@ static SlangResult _testStdinWithLangGlsl(UnitTestContext* context)
 }
 
 // Case 9: stdin combined with an on-disk .slang file.
-// Both inputs go into the same Slang translation unit (m_slangTranslationUnitIndex reuse),
-// so the stdin entry point can call a function defined in the on-disk file.
+// Both inputs must have the .slang extension (or be recognised as Slang by extension) so
+// that addInputPath routes them through addInputSlangPath, which reuses
+// m_slangTranslationUnitIndex and places both sources into the same translation unit.
 // A future refactor that allocates a fresh TU for stdin would break cross-file visibility
 // and fail this test.
 static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
 {
     // Generate a uniquely-named temp file in the OS temp directory so the test
     // is safe in read-only cwds and parallel/re-run CI environments.
-    // No suffix is appended: the test passes -lang slang explicitly so the extension
-    // is irrelevant, and keeping the generateTemporary path ensures the FileGuard
-    // below removes the same inode that was atomically created here.
-    String helperPath;
-    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper"), helperPath));
+    // We append ".slang" so the file is routed through addInputSlangPath, which is
+    // the path that sets/reuses m_slangTranslationUnitIndex.  Both the base path
+    // (created by generateTemporary) and the ".slang" path must be removed on exit.
+    String basePath;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper"), basePath));
+    const String helperPath = basePath + ".slang";
 
-    // RAII guard: removes the file on any return path, including early-out failures.
+    // RAII guard: removes both the base inode (created by generateTemporary) and
+    // the ".slang" file written below on any return path, including early-out failures.
     struct FileGuard
     {
-        String path;
-        ~FileGuard() { File::remove(path); }
-    } guard{helperPath};
+        String base, slang;
+        ~FileGuard()
+        {
+            File::remove(base);
+            File::remove(slang);
+        }
+    } guard{basePath, helperPath};
 
     SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
 
     List<String> args;
-    args.add("-lang");
-    args.add("slang");
     args.add("-target");
     args.add("spirv-asm");
     args.add("-entry");
@@ -635,6 +640,74 @@ static SlangResult _testStdinGlslWithoutStage(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Helper: set an environment variable for the duration of a scope, then restore it.
+struct ScopedEnvVar
+{
+    const char* key;
+    bool hadOld;
+    String oldVal;
+
+    ScopedEnvVar(const char* k, const char* v) : key(k), hadOld(false)
+    {
+        if (const char* cur = getenv(k))
+        {
+            hadOld = true;
+            oldVal = cur;
+        }
+#ifdef _WIN32
+        String s = String(k) + "=" + v;
+        _putenv(s.getBuffer());
+#else
+        setenv(k, v, 1);
+#endif
+    }
+    ~ScopedEnvVar()
+    {
+#ifdef _WIN32
+        String s = String(key) + "=" + (hadOld ? oldVal.getBuffer() : "");
+        _putenv(s.getBuffer());
+#else
+        if (hadOld)
+            setenv(key, oldVal.getBuffer(), 1);
+        else
+            unsetenv(key);
+#endif
+    }
+};
+
+// Case 13: stdin input exceeds the cap → StdinInputTooLarge diagnostic (error 108).
+// The production cap is 256 MiB; we lower it to 10 bytes via SLANG_TEST_MAX_STDIN_BYTES
+// so the test can trigger the diagnostic without allocating hundreds of megabytes.
+static SlangResult _testStdinTooLarge(UnitTestContext* context)
+{
+    ScopedEnvVar capEnv("SLANG_TEST_MAX_STDIN_BYTES", "10");
+
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("--");
+    args.add("-");
+
+    // 11 bytes — one more than the cap set above.
+    const char* source = "12345678901";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    // Must fail with a non-zero exit code.
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    // The StdinInputTooLarge message must appear in the output.
+    if (result.standardError.getUnownedSlice().indexOf(
+            toSlice("stdin input exceeds the maximum allowed size")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -649,4 +722,5 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTooLarge(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -177,9 +177,92 @@ static SlangResult _testStdinTwice(UnitTestContext* context)
     ExecuteResult result;
     SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
 
-    // Both '-' tokens go into the same Slang translation unit (m_slangTranslationUnitIndex
-    // reuse), so the second read appends nothing meaningful. Compilation should still
-    // succeed since the first read provided a valid entry point.
+    // The second '-' is a no-op (m_stdinConsumed guard short-circuits before re-reading
+    // the drained pipe). The source from the first '-' should compile to exactly one
+    // entry point — if the second '-' were incorrectly processed it could produce two.
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+
+    // Count OpEntryPoint occurrences to confirm only one entry point was compiled.
+    Index count = 0;
+    const UnownedStringSlice marker = toSlice("OpEntryPoint");
+    UnownedStringSlice remaining = result.standardOutput.getUnownedSlice();
+    while (true)
+    {
+        Index found = remaining.indexOf(marker);
+        if (found < 0)
+            break;
+        count++;
+        remaining = remaining.tail(found + marker.getLength());
+    }
+    if (count != 1)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 6: a deliberate syntax error in stdin source should produce a diagnostic that
+// includes both "<stdin>" as the path and a line number, confirming the SourceFile
+// path-info flows correctly through the diagnostic sink for tooling integrations.
+static SlangResult _testStdinDiagnosticLocation(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // Line 1 is a valid declaration; line 2 references an undeclared identifier.
+    // This pins that the line number in the diagnostic refers to the stdin source.
+    const char* source =
+        "[shader(\"compute\")] void main() {\n"
+        "    undeclared_identifier;\n"
+        "}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    // Diagnostic format is: <stdin>(line): error N: message
+    // Verify both the path token and a line-number marker are present so that
+    // IDE/tooling consumers can parse stdin errors the same way as file errors.
+    UnownedStringSlice err = result.standardError.getUnownedSlice();
+    if (err.indexOf(toSlice("<stdin>(")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 7: stdin source with a UTF-8 BOM should compile correctly.
+// SourceFile does BOM detection; verify it works for the stdin blob path too.
+static SlangResult _testStdinWithBom(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // UTF-8 BOM (\xEF\xBB\xBF) prepended to a valid shader.
+    const char* source = "\xEF\xBB\xBF[shader(\"compute\")] void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
     if (result.resultCode != 0)
         return SLANG_FAIL;
     if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
@@ -195,4 +278,6 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithoutLang(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testEmptyStdin(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTwice(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinDiagnosticLocation(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithBom(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -2,6 +2,7 @@
 //
 // Tests that slangc can read shader source from stdin when '-' is passed as the input path.
 
+#include "../../source/core/slang-io.h"
 #include "../../source/core/slang-process-util.h"
 #include "unit-test/slang-unit-test.h"
 
@@ -271,6 +272,83 @@ static SlangResult _testStdinWithBom(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 8: GLSL shader piped via stdin with -lang glsl and -stage compute.
+// For GLSL the stage is normally inferred from the file extension (.comp, .vert, etc.);
+// stdin has no extension so -stage is always required. This pins that the path works
+// and that the documented requirement is enforced.
+static SlangResult _testStdinWithLangGlsl(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("glsl");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    const char* source =
+        "#version 450\n"
+        "layout(local_size_x = 1) in;\n"
+        "void main() {}\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 9: stdin combined with an on-disk .slang file.
+// Both inputs go into the same Slang translation unit (m_slangTranslationUnitIndex reuse),
+// so the stdin entry point can call a function defined in the on-disk file.
+// A future refactor that allocates a fresh TU for stdin would break cross-file visibility
+// and fail this test.
+static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
+{
+    // Write a helper file containing a function the stdin entry point will call.
+    String helperPath = String("slangc-stdin-helper-") + String(Process::getId()) + ".slang";
+    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
+
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add(helperPath);
+    args.add("--");
+    args.add("-");
+
+    // Entry point in stdin calls foo() defined in the on-disk file.
+    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
+
+    ExecuteResult result;
+    SlangResult spawnRes = _spawnSlangcWithStdin(context, args, source, result);
+
+    // Clean up the temp file regardless of outcome.
+    File::remove(helperPath);
+
+    SLANG_RETURN_ON_FAIL(spawnRes);
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -280,4 +358,6 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTwice(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithBom(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -619,8 +619,15 @@ static SlangResult _testStdinGlslWithoutStage(UnitTestContext* context)
     args.add("--");
     args.add("-");
 
+    // Use the same source that Case 8 proves compiles when -stage compute is given.
+    // This ensures the failure here is due to the missing stage, not invalid source.
+    const char* source =
+        "#version 450\n"
+        "layout(local_size_x = 1) in;\n"
+        "void main() {}\n";
+
     ExecuteResult result;
-    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, "void main() {}\n", result));
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
 
     if (result.resultCode == 0)
         return SLANG_FAIL;

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -328,6 +328,48 @@ static SlangResult _testStdinBomDiagnosticLocation(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 7c: source with \r\n line endings should produce correct line numbers.
+// On Windows, stdin is opened in text mode by default; text mode converts \r\n to \n,
+// which is consistent and does NOT change line counts, but it is inconsistent with
+// file-based compilation (binary FileStream) and silently strips \r from diagnostics.
+// More critically, text mode treats 0x1A (Ctrl-Z) as EOF, silently truncating source.
+// The fix is _setmode(_fileno(stdin), _O_BINARY) before fread.
+// This test sends \r\n-terminated source with a deliberate error on line 2 and asserts
+// that <stdin>(2): appears — ensuring \r\n is not treated as two newlines (which would
+// report line 3 instead).
+static SlangResult _testStdinCrlfLineNumbers(UnitTestContext* context)
+{
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    // Line 1: valid.  Line 2: deliberate error.  All endings are \r\n.
+    const char* source =
+        "[shader(\"compute\")] void main() {\r\n"
+        "    undeclared_identifier;\r\n"
+        "}\r\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+
+    // If \r\n were treated as two newlines the error would appear on line 3.
+    if (result.standardError.getUnownedSlice().indexOf(toSlice("<stdin>(2):")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 // Case 8: GLSL shader piped via stdin with -lang glsl and -stage compute.
 // For GLSL the stage is normally inferred from the file extension (.comp, .vert, etc.);
 // stdin has no extension so -stage is always required. This pins that the path works
@@ -405,6 +447,103 @@ static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
     args.add("-");
 
     // Entry point in stdin calls foo() defined in the on-disk file.
+    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 10a: stdin first, file second — reverse of Case 9.
+// -- - <file.slang>: stdin is processed first (initialising m_slangTranslationUnitIndex),
+// then the .slang file is processed and reuses the same translation unit.
+// The entry point is in stdin and calls a function defined in the on-disk file,
+// so cross-file visibility must hold regardless of argument order.
+static SlangResult _testStdinThenFile(UnitTestContext* context)
+{
+    String basePath;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper2"), basePath));
+    const String helperPath = basePath + ".slang";
+
+    struct FileGuard
+    {
+        String base, slang;
+        ~FileGuard()
+        {
+            File::remove(base);
+            File::remove(slang);
+        }
+    } guard{basePath, helperPath};
+
+    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
+
+    List<String> args;
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+    args.add(helperPath);
+
+    // Entry point in stdin calls foo() defined in the on-disk file.
+    const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+// Case 10b: file sandwiched between two '-' tokens — -- <file.slang> - -.
+// The file defines foo(); the first '-' reads stdin (entry point calling foo());
+// the second '-' hits m_stdinConsumed and is a no-op.
+// Verifies that the m_stdinConsumed guard interacts correctly with a file argument
+// between the two '-' tokens and that the single TU is used throughout.
+static SlangResult _testFileBetweenStdins(UnitTestContext* context)
+{
+    String basePath;
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(toSlice("slangc-stdin-helper3"), basePath));
+    const String helperPath = basePath + ".slang";
+
+    struct FileGuard
+    {
+        String base, slang;
+        ~FileGuard()
+        {
+            File::remove(base);
+            File::remove(slang);
+        }
+    } guard{basePath, helperPath};
+
+    SLANG_RETURN_ON_FAIL(File::writeAllText(helperPath, "void foo() {}\n"));
+
+    List<String> args;
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add(helperPath);
+    args.add("-");
+    args.add("-");
+
+    // Entry point in stdin calls foo() from the file; second '-' is a no-op.
     const char* source = "[shader(\"compute\")] void main() { foo(); }\n";
 
     ExecuteResult result;
@@ -718,8 +857,11 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithBom(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinBomDiagnosticLocation(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinCrlfLineNumbers(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinThenFile(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testFileBetweenStdins(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTooLarge(unitTestContext)));

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -8,6 +8,13 @@
 
 #include <string.h>
 
+#if SLANG_UNIX_FAMILY
+// For Case 11: fork+exec with a custom stdin fd.
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 using namespace Slang;
 
 static SlangResult _spawnSlangcWithStdin(
@@ -401,6 +408,115 @@ static SlangResult _testStdinMixedWithFile(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 11 (POSIX only): pass a write-only regular-file fd as slangc's stdin.
+// On POSIX, poll(2) always reports POLLIN for regular files regardless of the fd's
+// access mode.  UnixPipeStream therefore calls read(2), which returns EBADF because
+// the fd was opened O_WRONLY.  EBADF is not EAGAIN/EWOULDBLOCK, so read() returns
+// SLANG_FAIL, which propagates out of StreamUtil::readAll and causes slangc to emit
+// CannotReadFromStdin (error 107: "failed to read source from stdin").
+// On non-POSIX platforms the test is a no-op: triggering a genuine readAll failure
+// requires platform-specific handle manipulation outside the test framework's reach.
+static SlangResult _testStdinReadError(UnitTestContext* context)
+{
+#if SLANG_UNIX_FAMILY
+    // Create a temp file, close it, and reopen it write-only.
+    char tmpPath[] = "/tmp/slangc-stdin-err-XXXXXX";
+    const int tmpRW = mkstemp(tmpPath);
+    if (tmpRW < 0)
+        return SLANG_FAIL;
+    close(tmpRW);
+
+    const int wfd = ::open(tmpPath, O_WRONLY);
+    ::unlink(tmpPath); // delete the path; wfd keeps the inode alive until closed
+    if (wfd < 0)
+        return SLANG_FAIL;
+
+    // Pipe to capture slangc's stderr so we can inspect the diagnostic text.
+    int stderrPipe[2];
+    if (::pipe(stderrPipe) != 0)
+    {
+        ::close(wfd);
+        return SLANG_FAIL;
+    }
+
+    const String slangcPath = String(context->executableDirectory) + "/slangc";
+
+    const pid_t pid = ::fork();
+    if (pid < 0)
+    {
+        ::close(wfd);
+        ::close(stderrPipe[0]);
+        ::close(stderrPipe[1]);
+        return SLANG_FAIL;
+    }
+
+    if (pid == 0)
+    {
+        // Child: wire fds, then exec slangc.
+        // fd 0 (stdin) = write-only file fd → read(0,...) returns EBADF → diagnostic 107.
+        ::dup2(wfd, STDIN_FILENO);
+        ::dup2(stderrPipe[1], STDERR_FILENO);
+        const int devNull = ::open("/dev/null", O_WRONLY);
+        if (devNull >= 0)
+        {
+            ::dup2(devNull, STDOUT_FILENO);
+            ::close(devNull);
+        }
+        ::close(wfd);
+        ::close(stderrPipe[0]);
+        ::close(stderrPipe[1]);
+
+        ::execl(
+            slangcPath.getBuffer(),
+            slangcPath.getBuffer(),
+            "-lang",
+            "slang",
+            "-target",
+            "spirv-asm",
+            "-entry",
+            "main",
+            "-stage",
+            "compute",
+            "--",
+            "-",
+            (char*)nullptr);
+        ::_exit(127); // execl failed
+    }
+
+    // Parent: close the fds the child inherited.
+    ::close(wfd);
+    ::close(stderrPipe[1]);
+
+    // Drain slangc's stderr.
+    List<Byte> stderrBytes;
+    {
+        char buf[256];
+        ssize_t n;
+        while ((n = ::read(stderrPipe[0], buf, sizeof(buf))) > 0)
+            for (ssize_t i = 0; i < n; ++i)
+                stderrBytes.add(Byte(buf[i]));
+    }
+    ::close(stderrPipe[0]);
+
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+    const int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+    if (exitCode == 0)
+        return SLANG_FAIL;
+
+    const UnownedStringSlice stderrSlice(
+        (const char*)stderrBytes.getBuffer(), size_t(stderrBytes.getCount()));
+    if (stderrSlice.indexOf(toSlice("failed to read source from stdin")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+#else
+    SLANG_UNUSED(context);
+    return SLANG_OK;
+#endif
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -413,4 +529,5 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinBomDiagnosticLocation(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangGlsl(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinMixedWithFile(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
 }

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -847,6 +847,42 @@ static SlangResult _testStdinTooLarge(UnitTestContext* context)
     return SLANG_OK;
 }
 
+// Case 13b: exactly at the cap should succeed; this pins the check as > not >=.
+// A regression that changes > to >= would reject input of exactly kMaxStdinBytes bytes,
+// and this test would fail.
+static SlangResult _testStdinExactlyAtCap(UnitTestContext* context)
+{
+    const char* source = "[shader(\"compute\")] void main() {}\n";
+    const Index sourceLen = Index(strlen(source));
+
+    // Set the cap to exactly the source length so the check sits on the boundary.
+    char capStr[32];
+    snprintf(capStr, sizeof(capStr), "%lld", (long long)sourceLen);
+    ScopedEnvVar capEnv("SLANG_TEST_MAX_STDIN_BYTES", capStr);
+
+    List<String> args;
+    args.add("-lang");
+    args.add("slang");
+    args.add("-target");
+    args.add("spirv-asm");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("--");
+    args.add("-");
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_spawnSlangcWithStdin(context, args, source, result));
+
+    if (result.resultCode != 0)
+        return SLANG_FAIL;
+    if (result.standardOutput.getUnownedSlice().indexOf(toSlice("OpEntryPoint")) < 0)
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
 SLANG_UNIT_TEST(SlangcReadFromStdin)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinWithLangSlang(unitTestContext)));
@@ -865,4 +901,5 @@ SLANG_UNIT_TEST(SlangcReadFromStdin)
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinReadError(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinGlslWithoutStage(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testStdinTooLarge(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testStdinExactlyAtCap(unitTestContext)));
 }


### PR DESCRIPTION
## Summary of the problem from the end user perspective

`slangc` could not read shader source from standard input, making shell pipelines and editor/tool integrations awkward when no temporary source file is available.

### Minimal repro shader; if applicable

```slang
[shader("compute")]
void main() {}
```

Run with:

```bash
printf '[shader("compute")] void main() {}\n' | slangc -lang slang -target spirv-asm -entry main -stage compute -- -
```

## Root cause

The command-line input path handling only accepted real file paths and inferred source language from filenames. The `-` stdin convention has no extension, so it needs explicit source-language handling and a source-string translation-unit path.

## Solution in this PR

Add `slangc` support for `-` as a stdin input after `--`, require an explicit language for stdin, report clear stdin diagnostics, and cap stdin reads. The implementation reads stdin through blocking stdio, preserves binary input on Windows, and feeds the contents to the existing translation-unit pipeline as `<stdin>`.

### Notes to the reviewers; where to focus on

The main review areas are `OptionsParser::addInputPath`, `OptionsParser::addInputStdin`, and the handling of Slang translation-unit reuse when stdin is mixed with `.slang` files. The unit test was rewritten to cover the supported behavior instead of the earlier implementation details.
