### PR TITLE
Harden slash command workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,32 +1,122 @@
 name: Format
+# Security note:
+# PR branches can come from forks. The formatting job checks out and formats the PR branch
+# without bot secrets, then the apply job validates and commits only the generated patch.
 on:
   repository_dispatch:
     types: [format-command]
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
-  format:
+  validate-dispatch:
     if: >-
       github.repository == 'shader-slang/slang' &&
-      github.event.client_payload.github.payload.repository.full_name == 'shader-slang/slang' &&
-      github.event.client_payload.pull_request.base.repo.full_name == 'shader-slang/slang'
+      github.event.client_payload.github.payload.repository.full_name == 'shader-slang/slang'
     runs-on: ubuntu-latest
+    outputs:
+      base-ref: ${{ steps.validate.outputs.base-ref }}
+      comment-id: ${{ steps.validate.outputs.comment-id }}
+      head-ref: ${{ steps.validate.outputs.head-ref }}
+      head-repository: ${{ steps.validate.outputs.head-repository }}
+      pr-number: ${{ steps.validate.outputs.pr-number }}
+      pr-url: ${{ steps.validate.outputs.pr-url }}
+    steps:
+      - name: Validate dispatch payload
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.client_payload.github.payload.comment.id }}
+          PAYLOAD_BASE_REPOSITORY: ${{ github.event.client_payload.pull_request.base.repo.full_name }}
+          PAYLOAD_REPOSITORY: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" ]]; then
+            echo "Missing pull request number or comment id in dispatch payload" >&2
+            exit 1
+          fi
+
+          if [[ "$PAYLOAD_REPOSITORY" != "shader-slang/slang" ||
+                "$PAYLOAD_BASE_REPOSITORY" != "shader-slang/slang" ]]; then
+            echo "Dispatch payload does not target shader-slang/slang" >&2
+            exit 1
+          fi
+
+          api() {
+            curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$@"
+          }
+
+          pr_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/pulls/$PR_NUMBER")
+          comment_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/issues/comments/$COMMENT_ID")
+
+          pr_number=$(jq -r '.number' <<<"$pr_json")
+          pr_url=$(jq -r '.html_url' <<<"$pr_json")
+          base_repository=$(jq -r '.base.repo.full_name' <<<"$pr_json")
+          base_ref=$(jq -r '.base.ref' <<<"$pr_json")
+          head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+          head_ref=$(jq -r '.head.ref' <<<"$pr_json")
+          comment_issue_url=$(jq -r '.issue_url' <<<"$comment_json")
+          comment_body=$(jq -r '.body // ""' <<<"$comment_json")
+          comment_user=$(jq -r '.user.login // ""' <<<"$comment_json")
+
+          if [[ "$pr_number" != "$PR_NUMBER" ||
+                "$base_repository" != "shader-slang/slang" ||
+                "$comment_issue_url" != "$GITHUB_API_URL/repos/shader-slang/slang/issues/$PR_NUMBER" ||
+                ! "$comment_body" =~ ^[[:space:]]*/format([[:space:]]|$) ]]; then
+            echo "Dispatch payload does not match an authorized /format pull request comment" >&2
+            exit 1
+          fi
+
+          permission_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/collaborators/$comment_user/permission")
+          permission=$(jq -r '.permission' <<<"$permission_json")
+          case "$permission" in
+            admin | maintain | write) ;;
+            *)
+              echo "Comment author does not have write permission" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "base-ref=$base_ref"
+            echo "comment-id=$COMMENT_ID"
+            echo "head-ref=$head_ref"
+            echo "head-repository=$head_repository"
+            echo "pr-number=$pr_number"
+            echo "pr-url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+
+  format-pr-branch:
+    needs: validate-dispatch
+    runs-on: ubuntu-latest
+    outputs:
+      has-changes: ${{ steps.format-patch.outputs.has-changes }}
+      head-sha: ${{ steps.format-patch.outputs.head-sha }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          repository: ${{ needs.validate-dispatch.outputs.head-repository }}
+          ref: ${{ needs.validate-dispatch.outputs.head-ref }}
           path: pr-branch
           persist-credentials: false
+          token: ${{ github.token }}
 
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
           repository: shader-slang/slang
-          ref: ${{ github.event.client_payload.pull_request.base.ref }}
+          ref: ${{ needs.validate-dispatch.outputs.base-ref }}
           path: target-branch
           persist-credentials: false
+          token: ${{ github.token }}
 
       - name: Setup
         uses: ./target-branch/.github/actions/format-setup
@@ -36,32 +126,109 @@ jobs:
         run: |
           ./target-branch/extras/formatting.sh --source ./pr-branch
 
+      - name: Create formatting patch
+        id: format-patch
+        run: |
+          set -euo pipefail
+          echo "head-sha=$(git -C pr-branch rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git -C pr-branch diff --binary -- . > format.patch
+          if [[ -s format.patch ]]; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload formatting patch
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        with:
+          name: format-patch
+          path: format.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  apply-format:
+    needs: [validate-dispatch, format-pr-branch]
+    if: >-
+      always() &&
+      needs.validate-dispatch.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        if: needs.format-pr-branch.result == 'success' && needs.format-pr-branch.outputs.has-changes == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.validate-dispatch.outputs.head-repository }}
+          ref: ${{ needs.validate-dispatch.outputs.head-ref }}
+          path: pr-branch
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - name: Download formatting patch
+        if: needs.format-pr-branch.result == 'success' && needs.format-pr-branch.outputs.has-changes == 'true'
+        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
+        with:
+          name: format-patch
+          path: format-patch
+
+      - name: Apply formatting patch
+        id: apply-patch
+        if: needs.format-pr-branch.result == 'success' && needs.format-pr-branch.outputs.has-changes == 'true'
+        run: |
+          set -euo pipefail
+          patch_file="$GITHUB_WORKSPACE/format-patch/format.patch"
+          if [[ ! -f "$patch_file" || -L "$patch_file" ]]; then
+            echo "Formatting patch artifact is missing or invalid" >&2
+            exit 1
+          fi
+          expected_head_sha="${{ needs.format-pr-branch.outputs.head-sha }}"
+          actual_head_sha=$(git -C pr-branch rev-parse HEAD)
+          if [[ "$actual_head_sha" != "$expected_head_sha" ]]; then
+            echo "PR branch changed after formatting; please rerun /format" >&2
+            exit 1
+          fi
+          max_size=$((25 * 1024 * 1024))
+          actual_size=$(wc -c < "$patch_file")
+          if [[ "$actual_size" -gt "$max_size" ]]; then
+            echo "Formatting patch artifact is too large" >&2
+            exit 1
+          fi
+          git -C pr-branch apply --check "$patch_file"
+          git -C pr-branch apply "$patch_file"
+
       - name: Configure Git commit signing
         id: git-info
