### PR TITLE
Fix inherited associated type hoisting

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1467,17 +1467,33 @@ IRInst* mergeCandidateParentsForHoistableInst(IRInst* left, IRInst* right)
     //
     if (!parentNonBlock)
     {
-        HashSet<IRInst*> leftAncestors;
+        Int leftDepth = 0;
         for (auto ll = leftNonBlock; ll; ll = ll->getParent())
-            leftAncestors.add(ll);
+            leftDepth++;
+
+        Int rightDepth = 0;
         for (auto rr = rightNonBlock; rr; rr = rr->getParent())
+            rightDepth++;
+
+        auto ll = leftNonBlock;
+        auto rr = rightNonBlock;
+        while (leftDepth > rightDepth)
         {
-            if (leftAncestors.contains(rr))
-            {
-                parentNonBlock = rr;
-                break;
-            }
+            ll = ll->getParent();
+            leftDepth--;
         }
+        while (rightDepth > leftDepth)
+        {
+            rr = rr->getParent();
+            rightDepth--;
+        }
+        while (ll != rr)
+        {
+            ll = ll->getParent();
+            rr = rr->getParent();
+        }
+
+        parentNonBlock = ll;
     }
     SLANG_ASSERT(parentNonBlock);
     if (!parentNonBlock)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1460,20 +1460,28 @@ IRInst* mergeCandidateParentsForHoistableInst(IRInst* left, IRInst* right)
         }
     }
 
-    // As a matter of validity in the IR, we expect one
-    // of the two to be an ancestor (in the non-block case),
-    // because otherwise we'd be violating the basic dominance
-    // assumptions.
-    //
-    SLANG_ASSERT(parentNonBlock);
-
-    // As a fallback, try to use the left parent as a default
-    // in case things go badly.
+    // If neither side is an ancestor of the other, the operands live in
+    // sibling regions of the IR (for example, two generic interface bodies
+    // under the module). Place the hoistable instruction at their lowest
+    // common ancestor so it is in a scope that dominates both operands.
     //
     if (!parentNonBlock)
     {
-        parentNonBlock = leftNonBlock;
+        HashSet<IRInst*> leftAncestors;
+        for (auto ll = leftNonBlock; ll; ll = ll->getParent())
+            leftAncestors.add(ll);
+        for (auto rr = rightNonBlock; rr; rr = rr->getParent())
+        {
+            if (leftAncestors.contains(rr))
+            {
+                parentNonBlock = rr;
+                break;
+            }
+        }
     }
+    SLANG_ASSERT(parentNonBlock);
+    if (!parentNonBlock)
+        parentNonBlock = leftNonBlock;
 
     IRInst* parent = parentNonBlock;
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1460,44 +1460,20 @@ IRInst* mergeCandidateParentsForHoistableInst(IRInst* left, IRInst* right)
         }
     }
 
-    // If neither side is an ancestor of the other, the operands live in
-    // sibling regions of the IR (for example, two generic interface bodies
-    // under the module). Place the hoistable instruction at their lowest
-    // common ancestor so it is in a scope that dominates both operands.
+    // As a matter of validity in the IR, we expect one
+    // of the two to be an ancestor (in the non-block case),
+    // because otherwise we'd be violating the basic dominance
+    // assumptions.
+    //
+    SLANG_ASSERT(parentNonBlock);
+
+    // As a fallback, try to use the left parent as a default
+    // in case things go badly.
     //
     if (!parentNonBlock)
     {
-        Int leftDepth = 0;
-        for (auto ll = leftNonBlock; ll; ll = ll->getParent())
-            leftDepth++;
-
-        Int rightDepth = 0;
-        for (auto rr = rightNonBlock; rr; rr = rr->getParent())
-            rightDepth++;
-
-        auto ll = leftNonBlock;
-        auto rr = rightNonBlock;
-        while (leftDepth > rightDepth)
-        {
-            ll = ll->getParent();
-            leftDepth--;
-        }
-        while (rightDepth > leftDepth)
-        {
-            rr = rr->getParent();
-            rightDepth--;
-        }
-        while (ll != rr)
-        {
-            ll = ll->getParent();
-            rr = rr->getParent();
-        }
-
-        parentNonBlock = ll;
-    }
-    SLANG_ASSERT(parentNonBlock);
-    if (!parentNonBlock)
         parentNonBlock = leftNonBlock;
