### PR TITLE
Handle global descriptor handle casts in SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2828,6 +2828,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return emitMakeMatrixFromScalar(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 inst);
+        case kIROp_CastDescriptorHandleToUInt2:
+        case kIROp_CastUInt2ToDescriptorHandle:
+        case kIROp_CastUInt64ToDescriptorHandle:
+        case kIROp_CastDescriptorHandleToUInt64:
+        case kIROp_GlobalValueRef:
+            {
+                auto inner = ensureInst(inst->getOperand(0));
+                registerInst(inst, inner);
+                return inner;
+            }
         case kIROp_GlobalParam:
             return emitGlobalParam(as<IRGlobalParam>(inst));
         case kIROp_GlobalVar:

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage fragment -entry fragmentMain
+
+// A global DescriptorHandle constant lowers to a module-scope descriptor-handle
+// representation cast. SPIR-V emission should treat that cast as transparent.
+static const DescriptorHandle<SamplerState> kSampler =
+    DescriptorHandle<SamplerState>(uint2(0, 0));
+
+struct FragmentInput
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+struct Args
+{
+    DescriptorHandle<Texture2D<float4>> texture;
+};
+
+[[vk::push_constant]] uniform Args args;
+
+[shader("fragment")]
+float4 fragmentMain(FragmentInput input) : SV_Target
+{
+    return args.texture.Sample(kSampler, input.uv);
+}
+
+// CHECK: OpImageSampleImplicitLod


### PR DESCRIPTION
Fixes shader-slang/slang#9916

## Summary of the problem from the end user perspective

Declaring a `DescriptorHandle<SamplerState>` as a top-level static constant caused SPIR-V compilation to abort. The same handle worked when declared as a function-local constant.

### Minimal repro shader; if applicable

```slang
static const DescriptorHandle<SamplerState> kSampler =
    DescriptorHandle<SamplerState>(uint2(0, 0));

float4 fragmentMain(FragmentInput input) : SV_Target
{
    return args.texture.Sample(kSampler, input.uv);
}
```

## Root cause

Function-scope SPIR-V emission already treated descriptor-handle representation casts as transparent. Module-scope emission did not, so a global `CastUInt2ToDescriptorHandle` reached the unhandled global instruction path.

## Solution in this PR

The SPIR-V global emitter now forwards descriptor-handle representation casts to their operand, matching the existing local instruction behavior. A regression test covers a global sampler handle used in a fragment sample.

### Notes to the reviewers; where to focus on

The code change is intentionally limited to the global `ensureInst` switch in the SPIR-V emitter. The test exercises the issue shape and checks that SPIR-V sampling emission completes.

## Related PRs in the past

shader-slang/slang#9870 was mentioned while triaging this issue, but this PR handles the remaining module-scope cast path directly.
