### PR TITLE
Fix generic vector constructor prelinking

### DIFF
--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -8,6 +8,7 @@ void IRDeduplicationContext::init(IRModule* module)
     m_session = module->getSession();
 
     m_globalValueNumberingMap.clear();
+    m_scopedGlobalValueNumberingMap.clear();
     m_constantMap.clear();
 }
 

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -851,7 +851,6 @@ void cloneGlobalValueWithCodeCommon(
 
     cloneDecorations(context, clonedValue, originalValue);
     cloneExtraDecorations(context, clonedValue, originalValues);
-    clonedValue->setFullType((IRType*)cloneValue(context, originalValue->getFullType()));
 
     // We will walk through the blocks of the function, and clone each of them.
     //
@@ -926,6 +925,10 @@ void cloneGlobalValueWithCodeCommon(
             cb = cb->getNextBlock();
         }
     }
+
+    // The full type can reference params that are registered while cloning the blocks above.
+    // Cloning it earlier can leave hoistable types pointing at sibling generic clones.
+    clonedValue->setFullType((IRType*)cloneValue(context, originalValue->getFullType()));
 }
 
 void checkIRDuplicate(IRInst* inst, IRInst* moduleInst, UnownedStringSlice const& mangledName)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2722,28 +2722,40 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         // If it's found, just return, and throw away the instruction
         if (found)
         {
-            memoryArena.rewindToCursor(cursor);
-
-            // If the found inst is defined in the same parent as current insert location but
-            // is located after the insert location, we need to move it to the insert location.
             auto foundInst = *found;
-            if (foundInst->getParent() && foundInst->getParent() == getInsertLoc().getParent() &&
-                getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+            auto foundGeneric = findOuterGeneric(foundInst);
+            auto insertGeneric = findOuterGeneric(getInsertLoc().getParent());
+            if (foundGeneric && foundGeneric != insertGeneric)
             {
-                auto insertLoc = getInsertLoc().getInst();
-                bool isAfter = false;
-                for (auto cur = insertLoc->next; cur; cur = cur->next)
-                {
-                    if (cur == foundInst)
-                    {
-                        isAfter = true;
-                        break;
-                    }
-                }
-                if (isAfter)
-                    foundInst->insertBefore(insertLoc);
+                // The global value-numbering map is keyed only by operands. A matching
+                // instruction in a different generic scope is not visible here, so keep the
+                // newly allocated instruction and let it be hoisted in the current scope.
             }
-            return *found;
+            else
+            {
+                memoryArena.rewindToCursor(cursor);
+
+                // If the found inst is defined in the same parent as current insert location but
+                // is located after the insert location, we need to move it to the insert location.
+                if (foundInst->getParent() &&
+                    foundInst->getParent() == getInsertLoc().getParent() &&
+                    getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+                {
+                    auto insertLoc = getInsertLoc().getInst();
+                    bool isAfter = false;
+                    for (auto cur = insertLoc->next; cur; cur = cur->next)
+                    {
+                        if (cur == foundInst)
+                        {
+                            isAfter = true;
+                            break;
+                        }
+                    }
+                    if (isAfter)
+                        foundInst->insertBefore(insertLoc);
+                }
+                return *found;
+            }
         }
     }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2717,6 +2717,51 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
     {
         IRInstKey key = {inst};
 
+        auto findVisibleScopedInst = [&](IRInst* insertGeneric) -> IRInst*
+        {
+            IRInst* scopedInst = nullptr;
+            auto& scopedMap = m_dedupContext->getScopedGlobalValueNumberingMap();
+            for (auto generic = insertGeneric; generic; generic = findOuterGeneric(generic->parent))
+            {
+                if (scopedMap.tryGetValue(IRScopedInstKey{key, generic}, scopedInst))
+                    return scopedInst;
+            }
+            if (scopedMap.tryGetValue(IRScopedInstKey{key, nullptr}, scopedInst))
+                return scopedInst;
+            return nullptr;
+        };
+
+        auto useFoundInst = [&](IRInst* foundInst) -> IRInst*
+        {
+            memoryArena.rewindToCursor(cursor);
+
+            // If the found inst is defined in the same parent as current insert location but
+            // is located after the insert location, we need to move it to the insert location.
+            if (foundInst->getParent() && foundInst->getParent() == getInsertLoc().getParent() &&
+                getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+            {
+                auto insertLoc = getInsertLoc().getInst();
+                while (insertLoc && insertLoc->getOp() == kIROp_Param)
+                    insertLoc = insertLoc->getNextInst();
+
+                if (!insertLoc)
+                    return foundInst;
+
+                bool isAfter = false;
+                for (auto cur = insertLoc->next; cur; cur = cur->next)
+                {
+                    if (cur == foundInst)
+                    {
+                        isAfter = true;
+                        break;
+                    }
+                }
+                if (isAfter)
+                    foundInst->insertBefore(insertLoc);
+            }
+            return foundInst;
+        };
+
         IRInst** found = m_dedupContext->getGlobalValueNumberingMap().tryGetValueOrAdd(key, inst);
         SLANG_ASSERT(endCursor == memoryArena.getCursor());
         // If it's found, just return, and throw away the instruction
@@ -2731,37 +2776,12 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
                 // The global value-numbering map is keyed only by operands. A matching
                 // instruction in a different generic scope is not visible here, so keep the
                 // newly allocated instruction and let it be hoisted in the current scope.
+                if (auto scopedInst = findVisibleScopedInst(insertGeneric))
+                    return useFoundInst(scopedInst);
             }
             else
             {
-                memoryArena.rewindToCursor(cursor);
-
-                // If the found inst is defined in the same parent as current insert location but
-                // is located after the insert location, we need to move it to the insert location.
-                if (foundInst->getParent() &&
-                    foundInst->getParent() == getInsertLoc().getParent() &&
-                    getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
-                {
-                    auto insertLoc = getInsertLoc().getInst();
-                    while (insertLoc && insertLoc->getOp() == kIROp_Param)
-                        insertLoc = insertLoc->getNextInst();
-
-                    if (!insertLoc)
-                        return *found;
-
-                    bool isAfter = false;
-                    for (auto cur = insertLoc->next; cur; cur = cur->next)
-                    {
-                        if (cur == foundInst)
-                        {
-                            isAfter = true;
-                            break;
-                        }
-                    }
-                    if (isAfter)
-                        foundInst->insertBefore(insertLoc);
-                }
-                return *found;
+                return useFoundInst(foundInst);
             }
         }
     }
@@ -2799,6 +2819,9 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         else
             addHoistableInst(this, inst);
     }
