### PR TITLE
Allow scalar alignment for byte-address buffer vector/matrix loads

### DIFF
--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -242,11 +242,25 @@ struct ByteAddressBufferLegalizationContext
 
     // Returns true if a vectorized load or store of `alignmentVal` bytes at
     // `baseOffset + immediateOffset` is known to be sufficiently aligned.
+    //
+    // `alignmentVal` is the size of the whole access (e.g. the full composite
+    // type); a single wide operation is only possible when the access is
+    // aligned to that size.
+    //
+    // `minAlignmentVal` is the alignment required by the individual element
+    // accesses if we fall back to scalarizing the load/store. Per the HLSL
+    // spec a byte-address buffer access only needs to be aligned to its scalar
+    // components, so an explicit alignment that satisfies `minAlignmentVal` but
+    // not `alignmentVal` is still valid; it simply forces us to scalarize
+    // instead of issuing a wide operation. Callers that cannot scalarize pass
+    // `alignmentVal` here to keep the strict "must cover the whole access"
+    // behavior.
     bool isAligned(
         IRInst* baseOffset,
         IRIntegerValue immediateOffset,
         IRInst* unknownOffsetAlignment,
-        IRIntegerValue alignmentVal)
+        IRIntegerValue alignmentVal,
+        IRIntegerValue minAlignmentVal)
     {
         if (alignmentVal <= 0)
             return false;
@@ -268,18 +282,26 @@ struct ByteAddressBufferLegalizationContext
             if (!alignInst->getValue())
                 return false;
 
+            // An explicit alignment that is smaller than the alignment required by
+            // the scalar components is genuinely invalid, so we diagnose it.
+            if ((alignInst->getValue() % minAlignmentVal) != 0)
+            {
+                m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
+                    .alignment = alignInst->getValue(),
+                    .elementSize = minAlignmentVal,
+                    .location = baseOffset->sourceLoc,
+                });
+                return false;
+            }
+
+            // The access is at least scalar-aligned. We can only issue a single
+            // wide load/store when both the immediate offset and the explicit
+            // alignment cover the whole access; otherwise we fall back to
+            // scalarizing the access (which only requires scalar alignment).
             if ((immediateOffset % alignmentVal) != 0)
                 return false;
 
-            if ((alignInst->getValue() % alignmentVal) == 0)
-            {
-                return true;
-            }
-            m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
-                .alignment = alignInst->getValue(),
-                .elementSize = alignmentVal,
-                .location = baseOffset->sourceLoc,
-            });
+            return (alignInst->getValue() % alignmentVal) == 0;
         }
         return false;
     }
