### PR TITLE
Avoid mesh line mode for isoline tessellation

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6324,21 +6324,24 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             m = SpvExecutionModeVertexOrderCcw;
                         else if (topologyType == OutputTopologyType::Point)
                             m = SpvExecutionModePointMode;
+                        // OutputTopologyType::Line is represented by the Isolines execution mode
+                        // emitted for the domain decoration.
+                        break;
+                    case Stage::Mesh:
+                        if (topologyType == OutputTopologyType::Triangle)
+                            m = SpvExecutionModeOutputTrianglesEXT;
+                        else if (topologyType == OutputTopologyType::Line)
+                            m = SpvExecutionModeOutputLinesEXT;
+                        else if (topologyType == OutputTopologyType::Point)
+                            m = SpvExecutionModeOutputPoints;
+                        break;
+                    default:
                         break;
                     }
                 }
-                if (m == SpvExecutionModeMax)
-                {
-                    if (topologyType == OutputTopologyType::Triangle)
-                        m = SpvExecutionModeOutputTrianglesEXT;
-                    else if (topologyType == OutputTopologyType::Line)
-                        m = SpvExecutionModeOutputLinesEXT;
-                    else if (topologyType == OutputTopologyType::Point)
-                        m = SpvExecutionModeOutputPoints;
-                }
 
-                SLANG_ASSERT(m != SpvExecutionModeMax);
-                requireSPIRVExecutionMode(decoration, dstID, m);
+                if (m != SpvExecutionModeMax)
+                    requireSPIRVExecutionMode(decoration, dstID, m);
             }
             break;
 

--- a/tests/spirv/hull-shader-outputtopology.slang
+++ b/tests/spirv/hull-shader-outputtopology.slang
@@ -1,10 +1,14 @@
 //TEST:SIMPLE(filecheck=SPIRV_POINT):-target spirv -stage hull -entry hullMain_point
 //TEST:SIMPLE(filecheck=SPIRV_TRICW):-target spirv -stage hull -entry hullMain_triangle_cw
 //TEST:SIMPLE(filecheck=SPIRV_TRICCW):-target spirv -stage hull -entry hullMain_triangle_ccw
+//TEST:SIMPLE(filecheck=SPIRV_LINE):-target spirv -stage hull -entry hullMain_line
 
 // SPIRV_POINT: OpExecutionMode %hullMain_point PointMode
 // SPIRV_TRICW: OpExecutionMode %hullMain_triangle_cw VertexOrderCw
 // SPIRV_TRICCW: OpExecutionMode %hullMain_triangle_ccw VertexOrderCcw
+// SPIRV_LINE-NOT: OutputLinesEXT
+// SPIRV_LINE: OpExecutionMode %hullMain_line Isolines
+// SPIRV_LINE-NOT: OutputLinesEXT
 
 struct Out {
     float x;
@@ -13,6 +17,10 @@ struct Out {
 struct PatchConst {
     float EdgeTessFactor[4] : SV_TessFactor;
     float InsideTessFactor[2] : SV_InsideTessFactor;
+};
+
+struct LinePatchConst {
+    float EdgeTessFactor[2] : SV_TessFactor;
 };
 
 PatchConst patchConst() {
@@ -26,12 +34,30 @@ PatchConst patchConst() {
     return o;
 }
 
+LinePatchConst patchConstLine() {
+    LinePatchConst o;
+    o.EdgeTessFactor[0] = 1;
+    o.EdgeTessFactor[1] = 1;
+    return o;
+}
+
 [domain("quad")]
 [partitioning("integer")]
 [outputtopology("point")]
 [outputcontrolpoints(4)]
 [patchconstantfunc("patchConst")]
 Out hullMain_point() {
+    Out o;
+    o.x = 0;
+    return o;
+}
+
+[domain("isoline")]
+[partitioning("integer")]
+[outputtopology("line")]
+[outputcontrolpoints(2)]
+[patchconstantfunc("patchConstLine")]
+Out hullMain_line() {
     Out o;
     o.x = 0;
     return o;


### PR DESCRIPTION
Fixes shader-slang/slang#11370

## Summary of the problem from the end user perspective

Isoline hull shaders compiled to SPIR-V emitted both the valid `Isolines` execution mode and the mesh-shader-only `OutputLinesEXT` execution mode. The extra mode made `spirv-val` reject the tessellation-control shader.

### Minimal repro shader; if applicable

```hlsl
[domain("isoline")]
[partitioning("integer")]
[outputtopology("line")]
[outputcontrolpoints(2)]
[patchconstantfunc("patchConstLine")]
Out hullMain_line()
{
    return Out(0);
}
```

## Root cause

The SPIR-V `kIROp_OutputTopologyDecoration` handler recognized hull/domain point and triangle topology cases, but `line` fell through to the mesh topology mapping and emitted `OutputLinesEXT`.

## Solution in this PR

Restrict mesh `Output*EXT` execution modes to mesh-stage entry points. For tessellation line topology, emit no extra output-topology execution mode and rely on the existing domain decoration emission of `Isolines`.

### Notes to the reviewers; where to focus on

Review the stage switch in `source/slang/slang-emit-spirv.cpp` and the new `SPIRV_LINE` checks in `tests/spirv/hull-shader-outputtopology.slang`.

## Related PRs in the past

PR #7662 added the comparable tessellation `PointMode` handling in this same emitter block.