+    m_dedupContext->getScopedGlobalValueNumberingMap()[IRScopedInstKey{
+        IRInstKey{inst},
+        findOuterGeneric(inst)}] = inst;
 
     return inst;
 }

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2725,7 +2725,8 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
             auto foundInst = *found;
             auto foundGeneric = findOuterGeneric(foundInst);
             auto insertGeneric = findOuterGeneric(getInsertLoc().getParent());
-            if (foundGeneric && foundGeneric != insertGeneric)
+            if (foundGeneric && foundGeneric != insertGeneric &&
+                !(insertGeneric && hasDescendent(foundGeneric, insertGeneric)))
             {
                 // The global value-numbering map is keyed only by operands. A matching
                 // instruction in a different generic scope is not visible here, so keep the
@@ -2742,6 +2743,12 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
                     getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
                 {
                     auto insertLoc = getInsertLoc().getInst();
+                    while (insertLoc && insertLoc->getOp() == kIROp_Param)
+                        insertLoc = insertLoc->getNextInst();
+
+                    if (!insertLoc)
+                        return *found;
+
                     bool isAfter = false;
                     for (auto cur = insertLoc->next; cur; cur = cur->next)
                     {

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1969,6 +1969,28 @@ public:
     }
 };
 
+struct IRScopedInstKey
+{
+    IRInstKey instKey;
+    IRInst* genericScope = nullptr;
+
+    IRScopedInstKey() = default;
+    IRScopedInstKey(IRInstKey const& key, IRInst* scope)
+        : instKey(key), genericScope(scope)
+    {
+    }
+
+    HashCode getHashCode() const
+    {
+        return combineHash(instKey.getHashCode(), Slang::getHashCode(genericScope));
+    }
+
+    bool operator==(IRScopedInstKey const& right) const
+    {
+        return genericScope == right.genericScope && instKey == right.instKey;
+    }
+};
+
 struct IRConstantKey
 {
     IRConstant* inst;
@@ -2015,9 +2037,14 @@ public:
     void tryHoistInst(IRInst* inst);
 
     typedef Dictionary<IRInstKey, IRInst*> GlobalValueNumberingMap;
+    typedef Dictionary<IRScopedInstKey, IRInst*> ScopedGlobalValueNumberingMap;
     typedef Dictionary<IRConstantKey, IRConstant*> ConstantMap;
 
     GlobalValueNumberingMap& getGlobalValueNumberingMap() { return m_globalValueNumberingMap; }
+    ScopedGlobalValueNumberingMap& getScopedGlobalValueNumberingMap()
+    {
+        return m_scopedGlobalValueNumberingMap;
+    }
     Dictionary<IRInst*, IRInst*>& getInstReplacementMap() { return m_instReplacementMap; }
 
     void _addGlobalNumberingEntry(IRInst* inst)
@@ -2025,6 +2052,8 @@ public:
         m_globalValueNumberingMap.add(IRInstKey{inst}, inst);
         m_instReplacementMap.remove(inst);
         tryHoistInst(inst);
+        m_scopedGlobalValueNumberingMap[IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)}] =
+            inst;
     }
     void _removeGlobalNumberingEntry(IRInst* inst)
     {
@@ -2034,6 +2063,14 @@ public:
             if (value == inst)
             {
                 m_globalValueNumberingMap.remove(IRInstKey{inst});
+            }
+        }
+        IRScopedInstKey scopedKey{IRInstKey{inst}, findOuterGeneric(inst)};
+        if (m_scopedGlobalValueNumberingMap.tryGetValue(scopedKey, value))
+        {
+            if (value == inst)
+            {
+                m_scopedGlobalValueNumberingMap.remove(scopedKey);
             }
         }
     }
