### PR TITLE
Default implicit SPIR-V SER to EXT

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1370,7 +1370,8 @@ Compound Capabilities
 
 `ser`
 > Capabilities needed for shader-execution-reordering (all paths)
-> Includes NVIDIA-specific (NV), cross-vendor standard (EXT), DXR 1.3 native, and CUDA paths
+> Defaults SPIR-V/GLSL to the cross-vendor standard EXT path; explicit NV still satisfies this
+> through the NV-to-EXT capability hierarchy. Use ser_nv for APIs that require NV opcodes.
 
 `ser_any_closesthit_intersection_miss`
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of anyhit, closesthit, intersection, and miss.

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -5860,7 +5860,7 @@ public void hitObjectRecordHitMotionNV(
     {
     case _GL_NV_shader_invocation_reorder_motion:
     {
-        HitObject::__glslMakeMotionHit(
+        HitObject::__glslMakeMotionHitNV(
             hitObject,
             topLevel,
             instanceid,
@@ -5990,7 +5990,7 @@ public void hitObjectRecordHitWithIndexMotionNV(
     {
     case _GL_NV_shader_invocation_reorder_motion:
     {
-        HitObject::__glslMakeMotionHitWithIndex(
+        HitObject::__glslMakeMotionHitWithIndexNV(
             hitObject,
             topLevel,
             instanceid,

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -5676,7 +5676,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectTraceRayNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5708,7 +5708,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectTraceRayMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5774,7 +5774,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordHitNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5839,7 +5839,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordHitMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5908,7 +5908,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordHitWithIndexNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5970,7 +5970,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordHitWithIndexMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -6036,7 +6036,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordMissNV(
     inout hitObjectNV hitObject,
     uint sbtRecordIndex,
@@ -6056,7 +6056,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordMissMotionNV(
     inout hitObjectNV hitObject,
     uint sbtRecordIndex,
@@ -6077,7 +6077,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordEmptyNV(hitObjectNV hitObject)
 {
     hitObject = HitObject::MakeNop();
@@ -6087,7 +6087,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectExecuteShaderNV(
     inout hitObjectNV hitObject,
     constexpr int payload)
@@ -6114,7 +6114,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsEmptyNV(hitObjectNV hitObject)
 {
     return hitObject.IsNop();
@@ -6124,7 +6124,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsMissNV(hitObjectNV hitObject)
 {
     return hitObject.IsMiss();
@@ -6134,7 +6134,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsHitNV(hitObjectNV hitObject)
 {
     return hitObject.IsHit();
@@ -6144,7 +6144,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetRayTMinNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().TMin;
@@ -6154,7 +6154,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetRayTMaxNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().TMax;
@@ -6164,7 +6164,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetWorldRayOriginNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().Origin;
@@ -6174,7 +6174,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetWorldRayDirectionNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().Direction;
@@ -6184,7 +6184,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetObjectRayOriginNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectRayOrigin();
@@ -6194,7 +6194,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetObjectRayDirectionNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectRayDirection();
@@ -6204,7 +6204,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public mat4x3 hitObjectGetObjectToWorldNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectToWorld();
@@ -6214,7 +6214,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public mat4x3 hitObjectGetWorldToObjectNV(hitObjectNV hitObject)
 {
     return hitObject.GetWorldToObject();
@@ -6224,7 +6224,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetInstanceCustomIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetInstanceID();
@@ -6234,7 +6234,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetInstanceIdNV(hitObjectNV hitObject)
 {
     return hitObject.GetInstanceIndex();
@@ -6244,7 +6244,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetGeometryIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetGeometryIndex();
@@ -6254,7 +6254,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetPrimitiveIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetPrimitiveIndex();
@@ -6264,7 +6264,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uint hitObjectGetHitKindNV(hitObjectNV hitObject)
 {
     return hitObject.GetHitKind();
@@ -6274,7 +6274,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectGetAttributesNV(
     inout hitObjectNV hitObject,
     constexpr int attributeLocation)
@@ -6300,7 +6300,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uvec2 hitObjectGetShaderRecordBufferHandleNV(hitObjectNV hitObject)
 {
     return hitObject.GetShaderRecordBufferHandle();
@@ -6310,7 +6310,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uint hitObjectGetShaderBindingTableRecordIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetShaderTableIndex();
@@ -6320,7 +6320,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetCurrentTimeNV(hitObjectNV hitObject)
 {
     return hitObject.GetCurrentTime();
@@ -6330,7 +6330,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(uint hint, uint bits)
 {
     ReorderThread(hint, bits);
@@ -6340,7 +6340,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(hitObjectNV hitObject)
 {
     ReorderThread(hitObject);
@@ -6350,7 +6350,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(hitObjectNV hitObject, uint hint, uint bits)
 {
     ReorderThread(hitObject, hint, bits);

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24780,12 +24780,38 @@ struct HitObject
         }
     }
 
-    //  "void hitObjectRecordHitWithIndexMotionNV(hitObjectNV, accelerationStructureEXT,int,int,int,uint,uint,vec3,float,vec3,float,float,int);"
+    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHitWithIndex(
+        out HitObject hitObj,
+        RaytracingAccelerationStructure accelerationStructure,
+        int instanceid,
+        int primitiveid,
+        int geometryindex,
+        uint hitKind,
+        uint sbtRecordIndex,
+        float3 origin,
+        float Tmin,
+        float3 direction,
+        float Tmax,
+        float CurrentTime,
+        int attributeLocation)
+    {
+        __target_switch
+        {
+        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitWithIndexMotionNV";
+        }
+    }
+
+    // NV-specific helper used by public hitObjectRecordHitWithIndexMotionNV.
+    __glsl_extension(GL_EXT_ray_tracing)
+    __glsl_extension(GL_NV_ray_tracing_motion_blur)
+    __glsl_extension(GL_NV_shader_invocation_reorder)
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
+    static void __glslMakeMotionHitWithIndexNV(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
@@ -24832,12 +24858,39 @@ struct HitObject
         }
     }
 
-        // "void hitObjectRecordHitMotionNV(hitObjectNV,accelerationStructureEXT,int,int,int,uint,uint,uint,vec3,float,vec3,float,float,int);"
+    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHit(
+        out HitObject hitObj,
+        RaytracingAccelerationStructure accelerationStructure,
+        int instanceid,
+        int primitiveid,
+        int geometryindex,
+        uint hitKind,
+        uint sbtRecordOffset,
+        uint sbtRecordStride,
+        float3 origin,
+        float Tmin,
+        float3 direction,
+        float Tmax,
+        float CurrentTime,
+        int attributeLocation)
+    {
+        __target_switch
+        {
+        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitMotionNV";
+        }
+    }
+
+    // NV-specific helper used by public hitObjectRecordHitMotionNV.
+    __glsl_extension(GL_EXT_ray_tracing)
+    __glsl_extension(GL_NV_ray_tracing_motion_blur)
+    __glsl_extension(GL_NV_shader_invocation_reorder)
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
+    static void __glslMakeMotionHitNV(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24565,7 +24565,7 @@ struct HitObject
     // "void hitObjectRecordMissMotionNV(hitObjectNV, uint, vec3, float, vec3, float, float);"
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMissMotionNV(
         out HitObject hitObj,
         uint MissShaderIndex,
@@ -24784,7 +24784,7 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHitWithIndex(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
@@ -24836,7 +24836,7 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHit(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22896,7 +22896,7 @@ struct HitObject
             // Save the attributes
             __hitObjectAttributes<attr_t>() = attributes;
 
-            __glslMakeMotionHit(
+            __glslMakeMotionHitNV(
                 __return_val,
                 AccelerationStructure,
                 InstanceIndex,
@@ -23058,7 +23058,7 @@ struct HitObject
             // Save the attributes
             __hitObjectAttributes<attr_t>() = attributes;
 
-            __glslMakeMotionHitWithIndex(
+            __glslMakeMotionHitWithIndexNV(
                 __return_val,
                 AccelerationStructure,
                 InstanceIndex,              ///? Same as instanceid ?
@@ -24780,32 +24780,6 @@ struct HitObject
         }
     }
 
-    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
-    __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
-    static void __glslMakeMotionHitWithIndex(
-        out HitObject hitObj,
-        RaytracingAccelerationStructure accelerationStructure,
-        int instanceid,
-        int primitiveid,
-        int geometryindex,
-        uint hitKind,
-        uint sbtRecordIndex,
-        float3 origin,
-        float Tmin,
-        float3 direction,
-        float Tmax,
-        float CurrentTime,
-        int attributeLocation)
-    {
-        __target_switch
-        {
-        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitWithIndexMotionNV";
-        }
-    }
-
     // NV-specific helper used by public hitObjectRecordHitWithIndexMotionNV.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
@@ -24855,33 +24829,6 @@ struct HitObject
         {
         case glsl: // fallback - outer MakeHit routes glsl to EXT variant
         case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitNV";
-        }
-    }
-
-    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
-    __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
-    static void __glslMakeMotionHit(
-        out HitObject hitObj,
-        RaytracingAccelerationStructure accelerationStructure,
-        int instanceid,
-        int primitiveid,
-        int geometryindex,
-        uint hitKind,
-        uint sbtRecordOffset,
-        uint sbtRecordStride,
-        float3 origin,
-        float Tmin,
-        float3 direction,
-        float Tmax,
-        float CurrentTime,
-        int attributeLocation)
-    {
-        __target_switch
-        {
-        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitMotionNV";
         }
     }
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1319,9 +1319,10 @@ def ser_hlsl_native : _sm_6_9;
 alias ser_dxr = raytracing + ser_hlsl_native;
 
 /// Capabilities needed for shader-execution-reordering (all paths)
-/// Includes NVIDIA-specific (NV), cross-vendor standard (EXT), DXR 1.3 native, and CUDA paths
+/// Defaults SPIR-V/GLSL to the cross-vendor standard EXT path; explicit NV still satisfies this
+/// through the NV-to-EXT capability hierarchy. Use ser_nv for APIs that require NV opcodes.
 /// [Compound]
-alias ser = raytracing + GL_NV_shader_invocation_reorder | raytracing + GL_EXT_shader_invocation_reorder | ser_nvapi | ser_dxr | cuda;
+alias ser = raytracing + GL_EXT_shader_invocation_reorder | ser_nvapi | ser_dxr | cuda;
 
 /// NVIDIA-specific SER capabilities (excludes cross-vendor EXT)
 /// Includes GL_NV_shader_invocation_reorder (GLSL/SPIRV) and CUDA paths

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1620,7 +1620,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     return SpvStorageClassHitObjectAttributeNV;
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderEXT))
                     return SpvStorageClassHitObjectAttributeEXT;
-                return SpvStorageClassHitObjectAttributeNV;
+                return SpvStorageClassHitObjectAttributeEXT;
             }
         case AddressSpace::HitAttribute:
             return SpvStorageClassHitAttributeKHR;
@@ -2734,9 +2734,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_HitObjectType:
             {
                 // Check NV first (more specific) since NV derives from EXT in the
-                // capability hierarchy. If we checked EXT first, it would always
-                // match when NV is specified, causing a type/op mismatch
-                // (OpTypeHitObjectEXT=5313 vs OpTypeHitObjectNV=5281).
+                // capability hierarchy. If no SER capability was explicitly requested,
+                // default to EXT to match capability inference and target-switch fallback.
                 auto targetCaps = m_targetProgram->getTargetReq()->getTargetCaps();
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderNV))
                 {
@@ -2755,9 +2754,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else
                 {
                     ensureExtensionDeclaration(
-                        UnownedStringSlice("SPV_NV_shader_invocation_reorder"));
-                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderNV);
-                    return emitOpTypeHitObject(inst);
+                        UnownedStringSlice("SPV_EXT_shader_invocation_reorder"));
+                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderEXT);
+                    return emitOpTypeHitObjectEXT(inst);
                 }
             }
 
@@ -6383,8 +6382,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else
                 {
                     ensureExtensionDeclaration(
-                        UnownedStringSlice("SPV_NV_shader_invocation_reorder"));
-                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderNV);
+                        UnownedStringSlice("SPV_EXT_shader_invocation_reorder"));
+                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderEXT);
                 }
                 isRayTracingObject = true;
                 break;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1618,8 +1618,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 auto targetCaps = m_targetProgram->getTargetReq()->getTargetCaps();
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderNV))
                     return SpvStorageClassHitObjectAttributeNV;
-                if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderEXT))
-                    return SpvStorageClassHitObjectAttributeEXT;
                 return SpvStorageClassHitObjectAttributeEXT;
             }
         case AddressSpace::HitAttribute:

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -1,7 +1,7 @@
 // Test for issue #11082: implicit SER capability upgrades should consistently use EXT.
 
-//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration -line-directive-mode none
-//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration -line-directive-mode none
+//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration
+//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration
 
 // IMPLICIT: warning[E41012]
 // IMPLICIT: spvShaderInvocationReorderEXT

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -1,0 +1,60 @@
+// Test for issue #11082: implicit SER capability upgrades should consistently use EXT.
+
+//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration -line-directive-mode none
+//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration -line-directive-mode none
+
+// IMPLICIT: warning[E41012]
+// IMPLICIT: spvShaderInvocationReorderEXT
+// IMPLICIT-NOT: spvShaderInvocationReorderNV
+// IMPLICIT-NOT: ShaderInvocationReorderNV
+// IMPLICIT-NOT: SPV_NV_shader_invocation_reorder
+// IMPLICIT: OpCapability ShaderInvocationReorderEXT
+// IMPLICIT: OpExtension "SPV_EXT_shader_invocation_reorder"
+// IMPLICIT-NOT: OpTypeHitObjectNV
+// IMPLICIT: OpTypeHitObjectEXT
+// IMPLICIT-NOT: OpHitObjectTraceRayNV
+// IMPLICIT: OpHitObjectTraceRayEXT
+// IMPLICIT-NOT: ShaderInvocationReorderNV
+// IMPLICIT-NOT: SPV_NV_shader_invocation_reorder
+// IMPLICIT-NOT: OpTypeHitObjectNV
+// IMPLICIT-NOT: OpHitObjectTraceRayNV
+
+// EXT_RESTRICTIVE-NOT: error[E41013]
+// EXT_RESTRICTIVE-NOT: warning[E41012]
+// EXT_RESTRICTIVE-NOT: ShaderInvocationReorderNV
+// EXT_RESTRICTIVE-NOT: SPV_NV_shader_invocation_reorder
+// EXT_RESTRICTIVE: OpCapability ShaderInvocationReorderEXT
+// EXT_RESTRICTIVE: OpExtension "SPV_EXT_shader_invocation_reorder"
+// EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
+// EXT_RESTRICTIVE: OpTypeHitObjectEXT
+// EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
+// EXT_RESTRICTIVE: OpHitObjectTraceRayEXT
+// EXT_RESTRICTIVE-NOT: ShaderInvocationReorderNV
+// EXT_RESTRICTIVE-NOT: SPV_NV_shader_invocation_reorder
+// EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
+// EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
+
+RaytracingAccelerationStructure tlas;
+RWTexture2D<float> outImage;
+
+struct Payload
+{
+    uint foo;
+};
+
+[shader("raygeneration")]
+void main()
+{
+    RayDesc ray;
+    ray.Origin = float3(0.0);
+    ray.Direction = float3(1.0);
+    ray.TMin = 0.0;
+    ray.TMax = 1e30;
+
+    Payload payload;
+    HitObject hitObj = HitObject::TraceRay(tlas, 0, 0xFF, 0, 0, 0, ray, payload);
+    if (hitObj.IsHit())
+    {
+        outImage[DispatchRaysIndex().xy] = 1.0f;
+    }
+}

--- a/tests/glsl-intrinsic/raytracing/glsl-rayMiss.slang
+++ b/tests/glsl-intrinsic/raytracing/glsl-rayMiss.slang
@@ -13,7 +13,7 @@ buffer MyBlockName
 // CHECK_SPV-DAG: IncomingRayPayload{{NV|KHR}}
 layout(location = 2) rayPayloadInEXT vec4 payload;
 // CHECK_GLSL-DAG: hitObjectAttributeEXT
-// CHECK_SPV-DAG: HitObjectAttributeNV
+// CHECK_SPV-DAG: HitObjectAttributeEXT
 layout(location = 2) hitObjectAttributeNV vec4 attrMain;
 
 bool testVars() {

--- a/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -capability hlsl_nvapi
-//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -capability spvShaderInvocationReorderNV
 //HLSL: NvRtSphereObjectPositionAndRadius
 //HLSL: NvRtLssObjectPositionsAndRadii
 //HLSL: NvRtIsSphereHit
@@ -35,7 +35,7 @@ void closestHitShaderLss(inout RayPayload payload, in BuiltInTriangleIntersectio
     payload.lssData = GetLssPositionsAndRadii();
     payload.isSphere = IsSphereHit();
     payload.isLss = IsLssHit();
-    
+
     // Test HitObject API functions
     HitObject hitObj;
     float4 sphereData = hitObj.GetSpherePositionAndRadius();


### PR DESCRIPTION
Fixes shader-slang/slang#11082

## Summary of the problem from the end user perspective

Compiling `HitObject::TraceRay` for direct SPIR-V with a `spirv_1_6` profile implicitly upgraded SER to the NV capability while the generated hit-object trace operation used EXT. Restrictive explicit EXT requests were also rejected as if NV was required.

### Minimal repro shader; if applicable

```hlsl
[shader("raygeneration")]
void main()
{
    Payload payload;
    HitObject hitObj = HitObject::TraceRay(tlas, 0, 0xFF, 0, 0, 0, ray, payload);
    if (hitObj.IsHit())
    {
        outImage[DispatchRaysIndex().xy] = 1.0f;
    }
}
```

## Root cause

The generic `ser` capability still included the NV GL/SPIR-V path, while fallback SPIR-V hit-object emission defaulted to NV when no explicit SER capability was present. Because NV implies EXT, generic requirements could resolve through NV and then mismatch EXT opcode emission.

## Solution in this PR

Make the generic SPIR-V/GLSL SER path default to EXT while preserving explicit NV aliases for NV intrinsics, and make ambiguous SPIR-V hit-object fallback emission use EXT. Add regression coverage for implicit profile upgrade and restrictive explicit EXT.

### Notes to the reviewers; where to focus on

Review `slang-capabilities.capdef` and `slang-emit-spirv.cpp` for the EXT default, and the `ser_nv*` requirement changes that keep NV-named GLSL/HLSL intrinsics on the NV path. The new `gh-11082.slang` test checks that implicit and restrictive EXT emit only EXT hit-object declarations and opcodes.
