### PR TITLE
Set DXIL default profile to SM 6.0

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -106,11 +106,19 @@ Profile getEffectiveProfile(EntryPoint* entryPoint, TargetRequest* target)
     case CodeGenTarget::HLSL:
     case CodeGenTarget::DXBytecode:
     case CodeGenTarget::DXBytecodeAssembly:
-    case CodeGenTarget::DXIL:
-    case CodeGenTarget::DXILAssembly:
         if (targetProfile.getFamily() != ProfileFamily::DX)
         {
             targetProfile.setVersion(ProfileVersion::DX_5_1);
+        }
+        break;
+
+    case CodeGenTarget::DXIL:
+    case CodeGenTarget::DXILAssembly:
+        // DXIL generation goes through DXC, which requires Shader Model 6.0 or later.
+        if (targetProfile.getFamily() != ProfileFamily::DX ||
+            targetProfile.getVersion() < ProfileVersion::DX_6_0)
+        {
+            targetProfile.setVersion(ProfileVersion::DX_6_0);
         }
         break;
     case CodeGenTarget::Metal:

--- a/tests/bugs/gh-11021-dxil-default-profile.slang
+++ b/tests/bugs/gh-11021-dxil-default-profile.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=DXIL): -target dxil -entry computeMain
+
+// DXIL: define void @computeMain()
+
+StructuredBuffer<float> buffer0;
+StructuredBuffer<float> buffer1;
+RWStructuredBuffer<float> result;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 threadId: SV_DispatchThreadID)
+{
+    uint index = threadId.x;
+    result[index] = buffer0[index] + buffer1[index];
+}


### PR DESCRIPTION
Fixes shader-slang/slang#11021

## Summary of the problem from the end user perspective

Compiling a compute shader with `-target dxil` and no explicit `-profile` selected `cs_5_1`, which DXC rejects for DXIL output. Users had to manually specify `cs_6_0` or later even though DXIL implies Shader Model 6 support.

### Minimal repro shader; if applicable

```slang
[shader("compute")]
[numthreads(1, 1, 1)]
void computeMain(uint3 threadId: SV_DispatchThreadID)
{
    result[threadId.x] = buffer0[threadId.x] + buffer1[threadId.x];
}
```

## Root cause

DXIL and DXIL assembly shared the same default DX profile fallback as HLSL and DXBC in `getEffectiveProfile`, so an unspecified target profile was normalized to Shader Model 5.1.

## Solution in this PR

Split DXIL targets out of the HLSL/DXBC fallback and clamp their effective DX profile to Shader Model 6.0 or later. Added a regression test that compiles the issue's DXIL compute entry point without an explicit profile.

### Notes to the reviewers; where to focus on

The main behavior change is in the target-format switch in `getEffectiveProfile`. HLSL and DXBC still use the existing SM 5.1 fallback; only DXIL and DXIL assembly get the SM 6.0 floor required by DXC.