@@ -2048,6 +2085,7 @@ private:
     Session* m_session;
 
     GlobalValueNumberingMap m_globalValueNumberingMap;
+    ScopedGlobalValueNumberingMap m_scopedGlobalValueNumberingMap;
 
     // Duplicate insts that are still alive and needs to be replaced in m_globalValueNumberMap
     // when used as an operand to create another inst.

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2052,8 +2052,9 @@ public:
         m_globalValueNumberingMap.add(IRInstKey{inst}, inst);
         m_instReplacementMap.remove(inst);
         tryHoistInst(inst);
-        m_scopedGlobalValueNumberingMap[IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)}] =
-            inst;
+        m_scopedGlobalValueNumberingMap.add(
+            IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)},
+            inst);
     }
     void _removeGlobalNumberingEntry(IRInst* inst)
     {

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -1,0 +1,20 @@
+// Regression test for #11182: prelinking an imported generic vector constructor while
+// lowering this module used to crash while hoisting a cloned Func type.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
+
+vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+{
+    return vector<T, N>(0.0f);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void cs_main()
+{
+}
+
+// CHECK: OpCapability Shader
+// CHECK: OpEntryPoint GLCompute
+// CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
+// CHECK: OpReturn


### PR DESCRIPTION
Fixes shader-slang/slang#11182

## Summary of the problem from the end user perspective
A generic function that constructs `vector<T, N>` from a floating literal under `where T : __BuiltinFloatingPointType` could crash during prelinking, even with an otherwise empty compute shader entry point.

### Minimal repro shader; if applicable
```slang
vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
{
    return vector<T, N>(0.0f);
}
[shader("compute")][numthreads(1, 1, 1)] void cs_main() {}
```

## Root cause
During IR prelinking, the cloned generic's full type was cloned before its block parameters were registered, and hoistable value-numbering could also reuse an equivalent instruction from a sibling cloned generic. That left hoistable `Func` and autodiff-related types with operands in unrelated generic scopes.

## Solution in this PR
Clone global-value full types after block cloning has registered local operands, and reject hoistable value-numbering hits from a different enclosing generic scope. Add a focused regression test that compiles the generic vector constructor path to SPIR-V assembly.

### Notes to the reviewers; where to focus on
The main review points are `cloneGlobalValueWithCodeCommon` ordering and `_findOrEmitHoistableInst` dedup reuse checks. The regression is intentionally small and mirrors the issue's reduced repro.

## Related PRs in the past
shader-slang/slang#11072 fixed a similar annotation-cloning crash signature, but this case is on the normal hoistable clone path.
shader-slang/slang#11195 was a mitigation that avoided the immediate hoist assertion but left operands from unrelated generic scopes.
