### PR TITLE
Convert descriptor heap AS addresses in SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7042,7 +7042,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return type;
     }
 
-    SpvInst* getDescriptorRuntimeArrayType(SpvInst* descriptorElementType)
+    SpvInst* getDescriptorRuntimeArrayType(
+        SpvInst* descriptorElementType,
+        bool useConstantSizeOfStride = true,
+        int defaultArrayStride = 0)
     {
         if (auto found = m_descriptorHeapRuntimeArrayTypes.tryGetValue(descriptorElementType))
             return *found;
@@ -7061,10 +7064,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
         if (userDefinedStride == 0)
         {
-            IRBuilder builder(m_irModule);
-            builder.setInsertInto(m_irModule->getModuleInst());
+            if (useConstantSizeOfStride)
+            {
+                IRBuilder builder(m_irModule);
+                builder.setInsertInto(m_irModule->getModuleInst());
 
-            stride = emitOpConstantSizeOfEXT(nullptr, builder.getUIntType(), descriptorElementType);
+                stride =
+                    emitOpConstantSizeOfEXT(nullptr, builder.getUIntType(), descriptorElementType);
+            }
+            else
+            {
+                SLANG_ASSERT(defaultArrayStride != 0);
+                userDefinedStride = defaultArrayStride;
+            }
         }
 
         auto runtimeArrayType = emitOpTypeRuntimeArray(nullptr, descriptorElementType);
@@ -7093,12 +7105,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     {
         SpvInst* descriptorElementType = nullptr;
         bool isBufferResource = false;
+        bool useConstantSizeOfStride = true;
+        int defaultArrayStride = 0;
         switch (valueType->getOp())
         {
         case kIROp_TextureType:
         case kIROp_RaytracingAccelerationStructureType:
         case kIROp_SamplerStateType:
         case kIROp_SamplerComparisonStateType:
+            descriptorElementType = ensureInst(valueType);
+            break;
+        case kIROp_UInt64Type:
+            useConstantSizeOfStride = false;
+            defaultArrayStride = 8;
             descriptorElementType = ensureInst(valueType);
             break;
         default:
@@ -7111,7 +7130,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (outIsBufferResource)
             *outIsBufferResource = isBufferResource;
 
-        return getDescriptorRuntimeArrayType(descriptorElementType);
+        return getDescriptorRuntimeArrayType(
+            descriptorElementType,
+            useConstantSizeOfStride,
+            defaultArrayStride);
     }
 
     SpvInst* emitDescriptorHeapLoad(

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1371,6 +1371,61 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 
+    IRInst* emitConvertUIntToAccelerationStructure(
+        IRBuilder& builder,
+        IRType* accelerationStructureType,
+        IRInst* address)
+    {
+        auto asmBlock = builder.emitSPIRVAsm(accelerationStructureType);
+
+        IRBuilderInsertLocScope insertScope(&builder);
+        builder.setInsertInto(asmBlock);
+
+        auto emitOpcode = [&](SpvOp opcode)
+        {
+            return builder.emitSPIRVAsmOperandEnum(
+                builder.getIntValue(builder.getUIntType(), IRIntegerValue(opcode)));
+        };
+
+        {
+            List<IRInst*> operands;
+            operands.add(builder.emitSPIRVAsmOperandLiteral(
+                builder.getStringValue(UnownedStringSlice::fromLiteral("SPV_KHR_ray_tracing"))));
+            builder.emitSPIRVAsmInst(emitOpcode(SpvOpExtension), operands);
+        }
+
+        {
+            List<IRInst*> operands;
+            operands.add(builder.emitSPIRVAsmOperandInst(accelerationStructureType));
+            operands.add(builder.emitSPIRVAsmOperandResult());
+            operands.add(builder.emitSPIRVAsmOperandInst(address));
+            builder.emitSPIRVAsmInst(emitOpcode(SpvOpConvertUToAccelerationStructureKHR), operands);
+        }
+
+        return asmBlock;
+    }
+
+    void processSPIRVLoadDescriptorFromHeap(IRSPIRVLoadDescriptorFromHeap* inst)
+    {
+        auto resultType = inst->getDataType();
+        if (resultType->getOp() != kIROp_RaytracingAccelerationStructureType)
+            return;
+
+        IRBuilder builder(m_sharedContext->m_irModule);
+        builder.setInsertBefore(inst);
+        auto address = builder.emitLoadDescriptorFromHeap(
+            builder.getUInt64Type(),
+            inst->getHeap(),
+            inst->getIndex());
+        auto accelerationStructure =
+            emitConvertUIntToAccelerationStructure(builder, resultType, address);
+        inst->replaceUsesWith(accelerationStructure);
+        inst->removeAndDeallocate();
+
+        addToWorkList(address);
+        addUsersToWorkList(accelerationStructure);
+    }
+
     void processFieldAddress(IRFieldAddress* inst)
     {
         if (auto ptrType = as<IRPtrTypeBase>(inst->getBase()->getDataType()))
@@ -2115,6 +2170,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 break;
             case kIROp_ImageSubscript:
                 processImageSubscript(as<IRImageSubscript>(inst));
+                break;
+            case kIROp_SPIRVLoadDescriptorFromHeap:
+                processSPIRVLoadDescriptorFromHeap(as<IRSPIRVLoadDescriptorFromHeap>(inst));
                 break;
             case kIROp_RWStructuredBufferGetElementPtr:
                 processRWStructuredBufferGetElementPtr(

--- a/tests/spirv/descriptor-heap-acceleration-structure.slang
+++ b/tests/spirv/descriptor-heap-acceleration-structure.slang
@@ -1,0 +1,26 @@
+// Regression test for #10671: descriptor heap acceleration-structure entries
+// store a uint64 device address, not an opaque acceleration-structure handle.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT
+
+// CHECK-NOT: OpLoad %RaytracingAccelerationStructure
+// CHECK: %[[ADDR:[A-Za-z0-9_]+]] = OpLoad %ulong
+// CHECK: %[[TLAS:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR {{.*}} %[[ADDR]]
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[TLAS]]
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(
+    uniform RaytracingAccelerationStructure.Handle accelerationStructure,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    RayDesc ray;
+    ray.Origin = float3(0.0f, 0.0f, 0.0f);
+    ray.Direction = float3(0.0f, 0.0f, 1.0f);
+    ray.TMin = 0.0f;
+    ray.TMax = 1.0f;
+
+    RayQuery<RAY_FLAG_FORCE_NON_OPAQUE> rayQuery;
+    rayQuery.TraceRayInline(accelerationStructure, RAY_FLAG_FORCE_NON_OPAQUE, 0xff, ray);
+    output[0] = rayQuery.RayFlags();
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10671

## Summary of the problem from the end user perspective

SPIR-V descriptor heap loads for `RaytracingAccelerationStructure.Handle` produced invalid acceleration-structure values. Shaders using the descriptor heap path could load the descriptor as an opaque acceleration-structure handle instead of converting the stored device address.

### Minimal repro shader; if applicable

```hlsl
void computeMain(RaytracingAccelerationStructure.Handle accelerationStructure)
{
    RayQuery<RAY_FLAG_FORCE_NON_OPAQUE> rayQuery;
    rayQuery.TraceRayInline(accelerationStructure, RAY_FLAG_FORCE_NON_OPAQUE, 0xff, ray);
}
```

## Root cause

The descriptor heap stores acceleration structures as `uint64_t` device addresses, but the SPIR-V heap load path treated `RaytracingAccelerationStructure` like an opaque descriptor value.

## Solution in this PR

Legalize SPIR-V descriptor heap acceleration-structure loads into a raw `uint64_t` heap load followed by `OpConvertUToAccelerationStructureKHR`. The descriptor heap emitter now handles that raw `uint64_t` array with a literal 8-byte stride.

### Notes to the reviewers; where to focus on

Review the new `SPIRVLoadDescriptorFromHeap` legalization case and the `UInt64` descriptor heap runtime-array handling. The regression test checks that the emitted SPIR-V loads `%ulong`, converts it with `OpConvertUToAccelerationStructureKHR`, and uses the converted value in `OpRayQueryInitializeKHR`.

## Related PRs in the past

None identified.
