### PR TITLE
Bump DXC to v1.10.2605.24

### DIFF
--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -19,12 +19,18 @@ include(FetchContent)
 if(NOT DEFINED SLANG_DXC_BINARY_URL)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         set(SLANG_DXC_BINARY_URL
-            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/dxc_2026_02_20.zip"
+            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.10.2605.24/dxc_preview_2026_05_22.zip"
+        )
+        set(_dxc_url_hash
+            "SHA256=045e2cfd900135f640954553038febbc98692599c5606376726d00541dae69b6"
         )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
             set(SLANG_DXC_BINARY_URL
-                "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/linux_dxc_2026_02_20.x86_64.tar.gz"
+                "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.10.2605.24/linux_dxc_preview_2026_05_22.x86_64.tar.gz"
+            )
+            set(_dxc_url_hash
+                "SHA256=6119f59c4f758973cadc170607ba83e657dd2c6fb7ca3dfb7362717a4ece8d9e"
             )
         endif()
     endif()
@@ -42,6 +48,11 @@ set(_dxc_fetch_args
     SOURCE_SUBDIR
     _does_not_exist_
 )
+# URL_HASH only applies to the default URLs we ship; if the caller overrides
+# SLANG_DXC_BINARY_URL we have no way to know its digest.
+if(DEFINED _dxc_url_hash)
+    list(APPEND _dxc_fetch_args URL_HASH "${_dxc_url_hash}")
+endif()
 if(SLANG_GITHUB_TOKEN)
     list(
         APPEND
@@ -57,6 +68,34 @@ FetchContent_GetProperties(dxc)
 if(NOT dxc_POPULATED)
     FetchContent_MakeAvailable(dxc)
 endif()
+
+# Stage public DXC HLSL headers (e.g. dx/linalg.h) at a stable path so test
+# directives like `-Xdxc -Ibuild/dxc/include` can resolve them. Done as a
+# build-graph custom command, matching the DLL/.so copy pattern below.
+if(EXISTS "${dxc_SOURCE_DIR}/include/hlsl/dx/linalg.h")
+    set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/include/hlsl")
+elseif(EXISTS "${dxc_SOURCE_DIR}/inc/hlsl/dx/linalg.h")
+    set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/inc/hlsl")
+else()
+    message(
+        FATAL_ERROR
+        "DXC archive at ${SLANG_DXC_BINARY_URL} is missing dx/linalg.h. "
+        "The cooperative-{vector,matrix} tests rely on this header. "
+        "If Microsoft has reorganized the archive layout, update FetchDXC.cmake."
+    )
+endif()
+set(_dxc_inc_src "${_dxc_hlsl_include_dir}/dx/linalg.h")
+set(_dxc_inc_dst "${CMAKE_BINARY_DIR}/dxc/include/dx/linalg.h")
+add_custom_command(
+    OUTPUT "${_dxc_inc_dst}"
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory "${_dxc_hlsl_include_dir}"
+        "${CMAKE_BINARY_DIR}/dxc/include"
+    DEPENDS "${_dxc_inc_src}"
+    VERBATIM
+)
+add_custom_target(stage-dxc-headers DEPENDS "${_dxc_inc_dst}")
+set_target_properties(stage-dxc-headers PROPERTIES FOLDER generated)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -69,33 +69,35 @@ if(NOT dxc_POPULATED)
     FetchContent_MakeAvailable(dxc)
 endif()
 
-# Stage public DXC HLSL headers (e.g. dx/linalg.h) at a stable path so test
-# directives like `-Xdxc -Ibuild/dxc/include` can resolve them. Done as a
-# build-graph custom command, matching the DLL/.so copy pattern below.
-if(EXISTS "${dxc_SOURCE_DIR}/include/hlsl/dx/linalg.h")
-    set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/include/hlsl")
-elseif(EXISTS "${dxc_SOURCE_DIR}/inc/hlsl/dx/linalg.h")
-    set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/inc/hlsl")
-else()
-    message(
-        FATAL_ERROR
-        "DXC archive at ${SLANG_DXC_BINARY_URL} is missing dx/linalg.h. "
-        "The cooperative-{vector,matrix} tests rely on this header. "
-        "If Microsoft has reorganized the archive layout, update FetchDXC.cmake."
+if(SLANG_ENABLE_TESTS)
+    # Stage public DXC HLSL headers (e.g. dx/linalg.h) at a stable path so test
+    # directives like `-Xdxc -Ibuild/dxc/include` can resolve them. Done as a
+    # build-graph custom command, matching the DLL/.so copy pattern below.
+    if(EXISTS "${dxc_SOURCE_DIR}/include/hlsl/dx/linalg.h")
+        set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/include/hlsl")
+    elseif(EXISTS "${dxc_SOURCE_DIR}/inc/hlsl/dx/linalg.h")
+        set(_dxc_hlsl_include_dir "${dxc_SOURCE_DIR}/inc/hlsl")
+    else()
+        message(
+            FATAL_ERROR
+            "DXC archive at ${SLANG_DXC_BINARY_URL} is missing dx/linalg.h. "
+            "The cooperative-{vector,matrix} tests rely on this header. "
+            "If Microsoft has reorganized the archive layout, update FetchDXC.cmake."
+        )
+    endif()
+    set(_dxc_inc_src "${_dxc_hlsl_include_dir}/dx/linalg.h")
+    set(_dxc_inc_dst "${CMAKE_BINARY_DIR}/dxc/include/dx/linalg.h")
+    add_custom_command(
+        OUTPUT "${_dxc_inc_dst}"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_directory "${_dxc_hlsl_include_dir}"
+            "${CMAKE_BINARY_DIR}/dxc/include"
+        DEPENDS "${_dxc_inc_src}"
+        VERBATIM
     )
+    add_custom_target(stage-dxc-headers DEPENDS "${_dxc_inc_dst}")
+    set_target_properties(stage-dxc-headers PROPERTIES FOLDER generated)
 endif()
-set(_dxc_inc_src "${_dxc_hlsl_include_dir}/dx/linalg.h")
-set(_dxc_inc_dst "${CMAKE_BINARY_DIR}/dxc/include/dx/linalg.h")
-add_custom_command(
-    OUTPUT "${_dxc_inc_dst}"
-    COMMAND
-        ${CMAKE_COMMAND} -E copy_directory "${_dxc_hlsl_include_dir}"
-        "${CMAKE_BINARY_DIR}/dxc/include"
-    DEPENDS "${_dxc_inc_src}"
-    VERBATIM
-)
-add_custom_target(stage-dxc-headers DEPENDS "${_dxc_inc_dst}")
-set_target_properties(stage-dxc-headers PROPERTIES FOLDER generated)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")

--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -46,7 +46,10 @@ vector<OutElTy, MatM> __slang_linalg_Mul(
         dx::linalg::MatrixUse::A,
         dx::linalg::MatrixScope::Thread>;
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
-    return dx::linalg::Multiply<OutElTy>(mat, input);
+    return dx::linalg::MultiplyAdd<OutElTy>(
+        mat,
+        dx::linalg::MakeInterpretedVector<InputDT>(input),
+        (vector<OutElTy, MatM>)0);
 }
 
 template<
@@ -79,7 +82,10 @@ vector<OutElTy, MatM> __slang_linalg_MulAdd(
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
     using BiasVecTy = vector<BiasElTy, BiasVecDim>;
     BiasVecTy biasVec = biasBuf.template Load<BiasVecTy>(biasOff);
-    return dx::linalg::MultiplyAdd<OutElTy>(mat, input, biasVec);
+    return dx::linalg::MultiplyAdd<OutElTy>(
+        mat,
+        dx::linalg::MakeInterpretedVector<InputDT>(input),
+        biasVec);
 }
 
 template<
@@ -109,7 +115,7 @@ void __slang_linalg_OuterProductAccumulate(
 template<typename ElTy, uint N, typename BufTy>
 void __slang_linalg_VectorAccumulate(vector<ElTy, N> inputVec, BufTy buffer, uint offset)
 {
-    dx::linalg::VectorAccumulate(inputVec, buffer, offset);
+    dx::linalg::InterlockedAccumulate(inputVec, buffer, offset);
 }
 )";
 
@@ -384,9 +390,9 @@ __slang_cm_muladd(
         switch (slangValue)
         {
         case SLANG_SCALAR_TYPE_INT8:
-            return UnownedStringSlice(sm610OrAbove ? "PackedS8x32" : "DATA_TYPE_SINT8_T4_PACKED");
+            return UnownedStringSlice(sm610OrAbove ? "I8" : "DATA_TYPE_SINT8_T4_PACKED");
         case SLANG_SCALAR_TYPE_UINT8:
-            return UnownedStringSlice(sm610OrAbove ? "PackedU8x32" : "DATA_TYPE_UINT8_T4_PACKED");
+            return UnownedStringSlice(sm610OrAbove ? "U8" : "DATA_TYPE_UINT8_T4_PACKED");
         default:
             SLANG_UNEXPECTED(
                 "Unsupported packed cooperative vector input interpretation for HLSL emission");

--- a/tests/cooperative-matrix/add.slang
+++ b/tests/cooperative-matrix/add.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1

--- a/tests/cooperative-matrix/array.slang
+++ b/tests/cooperative-matrix/array.slang
@@ -4,7 +4,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 //TEST(compute, metal):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -Xslang -DMETAL
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1.000000

--- a/tests/cooperative-matrix/comparison.slang
+++ b/tests/cooperative-matrix/comparison.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 0

--- a/tests/cooperative-matrix/conversion-1.slang
+++ b/tests/cooperative-matrix/conversion-1.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2.000000

--- a/tests/cooperative-matrix/conversion.slang
+++ b/tests/cooperative-matrix/conversion.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-vk -emit-spirv-directly -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2.000000

--- a/tests/cooperative-matrix/copyFrom.slang
+++ b/tests/cooperative-matrix/copyFrom.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK-COUNT-256: 4

--- a/tests/cooperative-matrix/div.slang
+++ b/tests/cooperative-matrix/div.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2

--- a/tests/cooperative-matrix/fill.slang
+++ b/tests/cooperative-matrix/fill.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK-COUNT-256: A

--- a/tests/cooperative-matrix/inout.slang
+++ b/tests/cooperative-matrix/inout.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2.000000

--- a/tests/cooperative-matrix/length.slang
+++ b/tests/cooperative-matrix/length.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK_VK):-vk -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK_CUDA):-cuda
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // Note the length is NOT row * column.

--- a/tests/cooperative-matrix/load-store-rwbyteaddressbuffer.slang
+++ b/tests/cooperative-matrix/load-store-rwbyteaddressbuffer.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -Xslang -DRWBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: 1

--- a/tests/cooperative-matrix/load-store-rwstructuredbuffer.slang
+++ b/tests/cooperative-matrix/load-store-rwstructuredbuffer.slang
@@ -5,7 +5,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DRWSB
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1

--- a/tests/cooperative-matrix/load-store.slang
+++ b/tests/cooperative-matrix/load-store.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1.00

--- a/tests/cooperative-matrix/mat-mul-add.slang
+++ b/tests/cooperative-matrix/mat-mul-add.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-vk -emit-spirv-directly -Xslang -DBAB
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_CUDA):-cuda -output-using-type
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: type: float

--- a/tests/cooperative-matrix/mod.slang
+++ b/tests/cooperative-matrix/mod.slang
@@ -1,7 +1,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 0

--- a/tests/cooperative-matrix/mod1.slang
+++ b/tests/cooperative-matrix/mod1.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 0

--- a/tests/cooperative-matrix/mul.slang
+++ b/tests/cooperative-matrix/mul.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2

--- a/tests/cooperative-matrix/out.slang
+++ b/tests/cooperative-matrix/out.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2.000000

--- a/tests/cooperative-matrix/parameter.slang
+++ b/tests/cooperative-matrix/parameter.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 3.000000

--- a/tests/cooperative-matrix/return.slang
+++ b/tests/cooperative-matrix/return.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 3.000000

--- a/tests/cooperative-matrix/scalar-mul.slang
+++ b/tests/cooperative-matrix/scalar-mul.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 4.500000

--- a/tests/cooperative-matrix/struct.slang
+++ b/tests/cooperative-matrix/struct.slang
@@ -4,7 +4,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 //TEST(compute, metal):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -Xslang -DMETAL
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1.000000

--- a/tests/cooperative-matrix/sub.slang
+++ b/tests/cooperative-matrix/sub.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1

--- a/tests/cooperative-matrix/subscript-in-func.slang
+++ b/tests/cooperative-matrix/subscript-in-func.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 1.000000

--- a/tests/cooperative-matrix/subscript.slang
+++ b/tests/cooperative-matrix/subscript.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: 2

--- a/tests/cooperative-matrix/unary_neg.slang
+++ b/tests/cooperative-matrix/unary_neg.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BAB):-cuda -Xslang -DBAB
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include -DBAB
 //DXIL: result code = 0
 
 // CHECK: -1