+        if: needs.format-pr-branch.result == 'success' && needs.format-pr-branch.outputs.has-changes == 'true'
+        env:
+          SLANGBOT_PAT: ${{ secrets.SLANGBOT_PAT }}
+          SLANGBOT_SIGNING_KEY: ${{ secrets.SLANGBOT_SIGNING_KEY }}
         run: |
-          echo "${{ secrets.SLANGBOT_SIGNING_KEY }}" > "${{runner.temp}}"/signing_key
+          set -euo pipefail
+          printf '%s\n' "$SLANGBOT_SIGNING_KEY" > "${{runner.temp}}"/signing_key
           chmod 600 "${{runner.temp}}"/signing_key
           git -C pr-branch config commit.gpgsign true
           git -C pr-branch config gpg.format ssh
           git -C pr-branch config user.signingkey "${{runner.temp}}"/signing_key
-          bot_info=$(curl -s -H "Authorization: Bearer ${{ secrets.SLANGBOT_PAT }}" \
+          bot_info=$(curl -fsSL -H "Authorization: Bearer $SLANGBOT_PAT" \
             "https://api.github.com/user")
-          echo "bot_identity=$(echo $bot_info | jq --raw-output '.login + " <" + (.id|tostring) + "+" + .login + "@users.noreply.github.com>"')" >> $GITHUB_OUTPUT
-          echo "bot_name=$(echo $bot_info | jq --raw-output '.login')" >> $GITHUB_OUTPUT
+          bot_login=$(jq --raw-output '.login' <<<"$bot_info")
+          bot_id=$(jq --raw-output '.id' <<<"$bot_info")
+          echo "bot_identity=$bot_login <$bot_id+$bot_login@users.noreply.github.com>" >> "$GITHUB_OUTPUT"
+          echo "bot_name=$bot_login" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: create-pr
+        if: needs.format-pr-branch.result == 'success' && needs.format-pr-branch.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           path: pr-branch
           commit-message: "format code"
-          title: "Format code for PR #${{ github.event.client_payload.pull_request.number }}"
-          body: "Automated code formatting for ${{ github.event.client_payload.pull_request.html_url }}"
+          title: "Format code for PR #${{ needs.validate-dispatch.outputs.pr-number }}"
+          body: "Automated code formatting for ${{ needs.validate-dispatch.outputs.pr-url }}"
           committer: ${{ steps.git-info.outputs.bot_identity }}
           author: ${{ steps.git-info.outputs.bot_identity }}
-          branch: format-${{ github.event.client_payload.pull_request.number }}-${{ github.event.client_payload.pull_request.head.ref }}
-          base: ${{ github.event.client_payload.pull_request.head.ref }}
+          branch: format-${{ needs.validate-dispatch.outputs.pr-number }}-${{ needs.validate-dispatch.outputs.head-ref }}
+          base: ${{ needs.validate-dispatch.outputs.head-ref }}
           push-to-fork: ${{ steps.git-info.outputs.bot_name }}/slang
           delete-branch: true
 
@@ -75,22 +242,26 @@ jobs:
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang
-          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          issue-number: ${{ needs.validate-dispatch.outputs.pr-number }}
           body: |
             ${{
-              steps.format.conclusion != 'success'
+              needs.format-pr-branch.result != 'success'
               && format('❌ Formatting failed. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
-              || (steps.create-pr.conclusion != 'success'
+              || (needs.format-pr-branch.outputs.has-changes != 'true'
+                  && '✅ Formatting completed; no changes were needed.'
+                  || (steps.create-pr.conclusion != 'success'
                   && format('❌ Failed to create formatting pull request. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
-                  || format('🌈 Formatted, please merge the changes from [this PR]({0})', steps.create-pr.outputs.pull-request-url))
+                  || format('🌈 Formatted, please merge the changes from [this PR]({0})', steps.create-pr.outputs.pull-request-url)))
             }}
 
       - name: Add reaction
-        if: steps.format.conclusion == 'success' && steps.create-pr.conclusion == 'success'
+        if: >-
+          needs.format-pr-branch.result == 'success' &&
+          (needs.format-pr-branch.outputs.has-changes != 'true' || steps.create-pr.conclusion == 'success')
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          comment-id: ${{ needs.validate-dispatch.outputs.comment-id }}
           reactions-edit-mode: replace
           reactions: hooray

--- a/.github/workflows/regenerate-toc.yml
+++ b/.github/workflows/regenerate-toc.yml
@@ -1,32 +1,122 @@
 name: Regenerate TOC
+# Security note:
+# PR branches can come from forks. The generation job checks out and updates the PR branch
+# without bot secrets, then the apply job validates and commits only the generated patch.
 on:
   repository_dispatch:
     types: [regenerate-toc-command]
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
-  regenerate-toc:
+  validate-dispatch:
     if: >-
       github.repository == 'shader-slang/slang' &&
-      github.event.client_payload.github.payload.repository.full_name == 'shader-slang/slang' &&
-      github.event.client_payload.pull_request.base.repo.full_name == 'shader-slang/slang'
+      github.event.client_payload.github.payload.repository.full_name == 'shader-slang/slang'
     runs-on: ubuntu-latest
+    outputs:
+      base-ref: ${{ steps.validate.outputs.base-ref }}
+      comment-id: ${{ steps.validate.outputs.comment-id }}
+      head-ref: ${{ steps.validate.outputs.head-ref }}
+      head-repository: ${{ steps.validate.outputs.head-repository }}
+      pr-number: ${{ steps.validate.outputs.pr-number }}
+      pr-url: ${{ steps.validate.outputs.pr-url }}
+    steps:
+      - name: Validate dispatch payload
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.client_payload.github.payload.comment.id }}
+          PAYLOAD_BASE_REPOSITORY: ${{ github.event.client_payload.pull_request.base.repo.full_name }}
+          PAYLOAD_REPOSITORY: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" ]]; then
+            echo "Missing pull request number or comment id in dispatch payload" >&2
+            exit 1
+          fi
+
+          if [[ "$PAYLOAD_REPOSITORY" != "shader-slang/slang" ||
+                "$PAYLOAD_BASE_REPOSITORY" != "shader-slang/slang" ]]; then
+            echo "Dispatch payload does not target shader-slang/slang" >&2
+            exit 1
+          fi
+
+          api() {
+            curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$@"
+          }
+
+          pr_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/pulls/$PR_NUMBER")
+          comment_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/issues/comments/$COMMENT_ID")
+
+          pr_number=$(jq -r '.number' <<<"$pr_json")
+          pr_url=$(jq -r '.html_url' <<<"$pr_json")
+          base_repository=$(jq -r '.base.repo.full_name' <<<"$pr_json")
+          base_ref=$(jq -r '.base.ref' <<<"$pr_json")
+          head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+          head_ref=$(jq -r '.head.ref' <<<"$pr_json")
+          comment_issue_url=$(jq -r '.issue_url' <<<"$comment_json")
+          comment_body=$(jq -r '.body // ""' <<<"$comment_json")
+          comment_user=$(jq -r '.user.login // ""' <<<"$comment_json")
+
+          if [[ "$pr_number" != "$PR_NUMBER" ||
+                "$base_repository" != "shader-slang/slang" ||
+                "$comment_issue_url" != "$GITHUB_API_URL/repos/shader-slang/slang/issues/$PR_NUMBER" ||
+                ! "$comment_body" =~ ^[[:space:]]*/regenerate-toc([[:space:]]|$) ]]; then
+            echo "Dispatch payload does not match an authorized /regenerate-toc pull request comment" >&2
+            exit 1
+          fi
+
+          permission_json=$(api "$GITHUB_API_URL/repos/shader-slang/slang/collaborators/$comment_user/permission")
+          permission=$(jq -r '.permission' <<<"$permission_json")
+          case "$permission" in
+            admin | maintain | write) ;;
+            *)
+              echo "Comment author does not have write permission" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "base-ref=$base_ref"
+            echo "comment-id=$COMMENT_ID"
+            echo "head-ref=$head_ref"
+            echo "head-repository=$head_repository"
+            echo "pr-number=$pr_number"
+            echo "pr-url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+
+  regenerate-toc-pr-branch:
+    needs: validate-dispatch
+    runs-on: ubuntu-latest
+    outputs:
+      has-changes: ${{ steps.toc-patch.outputs.has-changes }}
+      head-sha: ${{ steps.toc-patch.outputs.head-sha }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          repository: ${{ needs.validate-dispatch.outputs.head-repository }}
+          ref: ${{ needs.validate-dispatch.outputs.head-ref }}
           path: pr-branch
           persist-credentials: false
+          token: ${{ github.token }}
 
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
           repository: shader-slang/slang
-          ref: ${{ github.event.client_payload.pull_request.base.ref }}
+          ref: ${{ needs.validate-dispatch.outputs.base-ref }}
           path: target-branch
           persist-credentials: false
+          token: ${{ github.token }}
 
       - name: Install Mono
         run: |
@@ -38,32 +128,109 @@ jobs:
         run: |
           ./target-branch/docs/build_toc.sh --source ./pr-branch
 
+      - name: Create ToC patch
+        id: toc-patch
+        run: |
+          set -euo pipefail
+          echo "head-sha=$(git -C pr-branch rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git -C pr-branch diff --binary -- . > toc.patch
+          if [[ -s toc.patch ]]; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload ToC patch
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        with:
+          name: toc-patch
+          path: toc.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  apply-toc:
+    needs: [validate-dispatch, regenerate-toc-pr-branch]
+    if: >-
+      always() &&
+      needs.validate-dispatch.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        if: needs.regenerate-toc-pr-branch.result == 'success' && needs.regenerate-toc-pr-branch.outputs.has-changes == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.validate-dispatch.outputs.head-repository }}
+          ref: ${{ needs.validate-dispatch.outputs.head-ref }}
+          path: pr-branch
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - name: Download ToC patch
+        if: needs.regenerate-toc-pr-branch.result == 'success' && needs.regenerate-toc-pr-branch.outputs.has-changes == 'true'
+        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
+        with:
+          name: toc-patch
+          path: toc-patch
+
+      - name: Apply ToC patch
+        id: apply-patch
+        if: needs.regenerate-toc-pr-branch.result == 'success' && needs.regenerate-toc-pr-branch.outputs.has-changes == 'true'
+        run: |
+          set -euo pipefail
+          patch_file="$GITHUB_WORKSPACE/toc-patch/toc.patch"
+          if [[ ! -f "$patch_file" || -L "$patch_file" ]]; then
+            echo "ToC patch artifact is missing or invalid" >&2
+            exit 1
+          fi
+          expected_head_sha="${{ needs.regenerate-toc-pr-branch.outputs.head-sha }}"
+          actual_head_sha=$(git -C pr-branch rev-parse HEAD)
+          if [[ "$actual_head_sha" != "$expected_head_sha" ]]; then
+            echo "PR branch changed after regenerating ToC; please rerun /regenerate-toc" >&2
+            exit 1
+          fi
+          max_size=$((25 * 1024 * 1024))
+          actual_size=$(wc -c < "$patch_file")
+          if [[ "$actual_size" -gt "$max_size" ]]; then
+            echo "ToC patch artifact is too large" >&2
+            exit 1
+          fi
+          git -C pr-branch apply --check "$patch_file"
+          git -C pr-branch apply "$patch_file"
+
       - name: Configure Git commit signing
         id: git-info
