### PR TITLE
Handle descriptor heap byte-address coop vectors

### DIFF
--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -967,6 +967,19 @@ struct ByteAddressBufferLegalizationContext
                 1,
                 &arg);
         }
+        else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
+        {
+            auto structuredBufferType = getEquivalentStructuredBufferParamType(
+                elementType,
+                byteAddressBuffer->getDataType());
+            if (!structuredBufferType)
+                return nullptr;
+
+            return m_builder.emitLoadDescriptorFromHeap(
+                structuredBufferType,
+                loadDescriptor->getHeap(),
+                loadDescriptor->getIndex());
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/tests/cooperative-vector/matrix-mul-descriptor-heap.slang
+++ b/tests/cooperative-vector/matrix-mul-descriptor-heap.slang
@@ -1,0 +1,35 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -capability spvCooperativeVectorNV
+
+// CHECK-DAG: OpCapability CooperativeVectorNV
+// CHECK-DAG: OpCapability DescriptorHeapEXT
+// CHECK-DAG: OpExtension "SPV_EXT_descriptor_heap"
+// CHECK-DAG: BuiltIn ResourceHeapEXT
+// CHECK: OpBufferPointerEXT
+// CHECK: OpCooperativeVectorLoadNV
+// CHECK: OpBufferPointerEXT
+// CHECK: OpCooperativeVectorMatrixMulNV
+
+RWStructuredBuffer<float16_t> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 threadID: SV_DispatchThreadID)
+{
+    DescriptorHandle<RWByteAddressBuffer> input =
+        DescriptorHandle<RWByteAddressBuffer>(uint2(3024, 0));
+    DescriptorHandle<ByteAddressBuffer> weights =
+        DescriptorHandle<ByteAddressBuffer>(uint2(3025, 0));
+
+    let inputVec = coopVecLoad<4, float16_t>(input);
+    let output = coopVecMatMul<float16_t, 4, 4>(
+        inputVec,
+        CoopVecComponentType::Float16,
+        weights,
+        0,
+        CoopVecComponentType::Float16,
+        CoopVecMatrixLayout::RowMajor,
+        false,
+        8);
+
+    outputBuffer[threadID.x] = output[0];
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10979

## Summary of the problem from the end user perspective
Cooperative vector load and matrix multiply operations could hit a Slang internal error when their byte-address buffers came from `DescriptorHandle` values under `spvDescriptorHeapEXT`.

### Minimal repro shader; if applicable
```slang
DescriptorHandle<RWByteAddressBuffer> input = DescriptorHandle<RWByteAddressBuffer>(uint2(3024, 0));
DescriptorHandle<ByteAddressBuffer> weights = DescriptorHandle<ByteAddressBuffer>(uint2(3025, 0));
let inputVec = coopVecLoad<4, float16_t>(input);
let output = coopVecMatMul<float16_t, 4, 4>(inputVec, CoopVecComponentType::Float16, weights, 0, CoopVecComponentType::Float16, CoopVecMatrixLayout::RowMajor, false, 8);
```

## Root cause
Byte-address legalization converts byte-address buffers to equivalent structured-buffer operands for SPIR-V cooperative-vector paths, but it did not recognize byte-address buffers loaded from the SPIR-V descriptor heap.

## Solution in this PR
When byte-address legalization sees `SPIRVLoadDescriptorFromHeap`, it now re-emits that descriptor load with the equivalent structured-buffer type. A SPIR-V assembly regression verifies descriptor-heap buffer pointers feed both `OpCooperativeVectorLoadNV` and `OpCooperativeVectorMatrixMulNV`.

### Notes to the reviewers; where to focus on
The behavioral change is limited to `getEquivalentStructuredBuffer` handling in byte-address legalization. The regression test checks the exact SPIR-V descriptor heap and cooperative-vector instructions without requiring runtime GPU execution.