--- a/tests/cooperative-vector/matrix-mul-bias-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-bias-packed-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-packed-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-bias-packed.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-packed.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-bias.slang
+++ b/tests/cooperative-vector/matrix-mul-bias.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-byteaddress.slang
+++ b/tests/cooperative-vector/matrix-mul-byteaddress.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
+++ b/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
@@ -7,9 +7,9 @@
 // CHECK609: ByteAddressBuffer bias_0 : register
 // CHECK609-COUNT-4: __slang_linalg_Mul
 
-// CHECK610: dx::linalg::Multiply<
 // CHECK610: dx::linalg::MultiplyAdd<
-// CHECK610-NOT: MakeInterpretedVector
+// CHECK610: dx::linalg::MakeInterpretedVector<InputDT>(input)
+// CHECK610-NOT: PackedS8x32
 
 RWStructuredBuffer<int32_t> outputBuffer;
 ByteAddressBuffer input;

--- a/tests/cooperative-vector/matrix-mul-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-packed-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-packed-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-packed.slang
+++ b/tests/cooperative-vector/matrix-mul-packed.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul.slang
+++ b/tests/cooperative-vector/matrix-mul.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Ibuild/dxc/include -X.
 
-//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
+//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_10 -entry computeMain -Xdxc -Ibuild/dxc/include
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
+++ b/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
@@ -1,6 +1,6 @@
 // SM6.10 behavioral test for cooperative-vector reduce-sum accumulate.
 // TODO: enable when GPU CI runners gain cs_6_10 / DXC SM6.10 support
