### PR TITLE
Fix unaligned byte-address descriptor loads

### DIFF
--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -240,16 +240,19 @@ struct ByteAddressBufferLegalizationContext
         return false;
     }
 
-    // Helper function to check if the alignment value passed is
-    // divisible by the offset at which the resource is indexed into
-    // in order to ensure if the load or store can be vectorized.
-    bool isAligned(IRInst* offset, IRInst* unknownOffsetAlignment, IRIntegerValue alignmentVal)
+    // Helper function to check if the offset at which the resource is indexed into
+    // is aligned enough to allow a vectorized load or store.
+    bool isAligned(
+        IRInst* baseOffset,
+        IRIntegerValue immediateOffset,
+        IRInst* unknownOffsetAlignment,
+        IRIntegerValue alignmentVal)
     {
-        if (auto baseOffsetVal = as<IRIntLit>(offset))
+        if (auto baseOffsetVal = as<IRIntLit>(baseOffset))
         {
             // If the offset is a constant known at compile time, simply check if it aligned to
             // the elementsize of the underlying resource.
-            return (baseOffsetVal->getValue() % alignmentVal) == 0;
+            return ((baseOffsetVal->getValue() + immediateOffset) % alignmentVal) == 0;
         }
         else if (auto alignInst = as<IRIntLit>(unknownOffsetAlignment))
         {
@@ -262,6 +265,9 @@ struct ByteAddressBufferLegalizationContext
             if (!alignInst->getValue())
                 return false;
 
+            if ((immediateOffset % alignmentVal) != 0)
+                return false;
+
             if ((alignInst->getValue() % alignmentVal) == 0)
             {
                 return true;
@@ -269,10 +275,35 @@ struct ByteAddressBufferLegalizationContext
             m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
                 .alignment = alignInst->getValue(),
                 .elementSize = alignmentVal,
-                .location = offset->sourceLoc,
+                .location = baseOffset->sourceLoc,
             });
         }
         return false;
+    }
+
+    IRType* getDescriptorHandleStorageType()
+    {
+        if (!m_options.translateToStructuredBufferOps)
+            return nullptr;
+
+        if (m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV))
+            return m_builder.getUInt64Type();
+
+        return m_builder.getVectorType(m_builder.getUIntType(), 2);
+    }
+
+    IROp getCastDescriptorHandleToStorageOp()
+    {
+        return m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV)
+                   ? kIROp_CastDescriptorHandleToUInt64
+                   : kIROp_CastDescriptorHandleToUInt2;
+    }
+
+    IROp getCastStorageToDescriptorHandleOp()
+    {
+        return m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV)
+                   ? kIROp_CastUInt64ToDescriptorHandle
+                   : kIROp_CastUInt2ToDescriptorHandle;
     }
 
     SlangResult getOffset(TargetProgram* target, IRStructField* field, IRIntegerValue* outOffset)
@@ -408,10 +439,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -427,6 +455,22 @@ struct ByteAddressBufferLegalizationContext
                 {
                     return emitSimpleLoad(type, buffer, baseOffset, immediateOffset);
                 }
+            }
+        }
+        else if (auto descriptorHandleType = as<IRDescriptorHandleType>(type))
+        {
+            if (auto storageType = getDescriptorHandleStorageType())
+            {
+                auto storageVal =
+                    emitLegalLoad(storageType, buffer, baseOffset, immediateOffset, alignment);
+                if (!storageVal)
+                    return nullptr;
+                IRInst* args[] = {storageVal};
+                return m_builder.emitIntrinsicInst(
+                    descriptorHandleType,
+                    getCastStorageToDescriptorHandleOp(),
+                    1,
+                    args);
             }
         }
         else if (auto matType = as<IRMatrixType>(type))
@@ -507,10 +551,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -1280,10 +1321,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1303,6 +1341,25 @@ struct ByteAddressBufferLegalizationContext
                         immediateOffset,
                         value);
                 }
+            }
+        }
+        else if (auto descriptorHandleType = as<IRDescriptorHandleType>(type))
+        {
+            if (auto storageType = getDescriptorHandleStorageType())
+            {
+                IRInst* args[] = {value};
+                auto storageVal = m_builder.emitIntrinsicInst(
+                    storageType,
+                    getCastDescriptorHandleToStorageOp(),
+                    1,
+                    args);
+                return emitLegalStore(
+                    storageType,
+                    buffer,
+                    baseOffset,
+                    immediateOffset,
+                    alignment,
+                    storageVal);
             }
         }
         else if (auto matType = as<IRMatrixType>(type))
