### PR TITLE
Add bindless resource metadata usage query

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -4539,6 +4539,29 @@ struct IMetadata : public ISlangCastable
 };
     #define SLANG_UUID_IMetadata IMetadata::getTypeGuid()
 
+/** Bindless resource metadata produced for a compiled target.
+
+The bindless space index reported through program reflection is a frontend-predicted reserved
+descriptor space. It remains stable even when later optimization or target lowering removes all
+descriptor-handle heap use from the emitted shader. This metadata interface reports the
+post-lowering usage signal instead.
+
+Cast from an artifact-associated `IMetadata*` using `castAs()`.
+*/
+struct IBindlessResourceMetadata : public ISlangCastable
+{
+    SLANG_COM_INTERFACE(
+        0xeafa96d3,
+        0x2352,
+        0x4bf4,
+        {0x88, 0x64, 0x32, 0x28, 0xa4, 0x07, 0x7a, 0x83})
+
+    /// Returns true when the compiled target uses a bindless descriptor
+    /// heap/resource-handle path after target-specific lowering.
+    virtual SLANG_NO_THROW bool SLANG_MCALL usesBindlessResourceHeap() = 0;
+};
+    #define SLANG_UUID_IBindlessResourceMetadata IBindlessResourceMetadata::getTypeGuid()
+
 /** Coverage tracing metadata produced when any shader coverage mode is active.
 
 The current implementation reports line, function-entry, and branch-arm

--- a/source/compiler-core/slang-artifact-associated-impl.cpp
+++ b/source/compiler-core/slang-artifact-associated-impl.cpp
@@ -289,6 +289,8 @@ void* ArtifactPostEmitMetadata::getInterface(const Guid& guid)
     }
     if (guid == slang::IMetadata::getTypeGuid())
         return static_cast<slang::IMetadata*>(this);
+    if (guid == slang::IBindlessResourceMetadata::getTypeGuid())
+        return static_cast<slang::IBindlessResourceMetadata*>(this);
     if (guid == slang::ICoverageTracingMetadata::getTypeGuid())
     {
         return static_cast<slang::ICoverageTracingMetadata*>(this);
@@ -354,6 +356,11 @@ SlangResult ArtifactPostEmitMetadata::isParameterLocationUsed(
 const char* ArtifactPostEmitMetadata::getDebugBuildIdentifier()
 {
     return m_debugBuildIdentifier.getBuffer();
+}
+
+bool ArtifactPostEmitMetadata::usesBindlessResourceHeap()
+{
+    return m_usesBindlessResourceHeap;
 }
 
 uint32_t ArtifactPostEmitMetadata::getCounterCount()

--- a/source/compiler-core/slang-artifact-associated-impl.h
+++ b/source/compiler-core/slang-artifact-associated-impl.h
@@ -220,6 +220,7 @@ enum class SyntheticResourceKnownID : uint32_t
 
 class ArtifactPostEmitMetadata : public ComBaseObject,
                                  public IArtifactPostEmitMetadata,
+                                 public slang::IBindlessResourceMetadata,
                                  public slang::ICoverageTracingMetadata,
                                  public slang::ISyntheticResourceMetadata,
                                  public slang::ICooperativeTypesMetadata
@@ -248,6 +249,9 @@ public:
         bool& outUsed) SLANG_OVERRIDE;
 
     SLANG_NO_THROW virtual const char* SLANG_MCALL getDebugBuildIdentifier() SLANG_OVERRIDE;
+
+    // IBindlessResourceMetadata
+    SLANG_NO_THROW virtual bool SLANG_MCALL usesBindlessResourceHeap() SLANG_OVERRIDE;
 
     // ICoverageTracingMetadata
     SLANG_NO_THROW virtual uint32_t SLANG_MCALL getCounterCount() SLANG_OVERRIDE;
@@ -299,6 +303,7 @@ public:
     List<slang::CooperativeVectorTypeUsageInfo> m_cooperativeVectorTypes;
     List<slang::CooperativeVectorCombination> m_cooperativeVectorCombinations;
     String m_debugBuildIdentifier;
+    bool m_usesBindlessResourceHeap = false;
 
     // Coverage tracing data, populated by `instrumentCoverage` when
     // `-trace-coverage` is active. Empty otherwise.

--- a/source/slang/slang-ir-metadata.cpp
+++ b/source/slang/slang-ir-metadata.cpp
@@ -118,6 +118,50 @@ static void _insertBinding(
     ranges.add(newRange);
 }
 
+static bool _isBindlessResourceHeapGlobalParam(IRInst* inst)
+{
+    if (inst->getOp() != kIROp_GlobalParam)
+        return false;
+
+    auto nameHint = inst->findDecoration<IRNameHintDecoration>();
+    return nameHint && nameHint->getName() == "__slang_resource_heap";
+}
+
+static bool _instUsesBindlessResourceHeap(IRInst* inst)
+{
+    if (_isBindlessResourceHeapGlobalParam(inst))
+        return true;
+
+    switch (inst->getOp())
+    {
+    case kIROp_GetDynamicResourceHeap:
+    case kIROp_LoadResourceDescriptorFromHeap:
+    case kIROp_LoadSamplerDescriptorFromHeap:
+    case kIROp_SPIRVLoadDescriptorFromHeap:
+    case kIROp_SPIRVResourceHeap:
+    case kIROp_SPIRVSamplerHeap:
+    case kIROp_MakeCombinedTextureSamplerFromHandle:
+    case kIROp_CastDescriptorHandleToResource:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool _subtreeUsesBindlessResourceHeap(IRInst* inst)
+{
+    if (_instUsesBindlessResourceHeap(inst))
+        return true;
+
+    for (auto child : inst->getChildren())
+    {
+        if (_subtreeUsesBindlessResourceHeap(child))
+            return true;
+    }
+
+    return false;
+}
+
 void collectMetadataFromInst(IRInst* param, ArtifactPostEmitMetadata& outMetadata)
 {
     auto layoutDecoration = param->findDecoration<IRLayoutDecoration>();
@@ -194,8 +238,12 @@ void collectMetadata(const IRModule* irModule, ArtifactPostEmitMetadata& outMeta
 {
     // Scan the instructions looking for global resource declarations
     // and exported functions.
+    bool usesBindlessResourceHeap = false;
     for (const auto& inst : irModule->getGlobalInsts())
     {
+        if (!usesBindlessResourceHeap && _subtreeUsesBindlessResourceHeap(inst))
+            usesBindlessResourceHeap = true;
+
         if (auto func = as<IRFunc>(inst))
         {
             if (func->findDecoration<IRDownstreamModuleExportDecoration>())
@@ -216,6 +264,7 @@ void collectMetadata(const IRModule* irModule, ArtifactPostEmitMetadata& outMeta
             continue;
         collectMetadataFromInst(param, outMetadata);
     }
+    outMetadata.m_usesBindlessResourceHeap = usesBindlessResourceHeap;
 }
 
 static SlangScalarType _getScalarTypeFromIRType(IRType* type)

--- a/tools/slang-unit-test/unit-test-bindless-space-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-bindless-space-reflection.cpp
@@ -11,28 +11,11 @@ using namespace Slang;
 
 // Test that the reflection API correctly returns the bindless space index.
 
-SLANG_UNIT_TEST(bindlessSpaceReflection)
+static void _checkBindlessSpaceReflection(
+    const char* userSource,
+    SlangInt expectedBindlessSpaceIndex,
+    bool expectedUsesBindlessResourceHeap)
 {
-    const char* userSource = R"(
-        RWStructuredBuffer<float> gInput;
-        RWStructuredBuffer<float> gOutput;
-
-        struct P
-        {
-            Texture2D.Handle t;
-        };
-
-        ParameterBlock<P> p1;
-
-        [Shader("compute")]
-        [NumThreads(4, 1, 1)]
-        void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
-        {
-            uint tid = dispatchThreadID.x;
-            gOutput[tid] = gInput[tid] + p1.t.Load(int3(0,0,0)).x;
-        }
-    )";
-
     ComPtr<slang::IGlobalSession> globalSession;
     SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
 
@@ -75,10 +58,73 @@ SLANG_UNIT_TEST(bindlessSpaceReflection)
     auto programLayout = linkedProgram->getLayout();
     SLANG_CHECK(programLayout != nullptr);
 
+    auto bindlessSpaceIndex = programLayout->getBindlessSpaceIndex();
+    if (expectedBindlessSpaceIndex >= 0)
+    {
+        SLANG_CHECK(bindlessSpaceIndex == expectedBindlessSpaceIndex);
+    }
+    else
+    {
+        SLANG_CHECK(bindlessSpaceIndex >= 0);
+    }
+
+    ComPtr<slang::IMetadata> metadata;
+    SLANG_CHECK(
+        linkedProgram->getTargetMetadata(0, metadata.writeRef(), diagnosticBlob.writeRef()) ==
+        SLANG_OK);
+    SLANG_CHECK(metadata != nullptr);
+
+    auto bindlessMetadata = static_cast<slang::IBindlessResourceMetadata*>(
+        metadata->castAs(slang::IBindlessResourceMetadata::getTypeGuid()));
+    SLANG_CHECK(bindlessMetadata != nullptr);
+    SLANG_CHECK(bindlessMetadata->usesBindlessResourceHeap() == expectedUsesBindlessResourceHeap);
+}
+
+SLANG_UNIT_TEST(bindlessSpaceReflection)
+{
+    const char* userSource = R"(
+        RWStructuredBuffer<float> gInput;
+        RWStructuredBuffer<float> gOutput;
+
+        struct P
+        {
+            Texture2D.Handle t;
+        };
+
+        ParameterBlock<P> p1;
+
+        [Shader("compute")]
+        [NumThreads(4, 1, 1)]
+        void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+        {
+            uint tid = dispatchThreadID.x;
+            gOutput[tid] = gInput[tid] + p1.t.Load(int3(0,0,0)).x;
+        }
+    )";
+
     // The shader has:
     // - gInput and gOutput at space 0 (default)
     // - ParameterBlock<P> p1 at space 1
-    // So the bindless space should be allocated at space 2
-    auto bindlessSpaceIndex = programLayout->getBindlessSpaceIndex();
-    SLANG_CHECK(bindlessSpaceIndex == 2);
+    // So the bindless space should be allocated at space 2.
+    _checkBindlessSpaceReflection(userSource, 2, true);
+}
+
+SLANG_UNIT_TEST(bindlessSpaceMetadataWithoutDescriptorHandle)
+{
+    const char* userSource = R"(
+        RWStructuredBuffer<float> gInput;
+        RWStructuredBuffer<float> gOutput;
+
+        [Shader("compute")]
+        [NumThreads(4, 1, 1)]
+        void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+        {
+            uint tid = dispatchThreadID.x;
+            gOutput[tid] = gInput[tid] + 1.0f;
+        }
+    )";
+
+    // Reflection still reserves a stable bindless space for descriptor-handle-capable
+    // targets, but post-emit metadata reports that no bindless heap path survived.
+    _checkBindlessSpaceReflection(userSource, -1, false);
 }

--- a/tools/slang-unit-test/unit-test-vtable-stability.cpp
+++ b/tools/slang-unit-test/unit-test-vtable-stability.cpp
@@ -915,6 +915,48 @@ SLANG_UNIT_TEST(vtableIMetadata)
 }
 
 // ---------------------------------------------------------------------------
+// IBindlessResourceMetadata : ISlangCastable  (own slot 4)
+// ---------------------------------------------------------------------------
+struct IBindlessResourceMetadataProbe : IBindlessResourceMetadata
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW bool SLANG_MCALL usesBindlessResourceHeap() SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return false;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIBindlessResourceMetadata)
+{
+    IBindlessResourceMetadataProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // usesBindlessResourceHeap
+}
+
+// ---------------------------------------------------------------------------
 // ICoverageTracingMetadata : ISlangCastable  (own slots 4-7)
 // ---------------------------------------------------------------------------
 struct ICoverageTracingMetadataProbe : ICoverageTracingMetadata


### PR DESCRIPTION
Fixes shader-slang/slang#10439

## Summary of the problem from the end user perspective

Shaders that do not use `DescriptorHandle<T>` still get a non-negative bindless space index in reflection. Hosts need a separate signal that tells them whether the compiled target actually uses a bindless descriptor heap path.

### Minimal repro shader; if applicable

```slang
RWStructuredBuffer<float> gInput;
RWStructuredBuffer<float> gOutput;

[shader("compute")]
[numthreads(4, 1, 1)]
void computeMain(uint3 tid : SV_DispatchThreadID)
{
    gOutput[tid.x] = gInput[tid.x] + 1.0f;
}
```

## Root cause

Bindless space allocation moved into frontend parameter binding so the reflected bindless space stays stable across later optimization and lowering. That stable reservation does not indicate whether a descriptor-handle heap use survived into emitted target IR.

## Solution in this PR

Add a queryable `IBindlessResourceMetadata` side interface on artifact metadata with `usesBindlessResourceHeap()`. Populate it from the final metadata IR walk by detecting target-visible bindless descriptor heap operations and synthesized resource-heap globals.

### Notes to the reviewers; where to focus on

The main behavior is in `source/slang/slang-ir-metadata.cpp`; the public API is intentionally a new side interface so `IMetadata` vtable layout stays unchanged. The unit tests cover both a shader that uses `Texture2D.Handle` and a shader that only has ordinary resources.

## Related PRs in the past

- #9870 moved bindless space allocation earlier so reflection can report a stable reserved space.
