### PR TITLE
Handle descriptor heap byte address buffers

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,6 +26997,9 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
+    // Under spvDescriptorHeapEXT, a scalar handle is a resource-heap index.
+    // Keep this distinct from the uint64_t constructors used by CUDA and
+    // spvBindlessTextureNV so integer literals do not select the wrong layout.
     [ForceInline]
     [require(spvDescriptorHeapEXT, descriptor_handle)]
     __init(uint handleValue)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,6 +26997,20 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
+    [ForceInline]
+    [require(spvDescriptorHeapEXT, descriptor_handle)]
+    __init(uint handleValue)
+    {
+        return DescriptorHandle<T>(uint2(handleValue, 0));
+    }
+
+    [ForceInline]
+    [require(spvDescriptorHeapEXT, descriptor_handle)]
+    __init(int handleValue)
+    {
+        return DescriptorHandle<T>(uint(handleValue));
+    }
+
     /// Constructor for uint64_t handles
     [ForceInline]
     [require(spvBindlessTextureNV, descriptor_handle)]

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,23 +26997,6 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
-    // Under spvDescriptorHeapEXT, a scalar handle is a resource-heap index.
-    // Keep this distinct from the uint64_t constructors used by CUDA and
-    // spvBindlessTextureNV so integer literals do not select the wrong layout.
-    [ForceInline]
-    [require(spvDescriptorHeapEXT, descriptor_handle)]
-    __init(uint handleValue)
-    {
-        return DescriptorHandle<T>(uint2(handleValue, 0));
-    }
-
-    [ForceInline]
-    [require(spvDescriptorHeapEXT, descriptor_handle)]
-    __init(int handleValue)
-    {
-        return DescriptorHandle<T>(uint(handleValue));
-    }
-
     /// Constructor for uint64_t handles
     [ForceInline]
     [require(spvBindlessTextureNV, descriptor_handle)]

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -969,6 +969,9 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
         {
+            // Under spvDescriptorHeapEXT, DescriptorHandle<T> dereferences lower to a heap load.
+            // Reinterpret that heap-sourced ByteAddressBuffer as the equivalent StructuredBuffer
+            // before replacing byte-address loads/stores with structured-buffer operations.
             auto structuredBufferType =
                 getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
             if (!structuredBufferType)

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -967,6 +967,18 @@ struct ByteAddressBufferLegalizationContext
                 1,
                 &arg);
         }
+        else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
+        {
+            auto structuredBufferType =
+                getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
+            if (!structuredBufferType)
+                return nullptr;
+
+            return m_builder.emitLoadDescriptorFromHeap(
+                structuredBufferType,
+                loadDescriptor->getHeap(),
+                loadDescriptor->getIndex());
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -969,9 +969,6 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
         {
-            // Under spvDescriptorHeapEXT, DescriptorHandle<T> dereferences lower to a heap load.
-            // Reinterpret that heap-sourced ByteAddressBuffer as the equivalent StructuredBuffer
-            // before replacing byte-address loads/stores with structured-buffer operations.
             auto structuredBufferType =
                 getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
             if (!structuredBufferType)

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -19,38 +19,27 @@
 //TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
 
-//TEST_INPUT: set runtimeReadOnlyBuffer = ubuffer(data=[4 99], stride=4)
-uniform ByteAddressBuffer.Handle runtimeReadOnlyBuffer;
+//TEST_INPUT: set readOnlyBuffer = ubuffer(data=[4 99], stride=4)
+uniform ByteAddressBuffer.Handle readOnlyBuffer;
 
-//TEST_INPUT: set runtimeReadWriteBuffer = ubuffer(data=[0 0], stride=4)
-uniform RWByteAddressBuffer.Handle runtimeReadWriteBuffer;
+//TEST_INPUT: set readWriteBuffer = ubuffer(data=[0 0], stride=4)
+uniform RWByteAddressBuffer.Handle readWriteBuffer;
+
+uniform RasterizerOrderedByteAddressBuffer.Handle rasterOrderedBuffer;
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-#if defined(RUNTIME)
-    let value0 = runtimeReadOnlyBuffer.Load<uint>(0);
-    runtimeReadWriteBuffer.Store<uint>(4, value0 * 2);
+    let value0 = readOnlyBuffer.Load<uint>(0);
+    readWriteBuffer.Store<uint>(4, value0 * 2);
 
     output[0] = value0;
-    output[1] = runtimeReadWriteBuffer.Load<uint>(4);
-#else
-    let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
-    let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
-
-    let value0 = readOnlyBuffer.Load<uint>(0);
-    readWriteBuffer.Store<uint>(4, value0 + 1);
-    let value1 = readWriteBuffer.Load<uint>(4);
-    output[0] = value1;
-#endif
+    output[1] = readWriteBuffer.Load<uint>(4);
 }
 
 [shader("fragment")]
 float4 fragmentMain() : SV_Target
 {
-    let rasterOrderedBuffer =
-        DescriptorHandle<RasterizerOrderedByteAddressBuffer>(uint(2));
-
     rasterOrderedBuffer.Store<uint>(8, 1);
     return float4(rasterOrderedBuffer.Load<uint>(8), 0, 0, 1);
 }

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -1,0 +1,36 @@
+// Regression test for descriptor-heap sourced ByteAddressBuffer values.
+// Byte-address-buffer legalization must rewrite the heap load to an equivalent
+// structured-buffer heap load before SPIR-V emission.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
+//TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+
+// CHECK: OpCapability DescriptorHeapEXT
+// CHECK: OpUntypedAccessChainKHR
+
+// ROV: OpCapability DescriptorHeapEXT
+// ROV: OpUntypedAccessChainKHR
+
+RWStructuredBuffer<uint> output;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
+    let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
+
+    let value0 = readOnlyBuffer.Load<uint>(0);
+    readWriteBuffer.Store<uint>(4, value0 + 1);
+    let value1 = readWriteBuffer.Load<uint>(4);
+    output[0] = value1;
+}
+
+[shader("fragment")]
+float4 fragmentMain() : SV_Target
+{
+    let rasterOrderedBuffer =
+        DescriptorHandle<RasterizerOrderedByteAddressBuffer>(uint(2));
+
+    rasterOrderedBuffer.Store<uint>(8, 1);
+    return float4(rasterOrderedBuffer.Load<uint>(8), 0, 0, 1);
+}

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -2,8 +2,13 @@
 // Byte-address-buffer legalization must rewrite the heap load to an equivalent
 // structured-buffer heap load before SPIR-V emission.
 
