### PR TITLE
Support coherent descriptor handles

### DIFF
--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -868,6 +868,11 @@ Val* ASTBuilder::getNoDiffModifierVal()
     return getOrCreate<NoDiffModifierVal>();
 }
 
+Val* ASTBuilder::getGloballyCoherentModifierVal()
+{
+    return getOrCreate<GloballyCoherentModifierVal>();
+}
+
 UIntSetVal* ASTBuilder::getUIntSetVal(const UIntSet& uintSet)
 {
     // Convert UIntSet buffer to list of ConstantIntVals

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -664,6 +664,7 @@ public:
     Val* getUNormModifierVal();
     Val* getSNormModifierVal();
     Val* getNoDiffModifierVal();
+    Val* getGloballyCoherentModifierVal();
 
     /// Create a UIntSetVal from a UIntSet
     UIntSetVal* getUIntSetVal(const UIntSet& uintSet);

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -1486,6 +1486,23 @@ Val* NoDiffModifierVal::_substituteImplOverride(
     return this;
 }
 
+// GloballyCoherentModifierVal
+void GloballyCoherentModifierVal::_toTextOverride(StringBuilder& out)
+{
+    out.append("globallycoherent");
+}
+
+Val* GloballyCoherentModifierVal::_substituteImplOverride(
+    ASTBuilder* astBuilder,
+    SubstitutionSet subst,
+    int* ioDiff)
+{
+    SLANG_UNUSED(astBuilder);
+    SLANG_UNUSED(subst);
+    SLANG_UNUSED(ioDiff);
+    return this;
+}
+
 // PolynomialIntVal
 
 void PolynomialIntVal::_toTextOverride(StringBuilder& out)

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -1164,6 +1164,14 @@ class NoDiffModifierVal : public TypeModifierVal
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
+FIDDLE()
+class GloballyCoherentModifierVal : public TypeModifierVal
+{
+    FIDDLE(...)
+    void _toTextOverride(StringBuilder& out);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+};
+
 /// Represents the result of differentiating a function.
 FIDDLE()
 class DifferentiateVal : public Val

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -8561,6 +8561,10 @@ Val* SemanticsExprVisitor::checkTypeModifier(Modifier* modifier, Type* type)
     {
         return m_astBuilder->getNoDiffModifierVal();
     }
+    else if (as<GloballyCoherentModifier>(modifier))
+    {
+        return m_astBuilder->getGloballyCoherentModifierVal();
+    }
     else if (as<ConstModifier>(modifier))
     {
         getSink()->diagnose(Diagnostics::ConstNotAllowedOnType{.location = modifier->loc});

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -2217,6 +2217,14 @@ void HLSLSourceEmitter::_emitPrefixTypeAttr(IRAttr* attr)
     case kIROp_SNormAttr:
         m_writer->emit("snorm ");
         break;
+    case kIROp_MemoryQualifierSetAttr:
+        {
+            auto memoryQualifierAttr = cast<IRMemoryQualifierSetAttr>(attr);
+            IRIntegerValue flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+            if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                m_writer->emit("globallycoherent ");
+        }
+        break;
     }
 }
 

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7043,7 +7043,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvStorageClass getDescriptorHeapBufferStorageClass(IRType* valueType)
     {
-        valueType = (IRType*)unwrapAttributedType(valueType);
+        valueType = as<IRType>(unwrapAttributedType(valueType));
         auto ptrType = as<IRPtrTypeBase>(valueType);
         if (!ptrType)
         {
@@ -7128,7 +7128,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* getDescriptorHeapBaseType(IRType* valueType, bool* outIsBufferResource = nullptr)
     {
-        valueType = (IRType*)unwrapAttributedType(valueType);
+        valueType = as<IRType>(unwrapAttributedType(valueType));
         SpvInst* descriptorElementType = nullptr;
         bool isBufferResource = false;
         switch (valueType->getOp())

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1717,12 +1717,61 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     }
 
+    bool hasCoherentMemoryQualifierDecoration(IRInst* inst)
+    {
+        if (!inst)
+            return false;
+
+        for (auto decoration : inst->getDecorations())
+        {
+            if (auto collection = as<IRMemoryQualifierSetDecoration>(decoration))
+            {
+                IRIntegerValue flags = collection->getMemoryQualifierBit();
+                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    bool hasCoherentMemoryQualifierAttr(IRInst* type)
+    {
+        while (auto attributedType = as<IRAttributedType>(type))
+        {
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                if (auto collection = as<IRMemoryQualifierSetAttr>(attr))
+                {
+                    IRIntegerValue flags = getIntVal(collection->getMemoryQualifierBit());
+                    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                        return true;
+                }
+            }
+            type = attributedType->getBaseType();
+        }
+        return false;
+    }
+
+    bool hasCoherentMemoryQualifier(IRInst* inst)
+    {
+        if (!inst)
+            return false;
+
+        if (hasCoherentMemoryQualifierDecoration(inst))
+            return true;
+
+        if (hasCoherentMemoryQualifierAttr(inst->getDataType()))
+            return true;
+
+        return hasCoherentMemoryQualifierAttr(inst->getFullType());
+    }
+
     bool NeedToUseCoherentLoadOrStore(IRInst* pointer)
     {
         if (m_memoryModel != SpvMemoryModelVulkan)
             return false;
 
-        auto ptrType = as<IRPtrTypeBase>(pointer->getFullType());
+        auto ptrType = as<IRPtrTypeBase>(unwrapAttributedType(pointer->getFullType()));
         if (!ptrType)
             return false;
 
@@ -1763,19 +1812,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (baseObj == nullptr)
             return false;
 
-        for (auto decoration : baseObj->getDecorations())
-        {
-            if (decoration->getOp() == kIROp_MemoryQualifierSetDecoration)
-            {
-                auto collection = as<IRMemoryQualifierSetDecoration>(decoration);
-                IRIntegerValue flags = collection->getMemoryQualifierBit();
-                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return hasCoherentMemoryQualifier(baseObj) ||
+               hasCoherentMemoryQualifierAttr(ptrType->getValueType());
     }
 
     bool NeedToUseCoherentImageLoadOrStore(IRInst* image)
@@ -1783,21 +1821,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (m_memoryModel != SpvMemoryModelVulkan)
             return false;
 
-        if (auto opLoad = as<IRLoad>(image->getOperand(0)))
+        auto imageValue = image;
+        if (as<IRImageLoad>(image) || as<IRImageStore>(image))
+            imageValue = image->getOperand(0);
+        else if (auto asmOperand = as<IRSPIRVAsmOperand>(image))
+            imageValue = asmOperand->getValue();
+
+        if (hasCoherentMemoryQualifier(imageValue))
+            return true;
+
+        if (auto opLoad = as<IRLoad>(imageValue))
         {
             auto texPtr = opLoad->getPtr();
-            for (auto decoration : texPtr->getDecorations())
-            {
-                if (decoration->getOp() == kIROp_MemoryQualifierSetDecoration)
-                {
-                    auto collection = as<IRMemoryQualifierSetDecoration>(decoration);
-                    IRIntegerValue flags = collection->getMemoryQualifierBit();
-                    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                    {
-                        return true;
-                    }
-                }
-            }
+            return hasCoherentMemoryQualifier(texPtr);
         }
         return false;
     }
@@ -7007,6 +7043,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvStorageClass getDescriptorHeapBufferStorageClass(IRType* valueType)
     {
+        valueType = (IRType*)unwrapAttributedType(valueType);
         auto ptrType = as<IRPtrTypeBase>(valueType);
         if (!ptrType)
         {
@@ -7091,6 +7128,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* getDescriptorHeapBaseType(IRType* valueType, bool* outIsBufferResource = nullptr)
     {
+        valueType = (IRType*)unwrapAttributedType(valueType);
         SpvInst* descriptorElementType = nullptr;
         bool isBufferResource = false;
         switch (valueType->getOp())

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1722,16 +1722,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (!inst)
             return false;
 
-        for (auto decoration : inst->getDecorations())
-        {
-            if (auto collection = as<IRMemoryQualifierSetDecoration>(decoration))
-            {
-                IRIntegerValue flags = collection->getMemoryQualifierBit();
-                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                    return true;
-            }
-        }
-        return false;
+        auto collection = inst->findDecoration<IRMemoryQualifierSetDecoration>();
+        if (!collection)
+            return false;
+
+        IRIntegerValue flags = collection->getMemoryQualifierBit();
+        return (flags & MemoryQualifierSetModifier::Flags::kCoherent) != 0;
     }
 
     bool hasCoherentMemoryQualifierAttr(IRInst* type)

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -600,6 +600,7 @@ return {
 	["Attr.unorm"] = 618,
 	["Attr.snorm"] = 619,
 	["Attr.no_diff"] = 620,
+	["Attr.memoryQualifierSet"] = 860,
 	["Attr.nonuniform"] = 621,
 	["Attr.Aligned"] = 622,
 	["Attr.SemanticAttr.userSemantic"] = 623,

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -2708,6 +2708,12 @@ local insts = {
 			},
 			{ no_diff = { struct_name = "NoDiffAttr" } },
 			{
+				memoryQualifierSet = {
+					struct_name = "MemoryQualifierSetAttr",
+					operands = { { "memoryQualifierBit" } },
+				},
+			},
+			{
 				nonuniform = {
 					struct_name = "NonUniformAttr",
 				},

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -459,6 +459,12 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                SLANG_ASSERT(
+                    attr->getOp() == kIROp_NoDiffAttr ||
+                    attr->getOp() == kIROp_MemoryQualifierSetAttr);
+            }
             return getSizeAndAlignment(
                 targetReq,
                 this,

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -459,7 +459,6 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
-            SLANG_ASSERT(attributedType->getAttr()->getOp() == kIROp_NoDiffAttr);
             return getSizeAndAlignment(
                 targetReq,
                 this,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2868,6 +2868,16 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         return LoweredValInfo::simple(getBuilder()->getAttr(kIROp_NoDiffAttr));
     }
 
+    LoweredValInfo visitGloballyCoherentModifierVal(GloballyCoherentModifierVal* astVal)
+    {
+        SLANG_UNUSED(astVal);
+        IRInst* memoryQualifierBit = getBuilder()->getIntValue(
+            getBuilder()->getIntType(),
+            MemoryQualifierSetModifier::Flags::kCoherent);
+        return LoweredValInfo::simple(
+            getBuilder()->getAttr(kIROp_MemoryQualifierSetAttr, memoryQualifierBit));
+    }
+
     // We do not expect to encounter the following types in ASTs that have
     // passed front-end semantic checking.
 #define UNEXPECTED_CASE(NAME)        \

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -1,0 +1,17 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+
+// SPIRV: OpImageRead %{{.*}} {{.*}} MakeTexelVisible|NonPrivateTexel %
+// SPIRV: OpImageWrite {{.*}} {{.*}} {{.*}} MakeTexelAvailable|NonPrivateTexel %
+
+// HLSL: globallycoherent RWTexture2D<float4
+
+uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
+uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint2 coord = dispatchThreadID.xy;
+    (*coherentTexture)[coord] = (*globallyCoherentTexture)[coord];
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10852

## Summary of the problem from the end user perspective

Declaring bindless coherent texture handles such as `DescriptorHandle<coherent RWTexture2D<float4>>` failed during compilation instead of producing a usable coherent resource.

### Minimal repro shader; if applicable

```slang
uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;

(*coherentTexture)[coord] = (*globallyCoherentTexture)[coord];
```

## Root cause

`coherent` and `globallycoherent` were accepted in modified type syntax but only existed as declaration-level memory qualifiers. The type-modifier path had no coherent modifier value or IR attribute, so descriptor-handle resource conversion could not preserve the qualifier.

## Solution in this PR

Add a type-level coherent modifier value and lower it into a memory qualifier IR attribute. SPIR-V and HLSL emission now preserve the attribute for descriptor-handle resources, including Vulkan memory model coherent image operands.

### Notes to the reviewers; where to focus on

Review the `MemoryQualifierSetAttr` propagation from semantic checking through IR lowering, and the SPIR-V coherent detection for attributed descriptor-heap resource loads.

## Related PRs in the past

None identified.