+        if: needs.regenerate-toc-pr-branch.result == 'success' && needs.regenerate-toc-pr-branch.outputs.has-changes == 'true'
+        env:
+          SLANGBOT_PAT: ${{ secrets.SLANGBOT_PAT }}
+          SLANGBOT_SIGNING_KEY: ${{ secrets.SLANGBOT_SIGNING_KEY }}
         run: |
-          echo "${{ secrets.SLANGBOT_SIGNING_KEY }}" > "${{runner.temp}}"/signing_key
+          set -euo pipefail
+          printf '%s\n' "$SLANGBOT_SIGNING_KEY" > "${{runner.temp}}"/signing_key
           chmod 600 "${{runner.temp}}"/signing_key
           git -C pr-branch config commit.gpgsign true
           git -C pr-branch config gpg.format ssh
           git -C pr-branch config user.signingkey "${{runner.temp}}"/signing_key
-          bot_info=$(curl -s -H "Authorization: Bearer ${{ secrets.SLANGBOT_PAT }}" \
+          bot_info=$(curl -fsSL -H "Authorization: Bearer $SLANGBOT_PAT" \
             "https://api.github.com/user")
-          echo "bot_identity=$(echo $bot_info | jq --raw-output '.login + " <" + (.id|tostring) + "+" + .login + "@users.noreply.github.com>"')" >> $GITHUB_OUTPUT
-          echo "bot_name=$(echo $bot_info | jq --raw-output '.login')" >> $GITHUB_OUTPUT
+          bot_login=$(jq --raw-output '.login' <<<"$bot_info")
+          bot_id=$(jq --raw-output '.id' <<<"$bot_info")
+          echo "bot_identity=$bot_login <$bot_id+$bot_login@users.noreply.github.com>" >> "$GITHUB_OUTPUT"
+          echo "bot_name=$bot_login" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: create-pr
+        if: needs.regenerate-toc-pr-branch.result == 'success' && needs.regenerate-toc-pr-branch.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           path: pr-branch
           commit-message: "regenerate documentation Table of Contents"
-          title: "Regenerate documentation ToC for PR #${{ github.event.client_payload.pull_request.number }}"
-          body: "Automated ToC generation for ${{ github.event.client_payload.pull_request.html_url }}"
+          title: "Regenerate documentation ToC for PR #${{ needs.validate-dispatch.outputs.pr-number }}"
+          body: "Automated ToC generation for ${{ needs.validate-dispatch.outputs.pr-url }}"
           committer: ${{ steps.git-info.outputs.bot_identity }}
           author: ${{ steps.git-info.outputs.bot_identity }}
-          branch: regenerate-toc-${{ github.event.client_payload.pull_request.number }}-${{ github.event.client_payload.pull_request.head.ref }}
-          base: ${{ github.event.client_payload.pull_request.head.ref }}
+          branch: regenerate-toc-${{ needs.validate-dispatch.outputs.pr-number }}-${{ needs.validate-dispatch.outputs.head-ref }}
+          base: ${{ needs.validate-dispatch.outputs.head-ref }}
           push-to-fork: ${{ steps.git-info.outputs.bot_name }}/slang
           delete-branch: true
 
@@ -77,22 +244,26 @@ jobs:
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang
-          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          issue-number: ${{ needs.validate-dispatch.outputs.pr-number }}
           body: |
             ${{
-              steps.regen.conclusion != 'success'
+              needs.regenerate-toc-pr-branch.result != 'success'
               && format('❌ Table of Contents generation failed. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
-              || (steps.create-pr.conclusion != 'success'
+              || (needs.regenerate-toc-pr-branch.outputs.has-changes != 'true'
+                  && '✅ Table of Contents generation completed; no changes were needed.'
+                  || (steps.create-pr.conclusion != 'success'
                   && format('❌ Failed to create regenerate ToC pull request. Please check the [workflow run](https://github.com/{0}/actions/runs/{1})', github.repository, github.run_id)
-                  || format('🌈 Regenerated Table of Contents, please merge the changes from [this PR]({0})', steps.create-pr.outputs.pull-request-url))
+                  || format('🌈 Regenerated Table of Contents, please merge the changes from [this PR]({0})', steps.create-pr.outputs.pull-request-url)))
             }}
 
       - name: Add reaction
-        if: steps.regen.conclusion == 'success' && steps.create-pr.conclusion == 'success'
+        if: >-
+          needs.regenerate-toc-pr-branch.result == 'success' &&
+          (needs.regenerate-toc-pr-branch.outputs.has-changes != 'true' || steps.create-pr.conclusion == 'success')
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          comment-id: ${{ needs.validate-dispatch.outputs.comment-id }}
           reactions-edit-mode: replace
           reactions: hooray


### PR DESCRIPTION
## Summary of the problem from the end user perspective

The slash-command workflows for `/format` and `/regenerate-toc` still trusted repository dispatch pull request metadata when checking out fork branches. Under a compromised or misconfigured dispatcher, the secret-using jobs could interact with attacker-selected repositories before loading bot credentials.

## Root cause

PR #11241 removed bot credentials from checkout and ran trusted scripts from the target branch, but the same workflow job still checked out the payload-selected head repository and later configured commit signing and opened bot PRs. The workflows did not revalidate the dispatch payload against GitHub's PR/comment APIs before using the payload-selected fork.

## Solution in this PR

Split each workflow into a validation job, a no-secret generation job that uploads a patch artifact, and a guarded apply job that uses bot secrets only after validating the patch and PR head SHA. Both workflows now verify the slash command comment, target repository, real PR metadata, and commenter write permission through GitHub API before using branch metadata.

### Notes to the reviewers; where to focus on

Focus on `.github/workflows/format.yml` and `.github/workflows/regenerate-toc.yml`: the validation logic is intentionally duplicated so each `repository_dispatch` workflow is self-contained. The apply jobs also reject stale patch artifacts if the PR branch moved after generation.

## Related PRs in the past

- #11241 removed bot credentials from checkout and split `/regenerate-cmdline-ref`; this PR applies that stricter split to `/format` and `/regenerate-toc`.