@@ -442,7 +464,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -554,7 +576,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -628,7 +650,12 @@ struct ByteAddressBufferLegalizationContext
                 SLANG_RETURN_NULL_ON_FAIL(
                     getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
                 if (sizeAlignment.size == 8 &&
-                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                    !isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        sizeAlignment.getStride(),
+                        sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitLoadFromTwoUInts(
                         type,
@@ -1396,7 +1423,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1506,7 +1533,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1558,7 +1585,12 @@ struct ByteAddressBufferLegalizationContext
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_ON_FAIL(getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
                 if (sizeAlignment.size == 8 &&
-                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                    !isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        sizeAlignment.getStride(),
+                        sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitStoreAsTwoUInts(
                         buffer,

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -464,7 +464,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (!isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        alignmentVal,
+                        elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -575,8 +580,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (m_options.scalarizeVectorLoadStore || !isAligned(
+                                                              baseOffset,
+                                                              immediateOffset,
+                                                              alignment,
+                                                              alignmentVal,
+                                                              elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -649,13 +658,12 @@ struct ByteAddressBufferLegalizationContext
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_NULL_ON_FAIL(
                     getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
-                if (sizeAlignment.size == 8 &&
-                    !isAligned(
-                        baseOffset,
-                        immediateOffset,
-                        alignment,
-                        sizeAlignment.getStride(),
-                        sizeAlignment.getStride()))
+                if (sizeAlignment.size == 8 && !isAligned(
+                                                   baseOffset,
+                                                   immediateOffset,
+                                                   alignment,
+                                                   sizeAlignment.getStride(),
+                                                   sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitLoadFromTwoUInts(
                         type,
@@ -1423,7 +1431,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (!isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        alignmentVal,
+                        elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1532,8 +1545,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (m_options.scalarizeVectorLoadStore || !isAligned(
+                                                              baseOffset,
+                                                              immediateOffset,
+                                                              alignment,
+                                                              alignmentVal,
+                                                              elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1584,13 +1601,12 @@ struct ByteAddressBufferLegalizationContext
             {
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_ON_FAIL(getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
-                if (sizeAlignment.size == 8 &&
-                    !isAligned(
-                        baseOffset,
-                        immediateOffset,
-                        alignment,
-                        sizeAlignment.getStride(),
-                        sizeAlignment.getStride()))
+                if (sizeAlignment.size == 8 && !isAligned(
+                                                   baseOffset,
+                                                   immediateOffset,
+                                                   alignment,
+                                                   sizeAlignment.getStride(),
+                                                   sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitStoreAsTwoUInts(
                         buffer,

--- a/tests/compute/byte-address-buffer-scalar-aligned.slang
+++ b/tests/compute/byte-address-buffer-scalar-aligned.slang
@@ -1,0 +1,34 @@
+// byte-address-buffer-scalar-aligned.slang
+
+// Regression test for https://github.com/shader-slang/slang/issues/9958
+//
+// A manually-aligned vector load/store from a `(RW)ByteAddressBuffer` only
+// requires the access to be aligned to the vector's *scalar* components, not
+// to the full vector size. When the explicit alignment is smaller than the
+// full vector size we must fall back to scalarized element loads/stores
+// instead of diagnosing an error.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -profile spirv_1_6 -entry computeMain -stage compute -fvk-use-c-layout
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -profile spirv_1_6 -entry computeMain -stage compute -fvk-use-c-layout
+
+RWByteAddressBuffer buffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // The offset is not known at compile time, so the explicit alignment of
+    // `2` is what drives the legalization. `uint16_t2` is 4 bytes wide but its
+    // scalar components only need 2-byte alignment, so this must scalarize
+    // into two `ushort` (16-bit) loads and two `ushort` stores rather than
+    // emitting error 41300.
+    int offset = int(tid.x);
+
+    // CHECK-NOT: E41300
+    // CHECK: OpLoad %ushort
+    // CHECK: OpLoad %ushort
+    // CHECK: OpStore {{.*}}
+    // CHECK: OpStore {{.*}}
+    uint16_t2 data = buffer.LoadAligned<uint16_t2>(offset, 2);
+    buffer.Store(offset, data, 2);
+}


### PR DESCRIPTION
Fixes shader-slang/slang#9958

## Summary of the problem from the end user perspective

Loading or storing a vector/matrix from a `(RW)ByteAddressBuffer` with a custom alignment failed to compile when the alignment was only large enough for the type's scalar components, even though the HLSL spec only requires scalar alignment.

### Minimal repro shader

```hlsl
[shader("compute")]
[numthreads(1, 1, 1)]
void main(uniform RWByteAddressBuffer buffer, uniform int offset)
{
  uint16_t2 data = buffer.LoadAligned<uint16_t2>(offset, 2);
  buffer.Store(offset, data, 2);
}
```

This previously failed with `error 41300: invalid alignment 2 specified for the byte address buffer resource with the element size of 4`.

## Root cause

The byte-address legalization pass required the explicit alignment to be a multiple of the *whole* composite type size (`elementStride * elementCount`); when it wasn't, `isAligned` emitted error 41300 instead of falling back to scalarized accesses.

## Solution in this PR

`isAligned` now distinguishes the minimum scalar-component alignment from the full composite size: an alignment that satisfies scalar alignment but not the full size simply scalarizes the load/store, and only alignments smaller than the scalar component alignment are diagnosed.

### Notes to the reviewers; where to focus on

- The core change is in `source/slang/slang-ir-byte-address-legalize.cpp`: `isAligned` gains a `minAlignmentVal` parameter, and the four vector/array load/store call sites pass `elementLayout.alignment` (the scalar alignment).
- Behavior matrix: alignment `>=` full type size and divisible -> single wide load/store (unchanged); scalar-aligned but not full-size -> scalarized accesses (newly allowed); below scalar alignment -> still error 41300.
- The existing `tests/compute/byte-address-buffer-align-error.slang` still errors (its alignments 5/3 are not multiples of the float scalar alignment 4).

## Related PRs in the past

- shader-slang/slang#4066 -- Add `LoadAligned`/`StoreAligned` methods to ByteAddressBuffers (introduced the alignment check this PR refines).
- shader-slang/slang#11430 -- Fix unaligned byte-address descriptor loads (#9931). This PR is rebased on top of it; `isAligned` was refactored there, and this change re-applies the scalar-alignment relaxation on top of that refactor. #11430 does **not** fix #9958 (it still errors when the explicit alignment is below the full composite size).