@@ -1374,10 +1431,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceStore(
                         buffer,

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -248,6 +248,9 @@ struct ByteAddressBufferLegalizationContext
         IRInst* unknownOffsetAlignment,
         IRIntegerValue alignmentVal)
     {
+        if (alignmentVal <= 0)
+            return false;
+
         if (auto baseOffsetVal = as<IRIntLit>(baseOffset))
         {
             // If the offset is a constant known at compile time, simply check if it aligned to

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -1,0 +1,46 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -bindless-space-index 2 -O0
+
+// CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
+// CHECK-NOT: OpTypeRuntimeArray %[[V2UINT]]
+// CHECK-NOT: OpTypePointer StorageBuffer %[[V2UINT]]
+// CHECK: OpCompositeConstruct %[[V2UINT]]
+
+struct VectorStruct
+{
+    uint flags;
+    uint2 data;
+};
+
+struct HandleStruct
+{
+    uint flags;
+    DescriptorHandle<Texture2D<float4>> handle;
+};
+
+[[vk::binding(0, 0)]]
+ByteAddressBuffer inputBuffer;
+
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<uint> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    VectorStruct v = inputBuffer.Load<VectorStruct>(0);
+    HandleStruct h = inputBuffer.Load<HandleStruct>(0);
+    HandleStruct hAligned = inputBuffer.LoadAligned<HandleStruct>(0, 8);
+
+    uint2 handleBits = reinterpret<uint2>(h.handle);
+    uint2 alignedHandleBits = reinterpret<uint2>(hAligned.handle);
+
+    outputBuffer[0] = v.flags;
+    outputBuffer[1] = v.data.x;
+    outputBuffer[2] = v.data.y;
+    outputBuffer[3] = h.flags;
+    outputBuffer[4] = handleBits.x;
+    outputBuffer[5] = handleBits.y;
+    outputBuffer[6] = alignedHandleBits.x;
+    outputBuffer[7] = alignedHandleBits.y;
+}

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -bindless-space-index 2 -O0
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=RESULT): -vk -compute -shaderobj -xslang -bindless-space-index -xslang 2
 
 // CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
@@ -19,9 +20,11 @@ struct HandleStruct
 };
 
 [[vk::binding(0, 0)]]
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):name=inputBuffer
 ByteAddressBuffer inputBuffer;
 
 [[vk::binding(1, 0)]]
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 [shader("compute")]
@@ -44,3 +47,12 @@ void computeMain()
     outputBuffer[6] = alignedHandleBits.x;
     outputBuffer[7] = alignedHandleBits.y;
 }
+
+// RESULT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2


### PR DESCRIPTION
Fixes shader-slang/slang#9931

## Summary of the problem from the end user perspective

`ByteAddressBuffer.Load<T>()` could read the wrong data for `uint2` or `DescriptorHandle<T>` fields placed at offsets that are only 4-byte aligned when emitting SPIR-V.

### Minimal repro shader; if applicable

```slang
struct S
{
    uint flags;
    DescriptorHandle<Texture2D<float4>> handle;
};

ByteAddressBuffer inputBuffer;
S value = inputBuffer.Load<S>(0);
```

## Root cause

The SPIR-V byte-address-buffer legalization translated descriptor handles as opaque leaf values, so they could become `v2uint` structured-buffer loads even when the field offset was not 8-byte aligned. The vector alignment helper also ignored constant nested field offsets when checking whether a wide vector load was valid.

## Solution in this PR

Descriptor handles now legalize through their concrete storage representation before structured-buffer translation, using `uint2` for ordinary SPIR-V and `uint64` for `spvBindlessTextureNV`. The alignment check now includes both the dynamic base offset and the immediate nested offset before allowing vectorized load/store lowering.

### Notes to the reviewers; where to focus on

The key changes are in byte-address-buffer load/store legalization: descriptor-handle load/store recursion and the updated `isAligned` helper. The new `gh-9931` regression checks that unaligned `uint2` and descriptor-handle fields are reconstructed from scalar `uint` storage-buffer loads instead of introducing a storage-buffer `v2uint` alias.

## Reviewer Directives (maintained by agent)

- Human reviewer @jkwak-work requested a COMPARE_COMPUTE regression test for this PR; keep that runtime coverage in tests/bugs/gh-9931.slang. See https://github.com/jkwak-work/slang/pull/228#discussion_r3341912783.