+    }
 
     IRInst* parent = parentNonBlock;
 

--- a/tests/language-feature/interfaces/gh-8135.slang
+++ b/tests/language-feature/interfaces/gh-8135.slang
@@ -1,0 +1,47 @@
+// Regression test for https://github.com/shader-slang/slang/issues/8135.
+// Using an associated type from an inherited generic interface in a child
+// interface method signature previously crashed in hoistable IR placement.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -entry computeMain -stage compute
+
+public interface IStorage<T>
+{
+    public associatedtype Address;
+}
+
+public interface IParameterStorage<T> : IStorage<T>
+{
+    public void add(Address address, T value);
+    public Address getAddress(T value);
+}
+
+struct DenseStorage : IParameterStorage<int>
+{
+    typedef uint Address;
+
+    void add(uint address, int value)
+    {}
+
+    uint getAddress(int value)
+    {
+        return uint(value);
+    }
+}
+
+void testStorage<T, S : IParameterStorage<T>>(S storage, T value)
+{
+    S.Address address = storage.getAddress(value);
+    storage.add(address, value);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DenseStorage storage;
+    testStorage(storage, int(dispatchThreadID.x));
+}
+
+// CHECK: OpEntryPoint GLCompute
+// CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
+// CHECK: OpReturn

--- a/tests/language-feature/interfaces/gh-8135.slang
+++ b/tests/language-feature/interfaces/gh-8135.slang
@@ -2,7 +2,7 @@
 // Using an associated type from an inherited generic interface in a child
 // interface method signature previously crashed in hoistable IR placement.
 
-//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -entry computeMain -stage compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
 
 public interface IStorage<T>
 {
@@ -15,16 +15,21 @@ public interface IParameterStorage<T> : IStorage<T>
     public Address getAddress(T value);
 }
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
 struct DenseStorage : IParameterStorage<int>
 {
     typedef uint Address;
 
     void add(uint address, int value)
-    {}
+    {
+        outputBuffer[address] = value;
+    }
 
     uint getAddress(int value)
     {
-        return uint(value);
+        return 0;
     }
 }
 
@@ -39,9 +44,6 @@ void testStorage<T, S : IParameterStorage<T>>(S storage, T value)
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     DenseStorage storage;
-    testStorage(storage, int(dispatchThreadID.x));
+    // CHECK: 7
+    testStorage(storage, int(dispatchThreadID.x) + 7);
 }
-
-// CHECK: OpEntryPoint GLCompute
-// CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
-// CHECK: OpReturn


### PR DESCRIPTION
Fixes shader-slang/slang#8135

## Summary of the problem from the end user perspective

A child generic interface used an associated type declared by its parent interface in method signatures. The original issue reported a Debug-build crash while lowering that inherited associated-type reference.

### Minimal repro shader; if applicable

```slang
interface IStorage<T> { associatedtype Address; }
interface IParameterStorage<T> : IStorage<T>
{
    void add(Address address, T value);
    Address getAddress(T value);
}
```

## Current state

The original crash no longer reproduces on current `master`; shader-slang/slang#9808 was identified in the issue discussion as the change that made the repro compile successfully.

## Solution in this PR

This PR adds a focused `gh-8135.slang` regression test for the inherited associated-type signature pattern so the scenario stays covered.

### Notes to the reviewers; where to focus on

Please focus on whether the regression test captures the issue pattern clearly and belongs with the existing interface tests.

## Related PRs in the past

- shader-slang/slang#9808 was identified in the issue discussion as the change that made the original repro no longer crash.