### PR TITLE
Allow SV_PrimitiveID in ray tracing hit stages

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -5050,6 +5050,9 @@ semantic sv_primitiveid
     [require(geometry)]
     [require(hull)]
     [require(domain)]
+    [require(intersection)]
+    [require(anyhit)]
+    [require(closesthit)]
     get : uint;
 
     [require(geometry)]

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1642,6 +1642,7 @@ Result linkAndOptimizeIR(
         // (must run before legalizeExistentialTypeLayout removes empty struct parameters)
         if (isD3DTarget(targetRequest))
         {
+            SLANG_PASS(legalizeRayTracingPrimitiveIDParamForHLSL);
             SLANG_PASS(legalizeNonStructParameterToStructForHLSL);
         }
 

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3097,6 +3097,9 @@ void consolidateRayTracingParameters(
         if (!isVaryingParameter(paramLayout))
             continue;
 
+        // Direct SPIR-V also reaches this pass for ray-tracing entry points.
+        // Only the GLSL/glslang path needs SV_PrimitiveID kept out of payload
+        // and hit-attribute consolidation so it can lower through gl_PrimitiveID.
         if (!codeGenContext->getTargetProgram()->shouldEmitSPIRVDirectly())
         {
             if (auto systemValueAttr = paramLayout->findSystemValueSemanticAttr())

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3077,7 +3077,10 @@ static void consolidateParameters(GLSLLegalizationContext* context, List<IRParam
 }
 
 // Consolidate ray tracing parameters for an entry point function
-void consolidateRayTracingParameters(GLSLLegalizationContext* context, IRFunc* func)
+void consolidateRayTracingParameters(
+    GLSLLegalizationContext* context,
+    CodeGenContext* codeGenContext,
+    IRFunc* func)
 {
     auto builder = context->getBuilder();
     auto firstBlock = func->getFirstBlock();
@@ -3093,6 +3096,16 @@ void consolidateRayTracingParameters(GLSLLegalizationContext* context, IRFunc* f
         auto paramLayout = findVarLayout(param);
         if (!isVaryingParameter(paramLayout))
             continue;
+
+        if (!codeGenContext->getTargetProgram()->shouldEmitSPIRVDirectly())
+        {
+            if (auto systemValueAttr = paramLayout->findSystemValueSemanticAttr())
+            {
+                if (systemValueAttr->getName().caseInsensitiveEquals(toSlice("sv_primitiveid")))
+                    continue;
+            }
+        }
+
         builder->setInsertBefore(firstBlock->getFirstOrdinaryInst());
         if (as<IROutParamType>(param->getDataType()) ||
             as<IRBorrowInOutParamType>(param->getDataType()))
@@ -4208,6 +4221,16 @@ void legalizeEntryPointParameterForGLSL(
     // to a single variable, and we can lower reads/writes of it
     // directly, rather than introduce an intermediate temporary.
     //
+    bool isRayTracingPrimitiveIDSystemValueParam = false;
+    if (!codeGenContext->getTargetProgram()->shouldEmitSPIRVDirectly())
+    {
+        if (auto systemValueAttr = paramLayout->findSystemValueSemanticAttr())
+        {
+            isRayTracingPrimitiveIDSystemValueParam =
+                systemValueAttr->getName().caseInsensitiveEquals(toSlice("sv_primitiveid"));
+        }
+    }
+
     switch (stage)
     {
     default:
@@ -4219,7 +4242,9 @@ void legalizeEntryPointParameterForGLSL(
     case Stage::Intersection:
     case Stage::Miss:
     case Stage::RayGeneration:
-        return;
+        if (!isRayTracingPrimitiveIDSystemValueParam)
+            return;
+        break;
     }
 
     // Is the parameter type a special pointer type
@@ -4918,7 +4943,7 @@ void legalizeEntryPointForGLSL(
     case Stage::Intersection:
     case Stage::Miss:
     case Stage::RayGeneration:
-        consolidateRayTracingParameters(&context, func);
+        consolidateRayTracingParameters(&context, codeGenContext, func);
         break;
     default:
         break;

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -59,29 +59,11 @@ static void addRayPayloadDecorationIfNeeded(IRBuilder& builder, IRType* type)
         builder.addRayPayloadDecoration(type);
 }
 
-static bool isRayTracingHitStage(Stage stage)
-{
-    switch (stage)
-    {
-    case Stage::Intersection:
-    case Stage::AnyHit:
-    case Stage::ClosestHit:
-        return true;
-    default:
-        return false;
-    }
-}
-
-static bool isPrimitiveIDSystemValueSemantic(UnownedStringSlice semanticName)
-{
-    return String(semanticName).toLower() == "sv_primitiveid";
-}
-
 static bool isPrimitiveIDSystemValueParam(IRParam* param)
 {
     if (auto semanticDecor = param->findDecoration<IRSemanticDecoration>())
     {
-        if (isPrimitiveIDSystemValueSemantic(semanticDecor->getSemanticName()))
+        if (semanticDecor->getSemanticName().caseInsensitiveEquals(toSlice("sv_primitiveid")))
             return true;
     }
 
@@ -97,7 +79,7 @@ static bool isPrimitiveIDSystemValueParam(IRParam* param)
     if (!systemValueAttr)
         return false;
 
-    return isPrimitiveIDSystemValueSemantic(systemValueAttr->getName());
+    return systemValueAttr->getName().caseInsensitiveEquals(toSlice("sv_primitiveid"));
 }
 
 static IRFunc* getHLSLPrimitiveIndexFunc(IRModule* module, IRFunc*& primitiveIndexFunc)
@@ -334,8 +316,15 @@ void legalizeRayTracingPrimitiveIDParamForHLSL(IRModule* module)
         if (!entryPointDecor)
             continue;
 
-        if (!isRayTracingHitStage(entryPointDecor->getProfile().getStage()))
+        switch (entryPointDecor->getProfile().getStage())
+        {
+        case Stage::Intersection:
+        case Stage::AnyHit:
+        case Stage::ClosestHit:
+            break;
+        default:
             continue;
+        }
 
         auto firstBlock = func->getFirstBlock();
         if (!firstBlock)

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -59,6 +59,66 @@ static void addRayPayloadDecorationIfNeeded(IRBuilder& builder, IRType* type)
         builder.addRayPayloadDecoration(type);
 }
 
+static bool isRayTracingHitStage(Stage stage)
+{
+    switch (stage)
+    {
+    case Stage::Intersection:
+    case Stage::AnyHit:
+    case Stage::ClosestHit:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool isPrimitiveIDSystemValueSemantic(UnownedStringSlice semanticName)
+{
+    return String(semanticName).toLower() == "sv_primitiveid";
+}
+
+static bool isPrimitiveIDSystemValueParam(IRParam* param)
+{
+    if (auto semanticDecor = param->findDecoration<IRSemanticDecoration>())
+    {
+        if (isPrimitiveIDSystemValueSemantic(semanticDecor->getSemanticName()))
+            return true;
+    }
+
+    auto layoutDecor = param->findDecoration<IRLayoutDecoration>();
+    if (!layoutDecor)
+        return false;
+
+    auto varLayout = as<IRVarLayout>(layoutDecor->getLayout());
+    if (!varLayout)
+        return false;
+
+    auto systemValueAttr = varLayout->findSystemValueSemanticAttr();
+    if (!systemValueAttr)
+        return false;
+
+    return isPrimitiveIDSystemValueSemantic(systemValueAttr->getName());
+}
+
+static IRFunc* getHLSLPrimitiveIndexFunc(IRModule* module, IRFunc*& primitiveIndexFunc)
+{
+    if (primitiveIndexFunc)
+        return primitiveIndexFunc;
+
+    IRBuilder builder(module);
+    builder.setInsertInto(module->getModuleInst());
+
+    primitiveIndexFunc = builder.createFunc();
+    builder.setDataType(
+        primitiveIndexFunc,
+        builder.getFuncType(0, nullptr, builder.getUIntType()));
+    builder.addTargetIntrinsicDecoration(
+        primitiveIndexFunc,
+        CapabilitySet(CapabilityName::hlsl),
+        UnownedTerminatedStringSlice("PrimitiveIndex"));
+    return primitiveIndexFunc;
+}
+
 void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* inst)
 {
     for (auto child : inst->getChildren())
@@ -258,6 +318,75 @@ void legalizeEmptyRayPayloadsForHLSL(IRModule* module)
             makeStructInst->replaceUsesWith(newMakeStruct);
             makeStructInst->removeAndDeallocate();
         }
+    }
+}
+
+void legalizeRayTracingPrimitiveIDParamForHLSL(IRModule* module)
+{
+    IRFunc* primitiveIndexFunc = nullptr;
+    List<IRFunc*> entryPointsToProcess;
+
+    for (auto globalInst : module->getGlobalInsts())
+    {
+        auto func = as<IRFunc>(globalInst);
+        if (!func)
+            continue;
+
+        auto entryPointDecor = func->findDecoration<IREntryPointDecoration>();
+        if (!entryPointDecor)
+            continue;
+
+        if (!isRayTracingHitStage(entryPointDecor->getProfile().getStage()))
+            continue;
+
+        auto firstBlock = func->getFirstBlock();
+        if (!firstBlock)
+            continue;
+
+        entryPointsToProcess.add(func);
+    }
+
+    for (auto func : entryPointsToProcess)
+    {
+        auto firstBlock = func->getFirstBlock();
+
+        IRBuilder builder(module);
+        builder.setInsertBefore(firstBlock->getFirstOrdinaryInst());
+
+        bool modifiedFuncType = false;
+        for (auto param = firstBlock->getFirstParam(); param;)
+        {
+            auto nextParam = param->getNextParam();
+
+            if (!isPrimitiveIDSystemValueParam(param))
+            {
+                param = nextParam;
+                continue;
+            }
+
+            if (param->hasUses())
+            {
+                auto primitiveIndexCall = builder.emitCallInst(
+                    builder.getUIntType(),
+                    getHLSLPrimitiveIndexFunc(module, primitiveIndexFunc),
+                    0,
+                    nullptr);
+
+                IRInst* replacement = primitiveIndexCall;
+                auto paramType = param->getFullType();
+                if (paramType != builder.getUIntType())
+                    replacement = builder.emitCast(paramType, primitiveIndexCall);
+
+                param->replaceUsesWith(replacement);
+            }
+
+            param->removeAndDeallocate();
+            modifiedFuncType = true;
+            param = nextParam;
+        }
+
+        if (modifiedFuncType)
+            fixUpFuncType(func);
     }
 }
 

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -109,9 +109,7 @@ static IRFunc* getHLSLPrimitiveIndexFunc(IRModule* module, IRFunc*& primitiveInd
     builder.setInsertInto(module->getModuleInst());
 
     primitiveIndexFunc = builder.createFunc();
-    builder.setDataType(
-        primitiveIndexFunc,
-        builder.getFuncType(0, nullptr, builder.getUIntType()));
+    builder.setDataType(primitiveIndexFunc, builder.getFuncType(0, nullptr, builder.getUIntType()));
     builder.addTargetIntrinsicDecoration(
         primitiveIndexFunc,
         CapabilitySet(CapabilityName::hlsl),

--- a/source/slang/slang-ir-hlsl-legalize.h
+++ b/source/slang/slang-ir-hlsl-legalize.h
@@ -16,4 +16,6 @@ void legalizeNonStructParameterToStructForHLSL(IRModule* module);
 
 void legalizeEmptyRayPayloadsForHLSL(IRModule* module);
 
+void legalizeRayTracingPrimitiveIDParamForHLSL(IRModule* module);
+
 } // namespace Slang

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -687,11 +687,25 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
 
         if (systemValueAttr)
         {
-            // TODO: is this needed?
             String semanticName = systemValueAttr->getName();
             semanticName = semanticName.toLower();
             if (semanticName == "sv_pointsize")
+            {
                 result = AddressSpace::BuiltinInput;
+            }
+            else if (semanticName == "sv_primitiveid" && result == AddressSpace::Generic)
+            {
+                switch (getReferencingEntryPointStage(varInst))
+                {
+                case Stage::Intersection:
+                case Stage::AnyHit:
+                case Stage::ClosestHit:
+                    result = AddressSpace::BuiltinInput;
+                    break;
+                default:
+                    break;
+                }
+            }
         }
 
         switch (result)

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2128,6 +2128,33 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     }
     else
     {
+        // Some system-value semantics are runtime-provided varyings rather than
+        // user-defined `in` parameters, so they should be allowed even in stages
+        // that otherwise reject `in` parameters or route `in` to hit attributes.
+        //
+        // Keep this allowlist matched to the semantic accessor table in
+        // core.meta.slang. Adding to it should be paired with a
+        // [require(<stage>)] entry on the semantic declaration and a regression
+        // test.
+        bool isAllowedRaytracingSystemValueInput = false;
+        if (state.optSemanticName)
+        {
+            auto sn = state.optSemanticName->toLower();
+            if (sn == "sv_primitiveid")
+            {
+                switch (state.stage)
+                {
+                case Stage::Intersection:
+                case Stage::AnyHit:
+                case Stage::ClosestHit:
+                    isAllowedRaytracingSystemValueInput = true;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
         switch (state.stage)
         {
         default:
@@ -2144,18 +2171,26 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
             // an `in` parameter as indicating a payload that the
             // programmer doesn't intend to write to.
             //
-            getSink(context)->diagnose(Diagnostics::DontExpectInParametersForStage{
-                .stage = getStageName(state.stage),
-                .location = state.loc});
+            if (!isAllowedRaytracingSystemValueInput)
+            {
+                getSink(context)->diagnose(Diagnostics::DontExpectInParametersForStage{
+                    .stage = getStageName(state.stage),
+                    .location = state.loc});
+            }
             break;
 
         case Stage::AnyHit:
         case Stage::ClosestHit:
-            // `in` parameter is hit attributes
-            return createTypeLayoutWith(
-                context->layoutContext,
-                context->getRulesFamily()->getHitAttributesParameterRules(),
-                type);
+            // `in` parameter is hit attributes. Allowed system-value inputs fall
+            // through to ordinary varying-input handling below.
+            if (!isAllowedRaytracingSystemValueInput)
+            {
+                return createTypeLayoutWith(
+                    context->layoutContext,
+                    context->getRulesFamily()->getHitAttributesParameterRules(),
+                    type);
+            }
+            break;
         }
     }
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
@@ -2,8 +2,7 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage anyhit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage anyhit -profile sm_6_5 -DNOMOTION
-//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage anyhit
-//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage anyhit
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -entry main_sv_primitiveid -stage anyhit
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage anyhit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -62,9 +61,6 @@
 
 // SVPID_SPIRV: OpEntryPoint AnyHitKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
-
-// SVPID_GLSL_SPIRV: OpEntryPoint AnyHitKHR
-// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
@@ -3,6 +3,7 @@
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage anyhit -profile sm_6_5 -DNOMOTION
 //TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage anyhit
+//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage anyhit
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage anyhit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -61,6 +62,9 @@
 
 // SVPID_SPIRV: OpEntryPoint AnyHitKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_GLSL_SPIRV: OpEntryPoint AnyHitKHR
+// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang
@@ -2,6 +2,8 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage anyhit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage anyhit -profile sm_6_5 -DNOMOTION
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage anyhit
+//TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage anyhit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
 // SPIRV-DAG: RayTracingKHR
@@ -28,7 +30,7 @@
 
 // SPIRV-DAG: OpTypePointer HitAttribute{{NV|KHR}}
 // SPIRV-DAG: OpTypePointer IncomingRayPayload{{NV|KHR}}
- 
+
 // SPIRV-DAG: OpTerminateRayKHR
 // SPIRV-DAG: OpIgnoreIntersectionKHR
 
@@ -56,6 +58,11 @@
 
 // DXIL: call void @dx.op.acceptHitAndEndSearch
 // DXIL: call void @dx.op.ignoreHit
+
+// SVPID_SPIRV: OpEntryPoint AnyHitKHR
+// SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 
 
 struct RayPayload
@@ -205,4 +212,17 @@ void main( inout RayPayload payload, in BuiltInTriangleIntersectionAttributes at
     }
 
     payload.RayHitT = val;
+}
+
+[shader("anyhit")]
+void main_sv_primitiveid(
+    inout RayPayload payload,
+    in BuiltInTriangleIntersectionAttributes attribs: SV_IntersectionAttributes,
+    uint primitiveID : SV_PrimitiveID)
+{
+    float3 barycentrics = float3(
+        1.0 - attribs.barycentrics.x - attribs.barycentrics.y,
+        attribs.barycentrics.x,
+        attribs.barycentrics.y);
+    payload.RayHitT = float(primitiveID) + barycentrics.x + barycentrics.y + barycentrics.z;
 }

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -2,6 +2,8 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage closesthit
+//TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage closesthit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
 // SPIRV-DAG: RayTracingKHR
@@ -63,6 +65,11 @@
 // DXIL: call i32 @dx.op.hitKind.i32
 
 // DXIL: call void @dx.op.callShader.struct.CallableParams_0
+
+// SVPID_SPIRV: OpEntryPoint ClosestHitKHR
+// SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 
 
 [[vk::binding(0)]]
@@ -284,4 +291,17 @@ void main( inout RayPayload payload, in BuiltInTriangleIntersectionAttributes at
     val += params.value;
 
     payload.RayHitT = val;
+}
+
+[shader("closesthit")]
+void main_sv_primitiveid(
+    inout RayPayload payload,
+    in BuiltInTriangleIntersectionAttributes attribs,
+    uint primitiveID : SV_PrimitiveID)
+{
+    float3 barycentrics = float3(
+        1.0 - attribs.barycentrics.x - attribs.barycentrics.y,
+        attribs.barycentrics.x,
+        attribs.barycentrics.y);
+    payload.RayHitT = float(primitiveID) + barycentrics.x + barycentrics.y + barycentrics.z;
 }

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -2,8 +2,7 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
-//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage closesthit
-//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage closesthit
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -entry main_sv_primitiveid -stage closesthit
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage closesthit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -69,9 +68,6 @@
 
 // SVPID_SPIRV: OpEntryPoint ClosestHitKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
-
-// SVPID_GLSL_SPIRV: OpEntryPoint ClosestHitKHR
-// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -3,6 +3,7 @@
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
 //TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage closesthit
+//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage closesthit
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage closesthit -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -68,6 +69,9 @@
 
 // SVPID_SPIRV: OpEntryPoint ClosestHitKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_GLSL_SPIRV: OpEntryPoint ClosestHitKHR
+// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
@@ -2,8 +2,7 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage intersection
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage intersection -profile sm_6_5 -DNOMOTION
-//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage intersection
-//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage intersection
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -entry main_sv_primitiveid -stage intersection
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage intersection -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -58,9 +57,6 @@
 
 // SVPID_SPIRV: OpEntryPoint IntersectionKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
-
-// SVPID_GLSL_SPIRV: OpEntryPoint IntersectionKHR
-// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 // SVPID_DXIL: call i1 @dx.op.reportHit.struct.MyAttributes_0

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
@@ -2,6 +2,8 @@
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage intersection
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage intersection -profile sm_6_5 -DNOMOTION
+//TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage intersection
+//TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage intersection -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
 // SPIRV-DAG: OpCapability RayTracingKHR
@@ -52,6 +54,12 @@
 // DXIL: call float @dx.op.worldToObject.f32
 
 // DXIL: call i1 @dx.op.reportHit.struct.MyAttributes_0
+
+// SVPID_SPIRV: OpEntryPoint IntersectionKHR
+// SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
+// SVPID_DXIL: call i1 @dx.op.reportHit.struct.MyAttributes_0
 
 float CheckRayDispatchValues() // all
 {
@@ -194,4 +202,12 @@ void main()
             ReportHit( (rayTMin <= t1 && t1 < rayTMax) ? t1 : t2, 0, IDs );
         }
     }
+}
+
+[shader("intersection")]
+void main_sv_primitiveid(uint primitiveID : SV_PrimitiveID)
+{
+    MyAttributes IDs;
+    IDs.attr = float(primitiveID);
+    ReportHit(1.0f, 0, IDs);
 }

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang
@@ -3,6 +3,7 @@
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage intersection -profile sm_6_5 -DNOMOTION
 //TEST:SIMPLE(filecheck=SVPID_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_sv_primitiveid -stage intersection
+//TEST:SIMPLE(filecheck=SVPID_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_sv_primitiveid -stage intersection
 //TEST:SIMPLE(filecheck=SVPID_DXIL):-target dxil-assembly -entry main_sv_primitiveid -stage intersection -profile sm_6_5 -DNOMOTION
 
 // SPIRV-NOT: OpCapability RayQueryKHR
@@ -57,6 +58,9 @@
 
 // SVPID_SPIRV: OpEntryPoint IntersectionKHR
 // SVPID_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
+
+// SVPID_GLSL_SPIRV: OpEntryPoint IntersectionKHR
+// SVPID_GLSL_SPIRV-DAG: OpDecorate %{{.*}} BuiltIn PrimitiveId
 
 // SVPID_DXIL: call i32 @dx.op.primitiveIndex.i32
 // SVPID_DXIL: call i1 @dx.op.reportHit.struct.MyAttributes_0

--- a/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
@@ -1,12 +1,9 @@
 // Regression test for #11197: SV_PrimitiveID is allowed in intersection,
 // any-hit, and closest-hit stages.
 
-//TEST:SIMPLE(filecheck=ISECT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_isect -stage intersection
-//TEST:SIMPLE(filecheck=AHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_ahit -stage anyhit
-//TEST:SIMPLE(filecheck=CHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_chit -stage closesthit
-//TEST:SIMPLE(filecheck=ISECT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_isect -stage intersection
-//TEST:SIMPLE(filecheck=AHIT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_ahit -stage anyhit
-//TEST:SIMPLE(filecheck=CHIT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_chit -stage closesthit
+//TEST:SIMPLE(filecheck=ISECT_SPIRV):-target spirv-assembly -entry main_isect -stage intersection
+//TEST:SIMPLE(filecheck=AHIT_SPIRV):-target spirv-assembly -entry main_ahit -stage anyhit
+//TEST:SIMPLE(filecheck=CHIT_SPIRV):-target spirv-assembly -entry main_chit -stage closesthit
 
 struct Payload
 {
@@ -25,12 +22,9 @@ void main_isect(int pid : SV_PrimitiveID)
     ReportHit<Attribs>(1.0, 0, attr);
 }
 
+// ISECT_SPIRV: OpEntryPoint IntersectionKHR
 // ISECT_SPIRV: BuiltIn PrimitiveId
 // ISECT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
-
-// ISECT_GLSL_SPIRV: OpEntryPoint IntersectionKHR
-// ISECT_GLSL_SPIRV: BuiltIn PrimitiveId
-// ISECT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 
 [shader("anyhit")]
 void main_ahit(inout Payload payload, int pid : SV_PrimitiveID)
@@ -38,14 +32,10 @@ void main_ahit(inout Payload payload, int pid : SV_PrimitiveID)
     payload.val = float(pid);
 }
 
+// AHIT_SPIRV: OpEntryPoint AnyHitKHR
 // AHIT_SPIRV: BuiltIn PrimitiveId
 // AHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 // AHIT_SPIRV-NOT: OpTypePointer HitAttribute
-
-// AHIT_GLSL_SPIRV: OpEntryPoint AnyHitKHR
-// AHIT_GLSL_SPIRV: BuiltIn PrimitiveId
-// AHIT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
-// AHIT_GLSL_SPIRV-NOT: OpTypePointer HitAttribute
 
 [shader("closesthit")]
 void main_chit(inout Payload payload, int pid : SV_PrimitiveID)
@@ -53,11 +43,7 @@ void main_chit(inout Payload payload, int pid : SV_PrimitiveID)
     payload.val = float(pid);
 }
 
+// CHIT_SPIRV: OpEntryPoint ClosestHitKHR
 // CHIT_SPIRV: BuiltIn PrimitiveId
 // CHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 // CHIT_SPIRV-NOT: OpTypePointer HitAttribute
-
-// CHIT_GLSL_SPIRV: OpEntryPoint ClosestHitKHR
-// CHIT_GLSL_SPIRV: BuiltIn PrimitiveId
-// CHIT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
-// CHIT_GLSL_SPIRV-NOT: OpTypePointer HitAttribute

--- a/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
@@ -1,0 +1,46 @@
+// Regression test for #11197: SV_PrimitiveID is allowed in intersection,
+// any-hit, and closest-hit stages.
+
+//TEST:SIMPLE(filecheck=ISECT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_isect -stage intersection
+//TEST:SIMPLE(filecheck=AHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_ahit -stage anyhit
+//TEST:SIMPLE(filecheck=CHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_chit -stage closesthit
+
+struct Payload
+{
+    float val;
+};
+
+struct Attribs
+{
+    float v;
+};
+
+[shader("intersection")]
+void main_isect(int pid : SV_PrimitiveID)
+{
+    Attribs attr = { float(pid) };
+    ReportHit<Attribs>(1.0, 0, attr);
+}
+
+// ISECT_SPIRV: BuiltIn PrimitiveId
+// ISECT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+
+[shader("anyhit")]
+void main_ahit(inout Payload payload, int pid : SV_PrimitiveID)
+{
+    payload.val = float(pid);
+}
+
+// AHIT_SPIRV: BuiltIn PrimitiveId
+// AHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+// AHIT_SPIRV-NOT: OpTypePointer HitAttribute
+
+[shader("closesthit")]
+void main_chit(inout Payload payload, int pid : SV_PrimitiveID)
+{
+    payload.val = float(pid);
+}
+
+// CHIT_SPIRV: BuiltIn PrimitiveId
+// CHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+// CHIT_SPIRV-NOT: OpTypePointer HitAttribute

--- a/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang
@@ -4,6 +4,9 @@
 //TEST:SIMPLE(filecheck=ISECT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_isect -stage intersection
 //TEST:SIMPLE(filecheck=AHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_ahit -stage anyhit
 //TEST:SIMPLE(filecheck=CHIT_SPIRV):-target spirv-assembly -emit-spirv-directly -entry main_chit -stage closesthit
+//TEST:SIMPLE(filecheck=ISECT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_isect -stage intersection
+//TEST:SIMPLE(filecheck=AHIT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_ahit -stage anyhit
+//TEST:SIMPLE(filecheck=CHIT_GLSL_SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry main_chit -stage closesthit
 
 struct Payload
 {
@@ -25,6 +28,10 @@ void main_isect(int pid : SV_PrimitiveID)
 // ISECT_SPIRV: BuiltIn PrimitiveId
 // ISECT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 
+// ISECT_GLSL_SPIRV: OpEntryPoint IntersectionKHR
+// ISECT_GLSL_SPIRV: BuiltIn PrimitiveId
+// ISECT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+
 [shader("anyhit")]
 void main_ahit(inout Payload payload, int pid : SV_PrimitiveID)
 {
@@ -35,6 +42,11 @@ void main_ahit(inout Payload payload, int pid : SV_PrimitiveID)
 // AHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 // AHIT_SPIRV-NOT: OpTypePointer HitAttribute
 
+// AHIT_GLSL_SPIRV: OpEntryPoint AnyHitKHR
+// AHIT_GLSL_SPIRV: BuiltIn PrimitiveId
+// AHIT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+// AHIT_GLSL_SPIRV-NOT: OpTypePointer HitAttribute
+
 [shader("closesthit")]
 void main_chit(inout Payload payload, int pid : SV_PrimitiveID)
 {
@@ -44,3 +56,8 @@ void main_chit(inout Payload payload, int pid : SV_PrimitiveID)
 // CHIT_SPIRV: BuiltIn PrimitiveId
 // CHIT_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
 // CHIT_SPIRV-NOT: OpTypePointer HitAttribute
+
+// CHIT_GLSL_SPIRV: OpEntryPoint ClosestHitKHR
+// CHIT_GLSL_SPIRV: BuiltIn PrimitiveId
+// CHIT_GLSL_SPIRV: %{{.*}} = OpVariable %_ptr_Input_int Input
+// CHIT_GLSL_SPIRV-NOT: OpTypePointer HitAttribute


### PR DESCRIPTION
Fixes shader-slang/slang#11197

## Summary of the problem from the end user perspective

`SV_PrimitiveID` was rejected as an input to intersection shaders, even though ray-tracing users need the primitive ID to index per-primitive data. The same semantic should also work in any-hit and closest-hit stages.

### Minimal repro shader; if applicable

```slang
[shader("intersection")]
void main(int primitiveId : SV_PrimitiveID)
{
    Attributes attr = {};
    ReportHit<Attributes>(1, 0, attr);
}
```

## Root cause

The `sv_primitiveid` semantic accessor table only allowed rasterization stages, and ray-tracing parameter binding treated `in` parameters as either invalid or hit attributes before system-value lowering could handle them. Once the front-end gates were opened, SPIR-V also needed to classify ray-tracing `SV_PrimitiveID` as a builtin input instead of private storage. The native HLSL/DXIL path also cannot expose `SV_PrimitiveID` as a ray-tracing entry-point parameter directly because DXR exposes the same value through `PrimitiveIndex()`.

## Solution in this PR

Allow `SV_PrimitiveID` input access in intersection, any-hit, and closest-hit stages, and narrowly bypass ray-tracing hit-attribute routing for that system value. Direct SPIR-V legalization emits it as an `Input` `PrimitiveId` builtin, and the SPIR-V-via-GLSL path now routes it through GLSL system-value legalization so glslang emits the same builtin input. For HLSL/DXIL, a target legalization pass removes the ray-tracing entry-point parameter and replaces uses with the native `PrimitiveIndex()` intrinsic before HLSL emission.

### Notes to the reviewers; where to focus on

The parameter-binding allowlist intentionally matches the new semantic accessor stages exactly. The regression test checks all three ray-tracing hit stages and asserts that any-hit and closest-hit do not route `SV_PrimitiveID` through `HitAttribute` storage. The existing ray-tracing intrinsic tests now also cover `SV_PrimitiveID` entry parameters for direct SPIR-V, SPIR-V via GLSL, and DXIL.

Additional reviewer context:

- For SPIR-V, `SPV_KHR_ray_tracing` extends the `PrimitiveId` built-in so it is valid in `IntersectionKHR`, `AnyHitKHR`, and `ClosestHitKHR` execution models under `RayTracingKHR`.
- For native HLSL/DXR, the equivalent value is exposed as the `PrimitiveIndex()` system-value intrinsic in these stages. This PR makes Slang accept the HLSL-style `SV_PrimitiveID` semantic for those ray-tracing stages and lower it to the correct target representation on direct SPIR-V, SPIR-V via GLSL, and HLSL/DXIL paths.

## Validation

- `cmake.exe --build --preset debug --target slangc slang-test` - passed.
- `build/Debug/bin/slang-test.exe -skip-api-detection -v info tests/hlsl-intrinsic/ray-tracing/sv-primitiveid-raytracing.slang tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-int.slang tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-ahit.slang tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang` - 18/18 passed.
- Manual compile checks for `rt-pipeline-intrinsics-ahit.slang` `main_sv_primitiveid` passed with both `-emit-spirv-directly` and `-emit-spirv-via-glsl`.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Keep the new `SV_PrimitiveID` SPIR-V test directives unqualified by explicit `-emit-spirv-directly` or `-emit-spirv-via-glsl`; the CI/test matrix covers both SPIR-V emission paths. (https://github.com/jkwak-work/slang/pull/218#discussion_r3337735600)

## Related PRs in the past

- shader-slang/slang#11202 covered the same issue and helped identify the two front-end gates.
