### PR TITLE
Avoid extra core module generation for neural bootstrap

### DIFF
--- a/source/standard-modules/neural/CMakeLists.txt
+++ b/source/standard-modules/neural/CMakeLists.txt
@@ -66,9 +66,12 @@ else()
     # When SLANG_ENABLE_SLANGC is OFF, slangc is not built as a target. Fall back
     # to slang-bootstrap (a generator always built regardless of SLANG_ENABLE_SLANGC)
     # rather than a system-installed slangc that may not be present.
+    # This branch is only reached when SLANG_EMBED_CORE_MODULE is ON, so the
+    # bootstrap executable can run directly without first generating the embedded
+    # core/glsl module headers used by the final slang library.
     set(SLANG_COMPILER slang-bootstrap)
     set(SLANG_COMPILER_DEPENDENCY slang-bootstrap)
-    set(SLANG_COMPILER_EXTRA_DEPS generate_core_module_headers)
+    set(SLANG_COMPILER_EXTRA_DEPS)
 endif()
 
 # Determine compiler flags based on build type


### PR DESCRIPTION
Fixes shader-slang/slang#11057

## Summary of the problem from the end user perspective
Embedding Slang with `SLANG_ENABLE_SLANGC=OFF` still needs the neural standard module to build from the in-tree bootstrap compiler. That path should not require an installed `slangc` or duplicate core/glsl module generation.

## Root cause
The neural module fallback correctly selected `slang-bootstrap`, but it also depended on `generate_core_module_headers`. In embedded-core builds this branch can run `slang-bootstrap` directly, so that dependency forced unnecessary generated core/glsl module work.

## Solution in this PR
Keep the `slang-bootstrap` fallback for `SLANG_ENABLE_SLANGC=OFF`, but clear the extra `generate_core_module_headers` dependency in the embedded-core branch. The neural module target now depends only on `slang-bootstrap` in this configuration.

### Notes to the reviewers; where to focus on
The key condition is the final `else()` in `source/standard-modules/neural/CMakeLists.txt`: it is reached only when `SLANG_EMBED_CORE_MODULE=ON` and `SLANG_ENABLE_SLANGC=OFF`, so the bootstrap executable does not need the generated embedded-module headers first.

## Related PRs in the past
- #11053 made the neural module build unconditionally and used `slang-bootstrap` when `SLANG_EMBED_CORE_MODULE=OFF`.
- #10945 changed the `SLANG_ENABLE_SLANGC=OFF` fallback from PATH `slangc` to `slang-bootstrap`.