+//TEST:COMPARE_COMPUTE(filecheck-buffer=RUNTIME): -vk -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly -Xslang -DRUNTIME
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
 //TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+
+// RUNTIME: type: uint
+// RUNTIME-NEXT: 4
+// RUNTIME-NEXT: 8
 
 // CHECK: OpCapability DescriptorHeapEXT
 // CHECK: OpUntypedAccessChainKHR
@@ -11,11 +16,25 @@
 // ROV: OpCapability DescriptorHeapEXT
 // ROV: OpUntypedAccessChainKHR
 
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
+
+//TEST_INPUT: set runtimeReadOnlyBuffer = ubuffer(data=[4 99], stride=4)
+uniform ByteAddressBuffer.Handle runtimeReadOnlyBuffer;
+
+//TEST_INPUT: set runtimeReadWriteBuffer = ubuffer(data=[0 0], stride=4)
+uniform RWByteAddressBuffer.Handle runtimeReadWriteBuffer;
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
+#if defined(RUNTIME)
+    let value0 = runtimeReadOnlyBuffer.Load<uint>(0);
+    runtimeReadWriteBuffer.Store<uint>(4, value0 * 2);
+
+    output[0] = value0;
+    output[1] = runtimeReadWriteBuffer.Load<uint>(4);
+#else
     let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
     let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
 
@@ -23,6 +42,7 @@ void computeMain()
     readWriteBuffer.Store<uint>(4, value0 + 1);
     let value1 = readWriteBuffer.Load<uint>(4);
     output[0] = value1;
+#endif
 }
 
 [shader("fragment")]


### PR DESCRIPTION
Fixes shader-slang/slang#10440
Fixes https://github.com/shader-slang/slang/issues/10979

## Summary of the problem from the end user perspective

SPIR-V compilation could fail for descriptor-heap `DescriptorHandle<ByteAddressBuffer>` values used through `Load<T>`. The same lowering gap affected writable and raster-ordered byte-address buffer handles.

### Minimal repro shader; if applicable

```slang
RWStructuredBuffer<uint> output;
[numthreads(1, 1, 1)]
void computeMain()
{
    let handle = DescriptorHandle<ByteAddressBuffer>(0);
    output[0] = handle.Load<uint>(0);
}
```

## Root cause

Byte-address-buffer legalization rewrites raw buffer loads and stores to equivalent structured-buffer operations for SPIR-V, but it did not recognize `IRSPIRVLoadDescriptorFromHeap` as a buffer source. The scalar `DescriptorHandle<T>(0)` form could also select the 64-bit bindless constructor instead of the descriptor-heap `uint2` representation.

## Solution in this PR

Re-emit descriptor-heap loads with the equivalent structured-buffer type during byte-address-buffer legalization. Add `spvDescriptorHeapEXT` scalar descriptor-handle constructors and regression coverage for read-only, read-write, and rasterizer-ordered byte-address buffers.

### Notes to the reviewers; where to focus on

The legalization change preserves the original descriptor heap and index while changing only the loaded resource type. The new scalar constructors are gated to `spvDescriptorHeapEXT`, so CUDA and `spvBindlessTextureNV` `uint64_t` handle construction remains separate.
