### PR TITLE
Convert descriptor heap AS addresses

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7094,6 +7094,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_SamplerComparisonStateType:
             descriptorElementType = ensureInst(valueType);
             break;
+        case kIROp_UInt64Type:
+            descriptorElementType = ensureInst(valueType);
+            break;
         default:
             isBufferResource = true;
             descriptorElementType = ensureDescriptorHeapBufferDescriptorType(

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4914,6 +4914,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     emitDescriptorHeapLoad(parent, inst, loadDesc->getHeap(), loadDesc->getIndex());
                 break;
             }
+        case kIROp_SPIRVConvertUToAccelerationStructure:
+            result = emitSPIRVConvertUToAccelerationStructure(
+                parent,
+                cast<IRSPIRVConvertUToAccelerationStructure>(inst));
+            break;
         case kIROp_SPIRVLoadTexelPointerFromHeap:
             {
                 auto loadDesc = as<IRSPIRVLoadTexelPointerFromHeap>(inst);
@@ -7155,6 +7160,20 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return result;
         }
         return emitOpLoad(parent, inst, inst->getDataType(), valuePtr);
+    }
+
+    SpvInst* emitSPIRVConvertUToAccelerationStructure(
+        SpvInstParent* parent,
+        IRSPIRVConvertUToAccelerationStructure* inst)
+    {
+        ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_ray_tracing"));
+        return emitInst(
+            parent,
+            inst,
+            SpvOpConvertUToAccelerationStructureKHR,
+            inst->getDataType(),
+            kResultID,
+            inst->getAddress());
     }
 
     SpvInst* maybeEmitSystemVal(IRInst* inst)

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -832,5 +832,6 @@ return {
 	["SubpassLoad"] = 856,
 	["TranslateBase.IdentityRemat"] = 857,
 	["IncrementFunctionCoverageCounter"] = 858,
-	["IncrementBranchCoverageCounter"] = 859
+	["IncrementBranchCoverageCounter"] = 859,
+	["SPIRVConvertUToAccelerationStructure"] = 860,
 }

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -987,6 +987,11 @@ local insts = {
 		},
 	},
 	{
+		SPIRVConvertUToAccelerationStructure = {
+			operands = { { "address" } },
+		},
+	},
+	{
 		SPIRVLoadTexelPointerFromHeap = {
 			operands = { { "heap" }, { "index" }, { "textureType" }, { "coord" }, { "sampleIndex" } },
 		},

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -28,6 +28,8 @@
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
 
+#include <spirv/unified1/spirv.h>
+
 namespace Slang
 {
 
@@ -1634,6 +1636,45 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         inst->removeAndDeallocate();
     }
 
+    void processSPIRVLoadDescriptorFromHeap(IRSPIRVLoadDescriptorFromHeap* inst)
+    {
+        if (inst->getDataType()->getOp() != kIROp_RaytracingAccelerationStructureType)
+            return;
+
+        IRBuilder builder(inst);
+        builder.setInsertBefore(inst);
+        auto address = builder.emitLoadDescriptorFromHeap(
+            builder.getUInt64Type(),
+            inst->getHeap(),
+            inst->getIndex());
+
+        auto asmInst = builder.emitSPIRVAsm(inst->getDataType());
+        {
+            IRBuilderInsertLocScope insertScope(&builder);
+            builder.setInsertInto(asmInst);
+
+            auto extensionOp = builder.emitSPIRVAsmOperandEnum(
+                builder.getIntValue(builder.getUIntType(), SpvOpExtension));
+            List<IRInst*> extensionOperands;
+            extensionOperands.add(builder.emitSPIRVAsmOperandLiteral(
+                builder.getStringValue(UnownedStringSlice::fromLiteral("SPV_KHR_ray_tracing"))));
+            builder.emitSPIRVAsmInst(extensionOp, extensionOperands);
+
+            auto convertOp = builder.emitSPIRVAsmOperandEnum(builder.getIntValue(
+                builder.getUIntType(),
+                SpvOpConvertUToAccelerationStructureKHR));
+            List<IRInst*> convertOperands;
+            convertOperands.add(builder.emitSPIRVAsmOperandInst(inst->getDataType()));
+            convertOperands.add(builder.emitSPIRVAsmOperandResult());
+            convertOperands.add(builder.emitSPIRVAsmOperandInst(address));
+            builder.emitSPIRVAsmInst(convertOp, convertOperands);
+        }
+
+        inst->replaceUsesWith(asmInst);
+        inst->removeAndDeallocate();
+        addUsersToWorkList(asmInst);
+    }
+
     static bool isAsmInst(IRInst* inst)
     {
         return (as<IRSPIRVAsmInst>(inst) || as<IRSPIRVAsmOperand>(inst));
@@ -2071,6 +2112,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 break;
             case kIROp_MakeCombinedTextureSamplerFromHandle:
                 processMakeCombinedTextureSamplerFromHandle(inst);
+                break;
+            case kIROp_SPIRVLoadDescriptorFromHeap:
+                processSPIRVLoadDescriptorFromHeap(cast<IRSPIRVLoadDescriptorFromHeap>(inst));
                 break;
             case kIROp_PtrLit:
                 processPtrLit(inst);

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -28,8 +28,6 @@
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
 
-#include <spirv/unified1/spirv.h>
-
 namespace Slang
 {
 
@@ -1648,31 +1646,16 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             inst->getHeap(),
             inst->getIndex());
 
-        auto asmInst = builder.emitSPIRVAsm(inst->getDataType());
-        {
-            IRBuilderInsertLocScope insertScope(&builder);
-            builder.setInsertInto(asmInst);
+        IRInst* addressArgs[] = {address};
+        auto accelerationStructure = builder.emitIntrinsicInst(
+            inst->getDataType(),
+            kIROp_SPIRVConvertUToAccelerationStructure,
+            SLANG_COUNT_OF(addressArgs),
+            addressArgs);
 
-            auto extensionOp = builder.emitSPIRVAsmOperandEnum(
-                builder.getIntValue(builder.getUIntType(), SpvOpExtension));
-            List<IRInst*> extensionOperands;
-            extensionOperands.add(builder.emitSPIRVAsmOperandLiteral(
-                builder.getStringValue(UnownedStringSlice::fromLiteral("SPV_KHR_ray_tracing"))));
-            builder.emitSPIRVAsmInst(extensionOp, extensionOperands);
-
-            auto convertOp = builder.emitSPIRVAsmOperandEnum(builder.getIntValue(
-                builder.getUIntType(),
-                SpvOpConvertUToAccelerationStructureKHR));
-            List<IRInst*> convertOperands;
-            convertOperands.add(builder.emitSPIRVAsmOperandInst(inst->getDataType()));
-            convertOperands.add(builder.emitSPIRVAsmOperandResult());
-            convertOperands.add(builder.emitSPIRVAsmOperandInst(address));
-            builder.emitSPIRVAsmInst(convertOp, convertOperands);
-        }
-
-        inst->replaceUsesWith(asmInst);
+        inst->replaceUsesWith(accelerationStructure);
         inst->removeAndDeallocate();
-        addUsersToWorkList(asmInst);
+        addUsersToWorkList(accelerationStructure);
     }
 
     static bool isAsmInst(IRInst* inst)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -9334,6 +9334,7 @@ bool IRInst::mightHaveSideEffects(SideEffectAnalysisOptions options)
     case kIROp_CastDescriptorHandleToUInt64:
     case kIROp_CastDescriptorHandleToResource:
     case kIROp_CastResourceToDescriptorHandle:
+    case kIROp_SPIRVConvertUToAccelerationStructure:
     case kIROp_GetDynamicResourceHeap:
     case kIROp_CastDynamicResource:
     case kIROp_AllocObj:

--- a/tests/spirv/descriptor-heap-acceleration-structure.slang
+++ b/tests/spirv/descriptor-heap-acceleration-structure.slang
@@ -1,0 +1,36 @@
+// Regression test for issue #10671. With spvDescriptorHeapEXT, an acceleration
+// structure descriptor heap entry is a device address and must be converted to
+// OpTypeAccelerationStructureKHR before ray query use.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry compute_main -stage compute -capability spvDescriptorHeapEXT -capability spvRayQueryKHR -spirv-resource-heap-stride 32
+
+struct Params
+{
+    DescriptorHandle<RaytracingAccelerationStructure> accelerationStructure;
+    DescriptorHandle<RWStructuredBuffer<uint>> output;
+};
+
+// CHECK: OpExtension "SPV_KHR_ray_tracing"
+// CHECK-DAG: %[[UINT64:[A-Za-z0-9_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[RTAS:[A-Za-z0-9_]+]] = OpTypeAccelerationStructureKHR
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void compute_main(uniform Params params)
+{
+    RayDesc ray;
+    ray.Origin = float3(0.0f, 0.0f, 1.0f);
+    ray.Direction = float3(0.0f, 0.0f, -1.0f);
+    ray.TMin = 0.0f;
+    ray.TMax = 100.0f;
+
+    RayQuery<RAY_FLAG_FORCE_NON_OPAQUE> query;
+
+    // CHECK: %[[ADDRESS:[A-Za-z0-9_]+]] = OpLoad %[[UINT64]]
+    // CHECK: %[[AS:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR %[[RTAS]] %[[ADDRESS]]
+    // CHECK: OpRayQueryInitializeKHR {{.*}} %[[AS]]
+    query.TraceRayInline(params.accelerationStructure, RAY_FLAG_FORCE_NON_OPAQUE, 0xff, ray);
+    bool proceed = query.Proceed();
+
+    params.output[0] = uint(query.CommittedStatus()) + uint(proceed);
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10671

## Summary of the problem from the end user perspective

Shaders that load `DescriptorHandle<RaytracingAccelerationStructure>` through `spvDescriptorHeapEXT` could emit invalid SPIR-V because the heap entry was used as an acceleration-structure object instead of an address.

### Minimal repro shader; if applicable

```hlsl
DescriptorHandle<RaytracingAccelerationStructure> accelerationStructure;
RayQuery<RAY_FLAG_FORCE_NON_OPAQUE> query;
query.TraceRayInline(accelerationStructure, RAY_FLAG_FORCE_NON_OPAQUE, 0xff, ray);
```

## Root cause

The SPIR-V descriptor heap load path emitted a heap load with `OpTypeAccelerationStructureKHR` as the descriptor element type. For acceleration structures, the descriptor heap stores a `uint64_t` device address that must be converted before ray-query use.

## Solution in this PR

Legalize acceleration-structure descriptor heap loads into a `uint64_t` heap load followed by an internal SPIR-V conversion IR op. The emitter translates that conversion op to `OpConvertUToAccelerationStructureKHR` and supports `uint64_t` as a descriptor heap element type for the lowered form. The PR adds focused SPIR-V regression coverage.

### Notes to the reviewers; where to focus on

The main behavior change is in SPIR-V legalization, where `SPIRVLoadDescriptorFromHeap<RaytracingAccelerationStructure>` is rewritten before emission. The emitter changes are limited to translating the legalized conversion op and permitting the legalized `uint64_t` heap element load.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Do not synthesize `spirv_asm` in the SPIR-V legalization pass; use a regular IR op and let the SPIR-V emitter translate it. (https://github.com/jkwak-work/slang/pull/232#discussion_r3349262564)