-//       (requires DXC >= v1.9.2602 and dx::linalg::VectorAccumulate in dx/linalg.h).
+//       (requires DXC >= v1.10.2605.24 and vector accumulation in dx/linalg.h).
 // Multi-threaded: 8 lanes each accumulate [1,1,1,1] into the same byte offset.
 // Atomic reduce-sum yields output[i]=8; a non-atomic load/add/store loop would
 // produce a smaller value due to lost updates under thread contention.

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -11,7 +11,7 @@
 // CHECK610-DAG: dx::linalg::OuterProduct<
 // CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
 // CHECK610-DAG: void __slang_linalg_VectorAccumulate(
-// CHECK610-DAG: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
+// CHECK610-DAG: dx::linalg::InterlockedAccumulate(inputVec, buffer, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -279,6 +279,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
             slang-llvm
             copy-dxcompiler
             copy-dxil
+            stage-dxc-headers
             copy-webgpu_dawn
             copy-slang-tint
         FOLDER test


### PR DESCRIPTION
Fixes shader-slang/slang#11002

## Summary of the problem from the end user perspective

Slang's pinned DXC preview was too old for current Shader Model 6.10 `dx::linalg` coverage, so cooperative vector and cooperative matrix DXIL tests that depend on the newer header support stayed disabled.

## Root cause

The default DXC fetch still used v1.9.2602, while the newer v1.10.2605.24 packages expose SM 6.10 headers with different archive layouts and updated linalg API names.

## Solution in this PR

Bump the default DXC packages to v1.10.2605.24 with updated hashes, stage `dx/linalg.h` from either package layout, update SM 6.10 cooperative-vector HLSL emission for the new linalg API, and re-enable the compile-only linalg DXIL tests that now compile.

### Notes to the reviewers; where to focus on

Review `FetchDXC.cmake` header staging and the SM 6.10 cooperative-vector prelude changes, especially `InterlockedAccumulate`, interpreted-vector handling, and packed int8/uint8 data-type emission.

## Related PRs in the past

- shader-slang/slang#11242 and shader-slang/slang#11243 explored the earlier v1.10.2605.2 bump.
