### PR TITLE
Fix ByteAddressBuffer descriptor heap legalization

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -611,7 +611,9 @@ are not opaque handles, `DescriptorHandle<T>` maps to `T` and will have the same
 struct DescriptorHandle<T> where T:IOpaqueDescriptor {}
 ```
 where `IOpaqueDescriptor` is an interface implemented by all resource types, including textures,
-`ConstantBuffer`, `RaytracingAccelerationStructure`, `SamplerState`, `SamplerComparisonState` and all types of `StructuredBuffer`.
+`ConstantBuffer`, `RaytracingAccelerationStructure`, `SamplerState`, `SamplerComparisonState`,
+all types of `StructuredBuffer`, and all byte-address buffer types (`ByteAddressBuffer`,
+`RWByteAddressBuffer`, `RasterizerOrderedByteAddressBuffer`).
 
 You may also write `Texture2D.Handle` as a shorthand for `DescriptorHandle<Texture2D>`.
 

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -967,6 +967,24 @@ struct ByteAddressBufferLegalizationContext
                 1,
                 &arg);
         }
+        else if (byteAddressBuffer->getOp() == kIROp_SPIRVLoadDescriptorFromHeap)
+        {
+            // For spvDescriptorHeapEXT, re-emit the heap load with the equivalent
+            // StructuredBuffer<T> type so downstream SPIR-V legalization turns it
+            // into a pointer-typed storage buffer resource.
+            auto equivalentType = getEquivalentStructuredBufferParamType(
+                elementType,
+                byteAddressBuffer->getDataType());
+            if (!equivalentType)
+                return nullptr;
+
+            IRInst* args[2] = {byteAddressBuffer->getOperand(0), byteAddressBuffer->getOperand(1)};
+            return m_builder.emitIntrinsicInst(
+                equivalentType,
+                kIROp_SPIRVLoadDescriptorFromHeap,
+                2,
+                args);
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/tests/cooperative-vector/matrix-mul-descriptor-heap-spirv.slang
+++ b/tests/cooperative-vector/matrix-mul-descriptor-heap-spirv.slang
@@ -1,0 +1,34 @@
+// Regression test for issue #10979:
+// coopVecLoad and coopVecMatMul with DescriptorHandle<*ByteAddressBuffer> should compile
+// to valid SPIR-V when spvDescriptorHeapEXT is requested.
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -capability spvCooperativeVectorNV
+
+// CHECK: OpBufferPointerEXT
+// CHECK: OpCooperativeVectorLoadNV
+// CHECK: OpCooperativeVectorMatrixMulNV
+
+RWStructuredBuffer<float16_t> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    DescriptorHandle<RWByteAddressBuffer> input =
+        DescriptorHandle<RWByteAddressBuffer>(uint2(0, 0));
+    DescriptorHandle<ByteAddressBuffer> weights =
+        DescriptorHandle<ByteAddressBuffer>(uint2(1, 0));
+
+    CoopVec<float16_t, 4> layer = coopVecLoad<4, float16_t>(input, 0);
+
+    let output = coopVecMatMul<float16_t, 4, 4>(
+        layer,
+        CoopVecComponentType::Float16,
+        weights,
+        0,
+        CoopVecComponentType::Float16,
+        CoopVecMatrixLayout::RowMajor,
+        false,
+        8);
+
+    outputBuffer[0] = output[0];
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10979

## Summary of the problem from the end user perspective

Using `DescriptorHandle<ByteAddressBuffer>` or `DescriptorHandle<RWByteAddressBuffer>` with `spvDescriptorHeapEXT` could hit an internal compiler error when the handle fed cooperative vector operations.

### Minimal repro shader; if applicable

```slang
DescriptorHandle<RWByteAddressBuffer> input = DescriptorHandle<RWByteAddressBuffer>(uint2(0, 0));
DescriptorHandle<ByteAddressBuffer> weights = DescriptorHandle<ByteAddressBuffer>(uint2(1, 0));
CoopVec<float16_t, 4> layer = coopVecLoad<4, float16_t>(input, 0);
let output = coopVecMatMul<float16_t, 4, 4>(layer, CoopVecComponentType::Float16, weights, 0, CoopVecComponentType::Float16, CoopVecMatrixLayout::RowMajor, false, 8);
```

## Root cause

Byte-address buffer legalization did not handle `kIROp_SPIRVLoadDescriptorFromHeap`, so descriptor-heap byte-address buffers could reach SPIR-V emit without being rewritten to an equivalent typed structured buffer resource.

## Solution in this PR

Add the missing descriptor-heap load case in `getEquivalentStructuredBuffer()` and re-emit the heap load with the equivalent `StructuredBuffer<T>` type before downstream SPIR-V legalization.

### Notes to the reviewers; where to focus on

The core change is the new `kIROp_SPIRVLoadDescriptorFromHeap` branch in `source/slang/slang-ir-byte-address-legalize.cpp`. The new cooperative-vector test checks that descriptor-heap byte-address buffers produce `OpBufferPointerEXT`, `OpCooperativeVectorLoadNV`, and `OpCooperativeVectorMatrixMulNV` instead of tripping the old assertion.

## Related PRs in the past

- shader-slang/slang#11014: earlier related fix attempt for byte-address buffers with `spvDescriptorHeapEXT`.
