### PR TITLE
Fix duplicate @location for non-entry-point structs in WGSL/Metal

### DIFF
--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -2380,13 +2380,15 @@ public:
         removeSemanticLayoutsFromLegalizedStructs();
 
         // Structs that carry user/SV_TARGET semantics but are not directly used
-        // as entry-point parameters or return types (e.g. a helper struct shared
-        // across functions) are never seen by `fixFieldSemanticsOfFlatStruct`
-        // above. Their fields keep the unparsed semantic name (e.g. "SV_TARGET0",
-        // "SV_TARGET1") with an unspecified index of -1, so the emitter maps them
-        // all to `@location(0)`, producing duplicate locations in WGSL/Metal.
-        // Fix the semantics of those remaining structs here. (See issue #10802.)
-        fixFieldSemanticsOfNonEntryPointStructs();
+        // as entry-point parameters or return types (e.g. a helper struct used
+        // by a function the entry point calls) are never seen by
+        // `fixFieldSemanticsOfFlatStruct` above. Their fields keep the unparsed
+        // semantic name (e.g. "SV_TARGET0", "SV_TARGET1") with an unspecified
+        // index of -1, so the emitter maps them all to `@location(0)`,
+        // producing duplicate locations in WGSL/Metal. Fix those structs here,
+        // scoped to the ones reachable from the entry points being legalized.
+        // (See issue #10802.)
+        fixFieldSemanticsOfEntryPointReachableStructs(entryPoints);
     }
 
 protected:
@@ -3659,52 +3661,97 @@ private:
         }
     }
 
-    // Apply `fixFieldSemanticsOfFlatStruct` to every struct in the module that
-    // carries semantic decorations on its fields but was not already handled as
-    // an entry-point parameter or return type.
-    void fixFieldSemanticsOfNonEntryPointStructs()
+    // Recursively collect every `IRStructType` referenced by `type`, descending
+    // through operands so element types of pointers/arrays and the field types
+    // of nested structs are covered too.
+    void collectReachableStructsFromType(
+        IRInst* type,
+        HashSet<IRInst*>& visitedTypes,
+        OrderedHashSet<IRStructType*>& reachableStructs)
     {
-        for (auto inst : m_module->getGlobalInsts())
-        {
-            auto structType = as<IRStructType>(inst);
-            if (!structType)
-                continue;
+        if (!type || !visitedTypes.add(type))
+            return;
+        if (auto structType = as<IRStructType>(type))
+            reachableStructs.add(structType);
+        for (UInt i = 0; i < type->getOperandCount(); ++i)
+            collectReachableStructsFromType(type->getOperand(i), visitedTypes, reachableStructs);
+    }
 
-            // Only structs whose fields actually carry semantics need fixing.
-            // Gate on semantic-bearing decorations specifically: an
-            // `IRSemanticDecoration`, or a layout decoration that holds a
-            // user/system-value semantic attribute. Triggering on any
-            // `IRLayoutDecoration` would be too broad and could route structs
-            // with unrelated (e.g. offset-only) layout metadata into
-            // `fixFieldSemanticsOfFlatStruct`, which may rewrite non-semantic
-            // offsets/attributes.
-            bool hasFieldSemantic = false;
-            for (auto field : structType->getFields())
+    // Returns true if any field of `structType` carries a user/SV_TARGET
+    // semantic. Gate on semantic-bearing decorations specifically: an
+    // `IRSemanticDecoration`, or a layout decoration that holds a
+    // user/system-value semantic attribute. Triggering on any
+    // `IRLayoutDecoration` would be too broad and could route structs with
+    // unrelated (e.g. offset-only) layout metadata into
+    // `fixFieldSemanticsOfFlatStruct`, which may rewrite non-semantic
+    // offsets/attributes.
+    bool structHasFieldSemantic(IRStructType* structType)
+    {
+        for (auto field : structType->getFields())
+        {
+            auto key = field->getKey();
+            if (key->findDecoration<IRSemanticDecoration>())
+                return true;
+            if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
             {
-                auto key = field->getKey();
-                if (key->findDecoration<IRSemanticDecoration>())
+                for (auto attr : layoutDecor->getLayout()->getAllAttrs())
                 {
-                    hasFieldSemantic = true;
-                    break;
-                }
-                if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
-                {
-                    for (auto attr : layoutDecor->getLayout()->getAllAttrs())
-                    {
-                        if (as<IRUserSemanticAttr>(attr) || as<IRSystemValueSemanticAttr>(attr))
-                        {
-                            hasFieldSemantic = true;
-                            break;
-                        }
-                    }
-                    if (hasFieldSemantic)
-                        break;
+                    if (as<IRUserSemanticAttr>(attr) || as<IRSystemValueSemanticAttr>(attr))
+                        return true;
                 }
             }
-            if (!hasFieldSemantic)
-                continue;
+        }
+        return false;
+    }
 
-            fixFieldSemanticsOfFlatStruct(structType);
+    // Collect every `IRStructType` reachable from the given entry points (via
+    // their call graph and referenced types) and fix overlapping field
+    // semantics on those that carry user/SV_TARGET semantics. Scoping to the
+    // entry points being legalized — rather than sweeping the whole module —
+    // keeps structs unrelated to these entry points untouched.
+    void fixFieldSemanticsOfEntryPointReachableStructs(const List<EntryPointInfo>& entryPoints)
+    {
+        HashSet<IRInst*> visitedTypes;
+        OrderedHashSet<IRStructType*> reachableStructs;
+
+        // Walk the call graph from each entry point, gathering the types
+        // referenced by every reachable function.
+        HashSet<IRFunc*> visitedFuncs;
+        List<IRFunc*> funcWorkList;
+        auto addFunc = [&](IRInst* maybeFunc)
+        {
+            if (auto func = as<IRFunc>(maybeFunc))
+            {
+                if (visitedFuncs.add(func))
+                    funcWorkList.add(func);
+            }
+        };
+
+        for (auto entryPoint : entryPoints)
+            addFunc(entryPoint.entryPointFunc);
+
+        while (funcWorkList.getCount())
+        {
+            auto func = funcWorkList.getLast();
+            funcWorkList.removeLast();
+            for (auto block : func->getBlocks())
+            {
+                for (auto inst : block->getChildren())
+                {
+                    collectReachableStructsFromType(
+                        inst->getFullType(),
+                        visitedTypes,
+                        reachableStructs);
+                    if (auto call = as<IRCall>(inst))
+                        addFunc(call->getCalleeUse()->get());
+                }
+            }
+        }
+
+        for (auto structType : reachableStructs)
+        {
+            if (structHasFieldSemantic(structType))
+                fixFieldSemanticsOfFlatStruct(structType);
         }
     }
 

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3743,7 +3743,11 @@ private:
                         visitedTypes,
                         reachableStructs);
                     if (auto call = as<IRCall>(inst))
-                        addFunc(call->getCalleeUse()->get());
+                    {
+                        // Resolve through `IRSpecialize`/generics so a
+                        // specialized callee's body is still walked.
+                        addFunc(getResolvedInstForDecorations(call->getCalleeUse()->get()));
+                    }
                 }
             }
         }

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -2533,9 +2533,12 @@ protected:
         }
         if (changed)
         {
+            // `layoutDecor` is removed and deallocated here, so return the
+            // replacement decoration rather than the freed original — callers
+            // immediately dereference the returned pointer.
             auto parent = layoutDecor->parent;
             layoutDecor->removeAndDeallocate();
-            builder.addLayoutDecoration(parent, builder.getVarLayout(layoutOps));
+            return builder.addLayoutDecoration(parent, builder.getVarLayout(layoutOps));
         }
         return layoutDecor;
     }

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -5007,8 +5007,8 @@ protected:
 // entry points themselves. (See issue #10802.)
 void legalizeStructVaryingSemanticsForMetal(
     IRModule* module,
-    DiagnosticSink* sink,
-    List<EntryPointInfo>& entryPoints)
+    List<EntryPointInfo>& entryPoints,
+    DiagnosticSink* sink)
 {
     LegalizeMetalVaryingStructContext context(module, sink);
     context.legalizeVaryingStructTypes(entryPoints);
@@ -5016,8 +5016,8 @@ void legalizeStructVaryingSemanticsForMetal(
 
 void legalizeStructVaryingSemanticsForWGSL(
     IRModule* module,
-    DiagnosticSink* sink,
-    List<EntryPointInfo>& entryPoints)
+    List<EntryPointInfo>& entryPoints,
+    DiagnosticSink* sink)
 {
     LegalizeWGSLVaryingStructContext context(module, sink);
     context.legalizeVaryingStructTypes(entryPoints);

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -2366,38 +2366,41 @@ void depointerizeInputParams(IRFunc* entryPointFunc)
 }
 
 
-class LegalizeShaderEntryPointContext
+// Base context shared by entry-point varying-parameter legalization and the
+// standalone struct-field-semantic legalization pass. It owns the module/sink
+// and the routines that rewrite overlapping varying field semantics on a flat
+// struct, so neither task needs to know about the other.
+class LegalizeShaderVaryingStructContext
 {
 public:
-    void legalizeEntryPoints(List<EntryPointInfo>& entryPoints)
+    LegalizeShaderVaryingStructContext(IRModule* module, DiagnosticSink* sink)
+        : m_module(module), m_sink(sink)
     {
-        // Collect struct types used as return types before processing.
-        // We should not remove semantic decorations from these structs
-        // since they are needed for output variable binding (e.g., @location in WGSL).
-        collectStructTypesUsedAsReturnType(entryPoints);
-
-        for (auto entryPoint : entryPoints)
-            legalizeEntryPoint(entryPoint);
-        removeSemanticLayoutsFromLegalizedStructs();
     }
 
     // Fix overlapping field semantics on structs that carry user/SV_TARGET
     // semantics but are not themselves entry-point parameters or return types
     // (e.g. a struct returned by a helper function the entry point calls). Such
-    // structs are never seen by the entry-point legalization above, so their
+    // structs are never seen by the entry-point parameter legalization, so their
     // fields keep the unparsed semantic name (e.g. "SV_TARGET0"/"SV_TARGET1"
     // with an unspecified index of -1), which the WGSL/Metal emitter maps to a
     // duplicate `@location(0)`. (See issue #10802.)
     //
-    // This is a separate step from entry-point legalization: it is driven by
-    // the target backends after `legalizeEntryPoints()` rather than from it.
-    // It reuses `buildEntryPointReferenceGraph()` to limit the module-wide
-    // struct sweep to functions reachable from the module's entry points, so
-    // structs unrelated to those entry points are left untouched.
-    void fixVaryingSemanticsOfEntryPointReachableStructs()
+    // The sweep is limited to functions reachable from the given entry points,
+    // so structs unrelated to those entry points are left untouched.
+    void legalizeVaryingStructTypes(List<EntryPointInfo>& entryPoints)
     {
+        if (entryPoints.getCount() == 0)
+            return;
+
+        // Build the module's entry-point reference graph, then limit the struct
+        // sweep to functions reachable from the entry points we were given.
         Dictionary<IRInst*, HashSet<IRFunc*>> referencingEntryPoints;
         buildEntryPointReferenceGraph(referencingEntryPoints, m_module);
+
+        HashSet<IRFunc*> targetEntryPoints;
+        for (auto& entryPoint : entryPoints)
+            targetEntryPoints.add(entryPoint.entryPointFunc);
 
         HashSet<IRInst*> visitedTypes;
         OrderedHashSet<IRStructType*> reachableStructs;
@@ -2406,8 +2409,20 @@ public:
             auto func = as<IRFunc>(inst);
             if (!func)
                 continue;
-            // Limit the sweep to functions reachable from an entry point.
-            if (!getReferencingEntryPoints(referencingEntryPoints, func))
+            // Only consider functions reachable from one of the given entry points.
+            auto referencing = getReferencingEntryPoints(referencingEntryPoints, func);
+            if (!referencing)
+                continue;
+            bool reachable = false;
+            for (auto referencingFunc : *referencing)
+            {
+                if (targetEntryPoints.contains(referencingFunc))
+                {
+                    reachable = true;
+                    break;
+                }
+            }
+            if (!reachable)
                 continue;
             for (auto block : func->getBlocks())
             {
@@ -2427,13 +2442,351 @@ public:
     }
 
 protected:
-    LegalizeShaderEntryPointContext(IRModule* module, DiagnosticSink* sink)
-        : m_module(module), m_sink(sink)
-    {
-    }
-
     IRModule* m_module;
     DiagnosticSink* m_sink;
+
+    virtual UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
+        const = 0;
+
+    UInt _returnNonOverlappingAttributeIndex(std::set<UInt>& usedSemanticIndex)
+    {
+        // Find first unused semantic index of equal semantic type
+        // to fill any gaps in user set semantic bindings
+        UInt prev = 0;
+        for (auto i : usedSemanticIndex)
+        {
+            if (i > prev + 1)
+            {
+                break;
+            }
+            prev = i;
+        }
+        usedSemanticIndex.insert(prev + 1);
+        return prev + 1;
+    }
+
+    template<typename T>
+    struct AttributeParentPair
+    {
+        IRLayoutDecoration* layoutDecor;
+        T* attr;
+    };
+
+    IRLayoutDecoration* _replaceAttributeOfLayout(
+        IRBuilder& builder,
+        IRLayoutDecoration* parentLayoutDecor,
+        IRInst* instToReplace,
+        IRInst* instToReplaceWith)
+    {
+        // Replace `instToReplace` with a `instToReplaceWith`
+
+        auto layout = parentLayoutDecor->getLayout();
+        // Find the exact same decoration `instToReplace` in-case multiple of the same type exist
+        List<IRInst*> opList;
+        opList.add(instToReplaceWith);
+        for (UInt i = 0; i < layout->getOperandCount(); i++)
+        {
+            if (layout->getOperand(i) != instToReplace)
+                opList.add(layout->getOperand(i));
+        }
+        auto newLayoutDecor = builder.addLayoutDecoration(
+            parentLayoutDecor->getParent(),
+            builder.getVarLayout(opList));
+        parentLayoutDecor->removeAndDeallocate();
+        return newLayoutDecor;
+    }
+
+    IRLayoutDecoration* _simplifyUserSemanticNames(
+        IRBuilder& builder,
+        IRLayoutDecoration* layoutDecor)
+    {
+        // Ensure all 'ExplicitIndex' semantics such as "SV_TARGET0" are simplified into
+        // ("SV_TARGET", 0) using 'IRUserSemanticAttr' This is done to ensure we can check semantic
+        // groups using 'IRUserSemanticAttr1->getName() == IRUserSemanticAttr2->getName()'
+        SLANG_ASSERT(layoutDecor);
+        auto layout = layoutDecor->getLayout();
+        List<IRInst*> layoutOps;
+        layoutOps.reserve(3);
+        bool changed = false;
+        for (auto attr : layout->getAllAttrs())
+        {
+            if (auto userSemantic = as<IRUserSemanticAttr>(attr))
+            {
+                UnownedStringSlice outName;
+                UnownedStringSlice outIndex;
+                bool hasStringIndex = splitNameAndIndex(userSemantic->getName(), outName, outIndex);
+                if (hasStringIndex)
+                {
+                    changed = true;
+                    auto loweredName = String(outName).toLower();
+                    auto loweredNameSlice = loweredName.getUnownedSlice();
+                    auto newDecoration =
+                        builder.getUserSemanticAttr(loweredNameSlice, stringToInt(outIndex));
+                    userSemantic->replaceUsesWith(newDecoration);
+                    userSemantic->removeAndDeallocate();
+                    userSemantic = newDecoration;
+                }
+                layoutOps.add(userSemantic);
+                continue;
+            }
+            layoutOps.add(attr);
+        }
+        if (changed)
+        {
+            auto parent = layoutDecor->parent;
+            layoutDecor->removeAndDeallocate();
+            builder.addLayoutDecoration(parent, builder.getVarLayout(layoutOps));
+        }
+        return layoutDecor;
+    }
+
+    // Find overlapping field semantics and legalize them
+    void fixFieldSemanticsOfFlatStruct(IRStructType* structType)
+    {
+        // Goal is to ensure we do not have overlapping semantics for the user defined semantics:
+        // Note that in WGSL, the semantics can be either `builtin` without index or `location` with
+        // index.
+        /*
+            // Assume the following code
+            struct Fragment
+            {
+                float4 p0 : SV_POSITION;
+                float2 p1 : TEXCOORD0;
+                float2 p2 : TEXCOORD1;
+                float3 p3 : COLOR0;
+                float3 p4 : COLOR1;
+            };
+
+            // Translates into
+            struct Fragment
+            {
+                float4 p0 : BUILTIN_POSITION;
+                float2 p1 : LOCATION_0;
+                float2 p2 : LOCATION_1;
+                float3 p3 : LOCATION_2;
+                float3 p4 : LOCATION_3;
+            };
+        */
+
+        // For Multi-Render-Target, the semantic index must be translated to `location` with
+        // the same index. Assume the following code
+        /*
+            struct Fragment
+            {
+                float4 p0 : SV_TARGET1;
+                float4 p1 : SV_TARGET0;
+            };
+
+            // Translates into
+            struct Fragment
+            {
+                float4 p0 : LOCATION_1;
+                float4 p1 : LOCATION_0;
+            };
+        */
+
+        IRBuilder builder(this->m_module);
+
+        List<IRSemanticDecoration*> overlappingSemanticsDecor;
+        Dictionary<UnownedStringSlice, std::set<UInt, std::less<UInt>>>
+            usedSemanticIndexSemanticDecor;
+
+        List<AttributeParentPair<IRVarOffsetAttr>> overlappingVarOffset;
+        Dictionary<UInt, std::set<UInt, std::less<UInt>>> usedSemanticIndexVarOffset;
+
+        List<AttributeParentPair<IRUserSemanticAttr>> overlappingUserSemantic;
+        Dictionary<UnownedStringSlice, std::set<UInt, std::less<UInt>>>
+            usedSemanticIndexUserSemantic;
+
+        // We store a map from old `IRLayoutDecoration*` to new `IRLayoutDecoration*` since when
+        // legalizing we may destroy and remake a `IRLayoutDecoration*`
+        Dictionary<IRLayoutDecoration*, IRLayoutDecoration*> oldLayoutDecorToNew;
+
+        // Collect all "semantic info carrying decorations". Any collected decoration will
+        // fill up their respective 'Dictionary<SEMANTIC_TYPE, OrderedHashSet<UInt>>'
+        // to keep track of in-use offsets for a semantic type.
+        // Example: IRSemanticDecoration with name of "SV_TARGET1".
+        // * This will have SEMANTIC_TYPE of "sv_target".
+        // * This will use up index '1'
+        //
+        // Now if a second equal semantic "SV_TARGET1" is found, we add this decoration to
+        // a list of 'overlapping semantic info decorations' so we can legalize this
+        // 'semantic info decoration' later.
+        //
+        // NOTE: this is a flat struct, all members are children of the initial
+        // IRStructType.
+        for (auto field : structType->getFields())
+        {
+            auto key = field->getKey();
+            if (auto semanticDecoration = key->findDecoration<IRSemanticDecoration>())
+            {
+                auto semanticName = semanticDecoration->getSemanticName();
+
+                // sv_target is treated as a user-semantic because it should be emitted with
+                // @location like how the user semantics are emitted.
+                // For fragment shader, only sv_target will user @location, and for non-fragment
+                // shaders, sv_target is not valid.
+                bool isUserSemantic =
+                    (semanticName.startsWithCaseInsensitive(toSlice("sv_target")) ||
+                     !semanticName.startsWithCaseInsensitive(toSlice("sv_")));
+
+                // Ensure names are in a uniform lowercase format so we can bunch together simmilar
+                // semantics.
+                UnownedStringSlice outName;
+                UnownedStringSlice outIndex;
+                bool hasStringIndex = splitNameAndIndex(semanticName, outName, outIndex);
+
+                auto loweredName = String(outName).toLower();
+                auto loweredNameSlice = getUserSemanticNameSlice(loweredName, isUserSemantic);
+                auto semanticIndex = hasStringIndex
+                                         ? stringToInt(outIndex)
+                                         : semanticDecoration->getEffectiveSemanticIndex();
+                auto newDecoration =
+                    builder.addSemanticDecoration(key, loweredNameSlice, semanticIndex);
+
+                semanticDecoration->replaceUsesWith(newDecoration);
+                semanticDecoration->removeAndDeallocate();
+                semanticDecoration = newDecoration;
+
+                auto& semanticUse =
+                    usedSemanticIndexSemanticDecor[semanticDecoration->getSemanticName()];
+                if (semanticUse.find(semanticDecoration->getSemanticIndex()) != semanticUse.end())
+                    overlappingSemanticsDecor.add(semanticDecoration);
+                else
+                    semanticUse.insert(semanticDecoration->getSemanticIndex());
+            }
+            if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
+            {
+                // Ensure names are in a uniform lowercase format so we can bunch together simmilar
+                // semantics
+                layoutDecor = _simplifyUserSemanticNames(builder, layoutDecor);
+                oldLayoutDecorToNew[layoutDecor] = layoutDecor;
+                auto layout = layoutDecor->getLayout();
+                for (auto attr : layout->getAllAttrs())
+                {
+                    if (auto offset = as<IRVarOffsetAttr>(attr))
+                    {
+                        auto& semanticUse = usedSemanticIndexVarOffset[offset->getResourceKind()];
+                        if (semanticUse.find(offset->getOffset()) != semanticUse.end())
+                            overlappingVarOffset.add({layoutDecor, offset});
+                        else
+                            semanticUse.insert(offset->getOffset());
+                    }
+                    else if (auto userSemantic = as<IRUserSemanticAttr>(attr))
+                    {
+                        auto& semanticUse = usedSemanticIndexUserSemantic[userSemantic->getName()];
+                        if (semanticUse.find(userSemantic->getIndex()) != semanticUse.end())
+                            overlappingUserSemantic.add({layoutDecor, userSemantic});
+                        else
+                            semanticUse.insert(userSemantic->getIndex());
+                    }
+                }
+            }
+        }
+
+        // Legalize all overlapping 'semantic info decorations'
+        for (auto decor : overlappingSemanticsDecor)
+        {
+            auto newOffset = _returnNonOverlappingAttributeIndex(
+                usedSemanticIndexSemanticDecor[decor->getSemanticName()]);
+            builder.addSemanticDecoration(
+                decor->getParent(),
+                decor->getSemanticName(),
+                (int)newOffset);
+            decor->removeAndDeallocate();
+        }
+        for (auto& varOffset : overlappingVarOffset)
+        {
+            auto newOffset = _returnNonOverlappingAttributeIndex(
+                usedSemanticIndexVarOffset[varOffset.attr->getResourceKind()]);
+            auto newVarOffset = builder.getVarOffsetAttr(
+                varOffset.attr->getResourceKind(),
+                newOffset,
+                varOffset.attr->getSpace());
+            oldLayoutDecorToNew[varOffset.layoutDecor] = _replaceAttributeOfLayout(
+                builder,
+                oldLayoutDecorToNew[varOffset.layoutDecor],
+                varOffset.attr,
+                newVarOffset);
+        }
+        for (auto& userSemantic : overlappingUserSemantic)
+        {
+            auto newOffset = _returnNonOverlappingAttributeIndex(
+                usedSemanticIndexUserSemantic[userSemantic.attr->getName()]);
+            auto newUserSemantic =
+                builder.getUserSemanticAttr(userSemantic.attr->getName(), newOffset);
+            oldLayoutDecorToNew[userSemantic.layoutDecor] = _replaceAttributeOfLayout(
+                builder,
+                oldLayoutDecorToNew[userSemantic.layoutDecor],
+                userSemantic.attr,
+                newUserSemantic);
+        }
+    }
+
+    // Recursively collect every `IRStructType` referenced by `type`, descending
+    // through operands so element types of pointers/arrays and the field types
+    // of nested structs are covered too.
+    void collectReachableStructsFromType(
+        IRInst* type,
+        HashSet<IRInst*>& visitedTypes,
+        OrderedHashSet<IRStructType*>& reachableStructs)
+    {
+        if (!type || !visitedTypes.add(type))
+            return;
+        if (auto structType = as<IRStructType>(type))
+            reachableStructs.add(structType);
+        for (UInt i = 0; i < type->getOperandCount(); ++i)
+            collectReachableStructsFromType(type->getOperand(i), visitedTypes, reachableStructs);
+    }
+
+    // Returns true if any field of `structType` carries a user/SV_TARGET
+    // semantic. Gate on semantic-bearing decorations specifically: an
+    // `IRSemanticDecoration`, or a layout decoration that holds a
+    // user/system-value semantic attribute. Triggering on any
+    // `IRLayoutDecoration` would be too broad and could route structs with
+    // unrelated (e.g. offset-only) layout metadata into
+    // `fixFieldSemanticsOfFlatStruct`, which may rewrite non-semantic
+    // offsets/attributes.
+    bool structHasFieldSemantic(IRStructType* structType)
+    {
+        for (auto field : structType->getFields())
+        {
+            auto key = field->getKey();
+            if (key->findDecoration<IRSemanticDecoration>())
+                return true;
+            if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
+            {
+                for (auto attr : layoutDecor->getLayout()->getAllAttrs())
+                {
+                    if (as<IRUserSemanticAttr>(attr) || as<IRSystemValueSemanticAttr>(attr))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+};
+
+class LegalizeShaderEntryPointContext : public LegalizeShaderVaryingStructContext
+{
+public:
+    void legalizeEntryPoints(List<EntryPointInfo>& entryPoints)
+    {
+        // Collect struct types used as return types before processing.
+        // We should not remove semantic decorations from these structs
+        // since they are needed for output variable binding (e.g., @location in WGSL).
+        collectStructTypesUsedAsReturnType(entryPoints);
+
+        for (auto entryPoint : entryPoints)
+            legalizeEntryPoint(entryPoint);
+        removeSemanticLayoutsFromLegalizedStructs();
+    }
+
+protected:
+    LegalizeShaderEntryPointContext(IRModule* module, DiagnosticSink* sink)
+        : LegalizeShaderVaryingStructContext(module, sink)
+    {
+    }
 
     struct SystemValueInfo
     {
@@ -2463,9 +2816,6 @@ protected:
         EntryPointInfo entryPoint) const = 0;
 
     virtual void flattenNestedStructsTransferKeyDecorations(IRInst* newKey, IRInst* oldKey)
-        const = 0;
-
-    virtual UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
         const = 0;
 
     virtual void addFragmentShaderReturnValueDecoration(
@@ -3419,324 +3769,6 @@ private:
                 returnInst->setOperand(0, copyLogicFunc(builder, newType, returnVal));
             }
         }
-    }
-
-    UInt _returnNonOverlappingAttributeIndex(std::set<UInt>& usedSemanticIndex)
-    {
-        // Find first unused semantic index of equal semantic type
-        // to fill any gaps in user set semantic bindings
-        UInt prev = 0;
-        for (auto i : usedSemanticIndex)
-        {
-            if (i > prev + 1)
-            {
-                break;
-            }
-            prev = i;
-        }
-        usedSemanticIndex.insert(prev + 1);
-        return prev + 1;
-    }
-
-    template<typename T>
-    struct AttributeParentPair
-    {
-        IRLayoutDecoration* layoutDecor;
-        T* attr;
-    };
-
-    IRLayoutDecoration* _replaceAttributeOfLayout(
-        IRBuilder& builder,
-        IRLayoutDecoration* parentLayoutDecor,
-        IRInst* instToReplace,
-        IRInst* instToReplaceWith)
-    {
-        // Replace `instToReplace` with a `instToReplaceWith`
-
-        auto layout = parentLayoutDecor->getLayout();
-        // Find the exact same decoration `instToReplace` in-case multiple of the same type exist
-        List<IRInst*> opList;
-        opList.add(instToReplaceWith);
-        for (UInt i = 0; i < layout->getOperandCount(); i++)
-        {
-            if (layout->getOperand(i) != instToReplace)
-                opList.add(layout->getOperand(i));
-        }
-        auto newLayoutDecor = builder.addLayoutDecoration(
-            parentLayoutDecor->getParent(),
-            builder.getVarLayout(opList));
-        parentLayoutDecor->removeAndDeallocate();
-        return newLayoutDecor;
-    }
-
-    IRLayoutDecoration* _simplifyUserSemanticNames(
-        IRBuilder& builder,
-        IRLayoutDecoration* layoutDecor)
-    {
-        // Ensure all 'ExplicitIndex' semantics such as "SV_TARGET0" are simplified into
-        // ("SV_TARGET", 0) using 'IRUserSemanticAttr' This is done to ensure we can check semantic
-        // groups using 'IRUserSemanticAttr1->getName() == IRUserSemanticAttr2->getName()'
-        SLANG_ASSERT(layoutDecor);
-        auto layout = layoutDecor->getLayout();
-        List<IRInst*> layoutOps;
-        layoutOps.reserve(3);
-        bool changed = false;
-        for (auto attr : layout->getAllAttrs())
-        {
-            if (auto userSemantic = as<IRUserSemanticAttr>(attr))
-            {
-                UnownedStringSlice outName;
-                UnownedStringSlice outIndex;
-                bool hasStringIndex = splitNameAndIndex(userSemantic->getName(), outName, outIndex);
-                if (hasStringIndex)
-                {
-                    changed = true;
-                    auto loweredName = String(outName).toLower();
-                    auto loweredNameSlice = loweredName.getUnownedSlice();
-                    auto newDecoration =
-                        builder.getUserSemanticAttr(loweredNameSlice, stringToInt(outIndex));
-                    userSemantic->replaceUsesWith(newDecoration);
-                    userSemantic->removeAndDeallocate();
-                    userSemantic = newDecoration;
-                }
-                layoutOps.add(userSemantic);
-                continue;
-            }
-            layoutOps.add(attr);
-        }
-        if (changed)
-        {
-            auto parent = layoutDecor->parent;
-            layoutDecor->removeAndDeallocate();
-            builder.addLayoutDecoration(parent, builder.getVarLayout(layoutOps));
-        }
-        return layoutDecor;
-    }
-
-    // Find overlapping field semantics and legalize them
-    void fixFieldSemanticsOfFlatStruct(IRStructType* structType)
-    {
-        // Goal is to ensure we do not have overlapping semantics for the user defined semantics:
-        // Note that in WGSL, the semantics can be either `builtin` without index or `location` with
-        // index.
-        /*
-            // Assume the following code
-            struct Fragment
-            {
-                float4 p0 : SV_POSITION;
-                float2 p1 : TEXCOORD0;
-                float2 p2 : TEXCOORD1;
-                float3 p3 : COLOR0;
-                float3 p4 : COLOR1;
-            };
-
-            // Translates into
-            struct Fragment
-            {
-                float4 p0 : BUILTIN_POSITION;
-                float2 p1 : LOCATION_0;
-                float2 p2 : LOCATION_1;
-                float3 p3 : LOCATION_2;
-                float3 p4 : LOCATION_3;
-            };
-        */
-
-        // For Multi-Render-Target, the semantic index must be translated to `location` with
-        // the same index. Assume the following code
-        /*
-            struct Fragment
-            {
-                float4 p0 : SV_TARGET1;
-                float4 p1 : SV_TARGET0;
-            };
-
-            // Translates into
-            struct Fragment
-            {
-                float4 p0 : LOCATION_1;
-                float4 p1 : LOCATION_0;
-            };
-        */
-
-        IRBuilder builder(this->m_module);
-
-        List<IRSemanticDecoration*> overlappingSemanticsDecor;
-        Dictionary<UnownedStringSlice, std::set<UInt, std::less<UInt>>>
-            usedSemanticIndexSemanticDecor;
-
-        List<AttributeParentPair<IRVarOffsetAttr>> overlappingVarOffset;
-        Dictionary<UInt, std::set<UInt, std::less<UInt>>> usedSemanticIndexVarOffset;
-
-        List<AttributeParentPair<IRUserSemanticAttr>> overlappingUserSemantic;
-        Dictionary<UnownedStringSlice, std::set<UInt, std::less<UInt>>>
-            usedSemanticIndexUserSemantic;
-
-        // We store a map from old `IRLayoutDecoration*` to new `IRLayoutDecoration*` since when
-        // legalizing we may destroy and remake a `IRLayoutDecoration*`
-        Dictionary<IRLayoutDecoration*, IRLayoutDecoration*> oldLayoutDecorToNew;
-
-        // Collect all "semantic info carrying decorations". Any collected decoration will
-        // fill up their respective 'Dictionary<SEMANTIC_TYPE, OrderedHashSet<UInt>>'
-        // to keep track of in-use offsets for a semantic type.
-        // Example: IRSemanticDecoration with name of "SV_TARGET1".
-        // * This will have SEMANTIC_TYPE of "sv_target".
-        // * This will use up index '1'
-        //
-        // Now if a second equal semantic "SV_TARGET1" is found, we add this decoration to
-        // a list of 'overlapping semantic info decorations' so we can legalize this
-        // 'semantic info decoration' later.
-        //
-        // NOTE: this is a flat struct, all members are children of the initial
-        // IRStructType.
-        for (auto field : structType->getFields())
-        {
-            auto key = field->getKey();
-            if (auto semanticDecoration = key->findDecoration<IRSemanticDecoration>())
-            {
-                auto semanticName = semanticDecoration->getSemanticName();
-
-                // sv_target is treated as a user-semantic because it should be emitted with
-                // @location like how the user semantics are emitted.
-                // For fragment shader, only sv_target will user @location, and for non-fragment
-                // shaders, sv_target is not valid.
-                bool isUserSemantic =
-                    (semanticName.startsWithCaseInsensitive(toSlice("sv_target")) ||
-                     !semanticName.startsWithCaseInsensitive(toSlice("sv_")));
-
-                // Ensure names are in a uniform lowercase format so we can bunch together simmilar
-                // semantics.
-                UnownedStringSlice outName;
-                UnownedStringSlice outIndex;
-                bool hasStringIndex = splitNameAndIndex(semanticName, outName, outIndex);
-
-                auto loweredName = String(outName).toLower();
-                auto loweredNameSlice = getUserSemanticNameSlice(loweredName, isUserSemantic);
-                auto semanticIndex = hasStringIndex
-                                         ? stringToInt(outIndex)
-                                         : semanticDecoration->getEffectiveSemanticIndex();
-                auto newDecoration =
-                    builder.addSemanticDecoration(key, loweredNameSlice, semanticIndex);
-
-                semanticDecoration->replaceUsesWith(newDecoration);
-                semanticDecoration->removeAndDeallocate();
-                semanticDecoration = newDecoration;
-
-                auto& semanticUse =
-                    usedSemanticIndexSemanticDecor[semanticDecoration->getSemanticName()];
-                if (semanticUse.find(semanticDecoration->getSemanticIndex()) != semanticUse.end())
-                    overlappingSemanticsDecor.add(semanticDecoration);
-                else
-                    semanticUse.insert(semanticDecoration->getSemanticIndex());
-            }
-            if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
-            {
-                // Ensure names are in a uniform lowercase format so we can bunch together simmilar
-                // semantics
-                layoutDecor = _simplifyUserSemanticNames(builder, layoutDecor);
-                oldLayoutDecorToNew[layoutDecor] = layoutDecor;
-                auto layout = layoutDecor->getLayout();
-                for (auto attr : layout->getAllAttrs())
-                {
-                    if (auto offset = as<IRVarOffsetAttr>(attr))
-                    {
-                        auto& semanticUse = usedSemanticIndexVarOffset[offset->getResourceKind()];
-                        if (semanticUse.find(offset->getOffset()) != semanticUse.end())
-                            overlappingVarOffset.add({layoutDecor, offset});
-                        else
-                            semanticUse.insert(offset->getOffset());
-                    }
-                    else if (auto userSemantic = as<IRUserSemanticAttr>(attr))
-                    {
-                        auto& semanticUse = usedSemanticIndexUserSemantic[userSemantic->getName()];
-                        if (semanticUse.find(userSemantic->getIndex()) != semanticUse.end())
-                            overlappingUserSemantic.add({layoutDecor, userSemantic});
-                        else
-                            semanticUse.insert(userSemantic->getIndex());
-                    }
-                }
-            }
-        }
-
-        // Legalize all overlapping 'semantic info decorations'
-        for (auto decor : overlappingSemanticsDecor)
-        {
-            auto newOffset = _returnNonOverlappingAttributeIndex(
-                usedSemanticIndexSemanticDecor[decor->getSemanticName()]);
-            builder.addSemanticDecoration(
-                decor->getParent(),
-                decor->getSemanticName(),
-                (int)newOffset);
-            decor->removeAndDeallocate();
-        }
-        for (auto& varOffset : overlappingVarOffset)
-        {
-            auto newOffset = _returnNonOverlappingAttributeIndex(
-                usedSemanticIndexVarOffset[varOffset.attr->getResourceKind()]);
-            auto newVarOffset = builder.getVarOffsetAttr(
-                varOffset.attr->getResourceKind(),
-                newOffset,
-                varOffset.attr->getSpace());
-            oldLayoutDecorToNew[varOffset.layoutDecor] = _replaceAttributeOfLayout(
-                builder,
-                oldLayoutDecorToNew[varOffset.layoutDecor],
-                varOffset.attr,
-                newVarOffset);
-        }
-        for (auto& userSemantic : overlappingUserSemantic)
-        {
-            auto newOffset = _returnNonOverlappingAttributeIndex(
-                usedSemanticIndexUserSemantic[userSemantic.attr->getName()]);
-            auto newUserSemantic =
-                builder.getUserSemanticAttr(userSemantic.attr->getName(), newOffset);
-            oldLayoutDecorToNew[userSemantic.layoutDecor] = _replaceAttributeOfLayout(
-                builder,
-                oldLayoutDecorToNew[userSemantic.layoutDecor],
-                userSemantic.attr,
-                newUserSemantic);
-        }
-    }
-
-    // Recursively collect every `IRStructType` referenced by `type`, descending
-    // through operands so element types of pointers/arrays and the field types
-    // of nested structs are covered too.
-    void collectReachableStructsFromType(
-        IRInst* type,
-        HashSet<IRInst*>& visitedTypes,
-        OrderedHashSet<IRStructType*>& reachableStructs)
-    {
-        if (!type || !visitedTypes.add(type))
-            return;
-        if (auto structType = as<IRStructType>(type))
-            reachableStructs.add(structType);
-        for (UInt i = 0; i < type->getOperandCount(); ++i)
-            collectReachableStructsFromType(type->getOperand(i), visitedTypes, reachableStructs);
-    }
-
-    // Returns true if any field of `structType` carries a user/SV_TARGET
-    // semantic. Gate on semantic-bearing decorations specifically: an
-    // `IRSemanticDecoration`, or a layout decoration that holds a
-    // user/system-value semantic attribute. Triggering on any
-    // `IRLayoutDecoration` would be too broad and could route structs with
-    // unrelated (e.g. offset-only) layout metadata into
-    // `fixFieldSemanticsOfFlatStruct`, which may rewrite non-semantic
-    // offsets/attributes.
-    bool structHasFieldSemantic(IRStructType* structType)
-    {
-        for (auto field : structType->getFields())
-        {
-            auto key = field->getKey();
-            if (key->findDecoration<IRSemanticDecoration>())
-                return true;
-            if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
-            {
-                for (auto attr : layoutDecor->getLayout()->getAllAttrs())
-                {
-                    if (as<IRUserSemanticAttr>(attr) || as<IRSystemValueSemanticAttr>(attr))
-                        return true;
-                }
-            }
-        }
-        return false;
     }
 
     void wrapReturnValueInStruct(EntryPointInfo entryPoint)
@@ -4924,22 +4956,68 @@ void legalizeEntryPointVaryingParamsForWGSL(
     context.legalizeEntryPoints(entryPoints);
 }
 
-// Fix overlapping field semantics on structs reachable from the module's entry
-// points but not themselves entry-point parameters/return types (e.g. a struct
-// returned by a helper function the entry point calls). Run as its own pass,
-// separately from entry-point varying-parameter legalization, so the entry-point
-// legalization functions stay focused on the entry points themselves.
-// (See issue #10802.)
-void legalizeReachableStructVaryingSemanticsForMetal(IRModule* module, DiagnosticSink* sink)
+// Dedicated context for the struct-field-semantic legalization pass. It is
+// intentionally separate from `Legalize{Metal,WGSL}EntryPointContext`, which
+// handle entry points themselves rather than the structs used by functions the
+// entry points call. Only the target-specific user-semantic naming differs, so
+// each backend just overrides `getUserSemanticNameSlice`.
+class LegalizeMetalVaryingStructContext : public LegalizeShaderVaryingStructContext
 {
-    LegalizeMetalEntryPointContext context(module, sink);
-    context.fixVaryingSemanticsOfEntryPointReachableStructs();
+public:
+    LegalizeMetalVaryingStructContext(IRModule* module, DiagnosticSink* sink)
+        : LegalizeShaderVaryingStructContext(module, sink)
+    {
+    }
+
+protected:
+    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
+        const SLANG_OVERRIDE
+    {
+        SLANG_UNUSED(isUserSemantic);
+        return loweredName.getUnownedSlice();
+    }
+};
+
+class LegalizeWGSLVaryingStructContext : public LegalizeShaderVaryingStructContext
+{
+public:
+    LegalizeWGSLVaryingStructContext(IRModule* module, DiagnosticSink* sink)
+        : LegalizeShaderVaryingStructContext(module, sink)
+    {
+    }
+
+protected:
+    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
+        const SLANG_OVERRIDE
+    {
+        return isUserSemantic ? userSemanticName : loweredName.getUnownedSlice();
+    }
+
+    const UnownedStringSlice userSemanticName = toSlice("user_semantic");
+};
+
+// Fix overlapping field semantics on structs used by functions reachable from
+// the module's entry points but not themselves entry-point parameters/return
+// types (e.g. a struct returned by a helper function the entry point calls).
+// Run as its own pass, separately from entry-point varying-parameter
+// legalization, so the entry-point legalization functions stay focused on the
+// entry points themselves. (See issue #10802.)
+void legalizeStructVaryingSemanticsForMetal(
+    IRModule* module,
+    DiagnosticSink* sink,
+    List<EntryPointInfo>& entryPoints)
+{
+    LegalizeMetalVaryingStructContext context(module, sink);
+    context.legalizeVaryingStructTypes(entryPoints);
 }
 
-void legalizeReachableStructVaryingSemanticsForWGSL(IRModule* module, DiagnosticSink* sink)
+void legalizeStructVaryingSemanticsForWGSL(
+    IRModule* module,
+    DiagnosticSink* sink,
+    List<EntryPointInfo>& entryPoints)
 {
-    LegalizeWGSLEntryPointContext context(module, sink);
-    context.fixVaryingSemanticsOfEntryPointReachableStructs();
+    LegalizeWGSLVaryingStructContext context(module, sink);
+    context.legalizeVaryingStructTypes(entryPoints);
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -1,6 +1,7 @@
 // slang-ir-legalize-varying-params.cpp
 #include "slang-ir-legalize-varying-params.h"
 
+#include "slang-ir-call-graph.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-layout.h"
@@ -2378,17 +2379,51 @@ public:
         for (auto entryPoint : entryPoints)
             legalizeEntryPoint(entryPoint);
         removeSemanticLayoutsFromLegalizedStructs();
+    }
 
-        // Structs that carry user/SV_TARGET semantics but are not directly used
-        // as entry-point parameters or return types (e.g. a helper struct used
-        // by a function the entry point calls) are never seen by
-        // `fixFieldSemanticsOfFlatStruct` above. Their fields keep the unparsed
-        // semantic name (e.g. "SV_TARGET0", "SV_TARGET1") with an unspecified
-        // index of -1, so the emitter maps them all to `@location(0)`,
-        // producing duplicate locations in WGSL/Metal. Fix those structs here,
-        // scoped to the ones reachable from the entry points being legalized.
-        // (See issue #10802.)
-        fixFieldSemanticsOfEntryPointReachableStructs(entryPoints);
+    // Fix overlapping field semantics on structs that carry user/SV_TARGET
+    // semantics but are not themselves entry-point parameters or return types
+    // (e.g. a struct returned by a helper function the entry point calls). Such
+    // structs are never seen by the entry-point legalization above, so their
+    // fields keep the unparsed semantic name (e.g. "SV_TARGET0"/"SV_TARGET1"
+    // with an unspecified index of -1), which the WGSL/Metal emitter maps to a
+    // duplicate `@location(0)`. (See issue #10802.)
+    //
+    // This is a separate step from entry-point legalization: it is driven by
+    // the target backends after `legalizeEntryPoints()` rather than from it.
+    // It reuses `buildEntryPointReferenceGraph()` to limit the module-wide
+    // struct sweep to functions reachable from the module's entry points, so
+    // structs unrelated to those entry points are left untouched.
+    void fixVaryingSemanticsOfEntryPointReachableStructs()
+    {
+        Dictionary<IRInst*, HashSet<IRFunc*>> referencingEntryPoints;
+        buildEntryPointReferenceGraph(referencingEntryPoints, m_module);
+
+        HashSet<IRInst*> visitedTypes;
+        OrderedHashSet<IRStructType*> reachableStructs;
+        for (auto inst : m_module->getGlobalInsts())
+        {
+            auto func = as<IRFunc>(inst);
+            if (!func)
+                continue;
+            // Limit the sweep to functions reachable from an entry point.
+            if (!getReferencingEntryPoints(referencingEntryPoints, func))
+                continue;
+            for (auto block : func->getBlocks())
+            {
+                for (auto bodyInst : block->getChildren())
+                    collectReachableStructsFromType(
+                        bodyInst->getFullType(),
+                        visitedTypes,
+                        reachableStructs);
+            }
+        }
+
+        for (auto structType : reachableStructs)
+        {
+            if (structHasFieldSemantic(structType))
+                fixFieldSemanticsOfFlatStruct(structType);
+        }
     }
 
 protected:
@@ -3704,61 +3739,6 @@ private:
         return false;
     }
 
-    // Collect every `IRStructType` reachable from the given entry points (via
-    // their call graph and referenced types) and fix overlapping field
-    // semantics on those that carry user/SV_TARGET semantics. Scoping to the
-    // entry points being legalized — rather than sweeping the whole module —
-    // keeps structs unrelated to these entry points untouched.
-    void fixFieldSemanticsOfEntryPointReachableStructs(const List<EntryPointInfo>& entryPoints)
-    {
-        HashSet<IRInst*> visitedTypes;
-        OrderedHashSet<IRStructType*> reachableStructs;
-
-        // Walk the call graph from each entry point, gathering the types
-        // referenced by every reachable function.
-        HashSet<IRFunc*> visitedFuncs;
-        List<IRFunc*> funcWorkList;
-        auto addFunc = [&](IRInst* maybeFunc)
-        {
-            if (auto func = as<IRFunc>(maybeFunc))
-            {
-                if (visitedFuncs.add(func))
-                    funcWorkList.add(func);
-            }
-        };
-
-        for (auto entryPoint : entryPoints)
-            addFunc(entryPoint.entryPointFunc);
-
-        while (funcWorkList.getCount())
-        {
-            auto func = funcWorkList.getLast();
-            funcWorkList.removeLast();
-            for (auto block : func->getBlocks())
-            {
-                for (auto inst : block->getChildren())
-                {
-                    collectReachableStructsFromType(
-                        inst->getFullType(),
-                        visitedTypes,
-                        reachableStructs);
-                    if (auto call = as<IRCall>(inst))
-                    {
-                        // Resolve through `IRSpecialize`/generics so a
-                        // specialized callee's body is still walked.
-                        addFunc(getResolvedInstForDecorations(call->getCalleeUse()->get()));
-                    }
-                }
-            }
-        }
-
-        for (auto structType : reachableStructs)
-        {
-            if (structHasFieldSemantic(structType))
-                fixFieldSemanticsOfFlatStruct(structType);
-        }
-    }
-
     void wrapReturnValueInStruct(EntryPointInfo entryPoint)
     {
         // Wrap return value into a struct if it is not already a struct.
@@ -4933,6 +4913,10 @@ void legalizeEntryPointVaryingParamsForMetal(
     }
     LegalizeMetalEntryPointContext context(module, sink);
     context.legalizeEntryPoints(entryPoints);
+    // Separately from entry-point legalization, fix overlapping field semantics
+    // on structs reachable from the entry points (e.g. helper-function return
+    // structs) so they do not emit duplicate `[[color(0)]]`. (See issue #10802.)
+    context.fixVaryingSemanticsOfEntryPointReachableStructs();
 }
 
 void legalizeEntryPointVaryingParamsForWGSL(
@@ -4942,6 +4926,10 @@ void legalizeEntryPointVaryingParamsForWGSL(
 {
     LegalizeWGSLEntryPointContext context(module, sink);
     context.legalizeEntryPoints(entryPoints);
+    // Separately from entry-point legalization, fix overlapping field semantics
+    // on structs reachable from the entry points (e.g. helper-function return
+    // structs) so they do not emit duplicate `@location(0)`. (See issue #10802.)
+    context.fixVaryingSemanticsOfEntryPointReachableStructs();
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -4913,10 +4913,6 @@ void legalizeEntryPointVaryingParamsForMetal(
     }
     LegalizeMetalEntryPointContext context(module, sink);
     context.legalizeEntryPoints(entryPoints);
-    // Separately from entry-point legalization, fix overlapping field semantics
-    // on structs reachable from the entry points (e.g. helper-function return
-    // structs) so they do not emit duplicate `[[color(0)]]`. (See issue #10802.)
-    context.fixVaryingSemanticsOfEntryPointReachableStructs();
 }
 
 void legalizeEntryPointVaryingParamsForWGSL(
@@ -4926,9 +4922,23 @@ void legalizeEntryPointVaryingParamsForWGSL(
 {
     LegalizeWGSLEntryPointContext context(module, sink);
     context.legalizeEntryPoints(entryPoints);
-    // Separately from entry-point legalization, fix overlapping field semantics
-    // on structs reachable from the entry points (e.g. helper-function return
-    // structs) so they do not emit duplicate `@location(0)`. (See issue #10802.)
+}
+
+// Fix overlapping field semantics on structs reachable from the module's entry
+// points but not themselves entry-point parameters/return types (e.g. a struct
+// returned by a helper function the entry point calls). Run as its own pass,
+// separately from entry-point varying-parameter legalization, so the entry-point
+// legalization functions stay focused on the entry points themselves.
+// (See issue #10802.)
+void legalizeReachableStructVaryingSemanticsForMetal(IRModule* module, DiagnosticSink* sink)
+{
+    LegalizeMetalEntryPointContext context(module, sink);
+    context.fixVaryingSemanticsOfEntryPointReachableStructs();
+}
+
+void legalizeReachableStructVaryingSemanticsForWGSL(IRModule* module, DiagnosticSink* sink)
+{
+    LegalizeWGSLEntryPointContext context(module, sink);
     context.fixVaryingSemanticsOfEntryPointReachableStructs();
 }
 

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -4970,8 +4970,8 @@ public:
     }
 
 protected:
-    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
-        const SLANG_OVERRIDE
+    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic) const
+        SLANG_OVERRIDE
     {
         SLANG_UNUSED(isUserSemantic);
         return loweredName.getUnownedSlice();
@@ -4987,8 +4987,8 @@ public:
     }
 
 protected:
-    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic)
-        const SLANG_OVERRIDE
+    UnownedStringSlice getUserSemanticNameSlice(String& loweredName, bool isUserSemantic) const
+        SLANG_OVERRIDE
     {
         return isUserSemantic ? userSemanticName : loweredName.getUnownedSlice();
     }

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -2378,6 +2378,15 @@ public:
         for (auto entryPoint : entryPoints)
             legalizeEntryPoint(entryPoint);
         removeSemanticLayoutsFromLegalizedStructs();
+
+        // Structs that carry user/SV_TARGET semantics but are not directly used
+        // as entry-point parameters or return types (e.g. a helper struct shared
+        // across functions) are never seen by `fixFieldSemanticsOfFlatStruct`
+        // above. Their fields keep the unparsed semantic name (e.g. "SV_TARGET0",
+        // "SV_TARGET1") with an unspecified index of -1, so the emitter maps them
+        // all to `@location(0)`, producing duplicate locations in WGSL/Metal.
+        // Fix the semantics of those remaining structs here. (See issue #10802.)
+        fixFieldSemanticsOfNonEntryPointStructs();
     }
 
 protected:
@@ -3647,6 +3656,38 @@ private:
                 oldLayoutDecorToNew[userSemantic.layoutDecor],
                 userSemantic.attr,
                 newUserSemantic);
+        }
+    }
+
+    // Apply `fixFieldSemanticsOfFlatStruct` to every struct in the module that
+    // carries semantic decorations on its fields but was not already handled as
+    // an entry-point parameter or return type.
+    void fixFieldSemanticsOfNonEntryPointStructs()
+    {
+        for (auto inst : m_module->getGlobalInsts())
+        {
+            auto structType = as<IRStructType>(inst);
+            if (!structType)
+                continue;
+
+            // Only structs whose fields actually carry semantics need fixing;
+            // `fixFieldSemanticsOfFlatStruct` is otherwise a no-op but iterates
+            // the whole module, so skip the irrelevant ones up front.
+            bool hasFieldSemantic = false;
+            for (auto field : structType->getFields())
+            {
+                auto key = field->getKey();
+                if (key->findDecoration<IRSemanticDecoration>() ||
+                    key->findDecoration<IRLayoutDecoration>())
+                {
+                    hasFieldSemantic = true;
+                    break;
+                }
+            }
+            if (!hasFieldSemantic)
+                continue;
+
+            fixFieldSemanticsOfFlatStruct(structType);
         }
     }
 

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3670,18 +3670,35 @@ private:
             if (!structType)
                 continue;
 
-            // Only structs whose fields actually carry semantics need fixing;
-            // `fixFieldSemanticsOfFlatStruct` is otherwise a no-op but iterates
-            // the whole module, so skip the irrelevant ones up front.
+            // Only structs whose fields actually carry semantics need fixing.
+            // Gate on semantic-bearing decorations specifically: an
+            // `IRSemanticDecoration`, or a layout decoration that holds a
+            // user/system-value semantic attribute. Triggering on any
+            // `IRLayoutDecoration` would be too broad and could route structs
+            // with unrelated (e.g. offset-only) layout metadata into
+            // `fixFieldSemanticsOfFlatStruct`, which may rewrite non-semantic
+            // offsets/attributes.
             bool hasFieldSemantic = false;
             for (auto field : structType->getFields())
             {
                 auto key = field->getKey();
-                if (key->findDecoration<IRSemanticDecoration>() ||
-                    key->findDecoration<IRLayoutDecoration>())
+                if (key->findDecoration<IRSemanticDecoration>())
                 {
                     hasFieldSemantic = true;
                     break;
+                }
+                if (auto layoutDecor = key->findDecoration<IRLayoutDecoration>())
+                {
+                    for (auto attr : layoutDecor->getLayout()->getAllAttrs())
+                    {
+                        if (as<IRUserSemanticAttr>(attr) || as<IRSystemValueSemanticAttr>(attr))
+                        {
+                            hasFieldSemantic = true;
+                            break;
+                        }
+                    }
+                    if (hasFieldSemantic)
+                        break;
                 }
             }
             if (!hasFieldSemantic)

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -38,12 +38,18 @@ void legalizeEntryPointVaryingParamsForWGSL(
     List<EntryPointInfo>& entryPoints);
 
 // Fix overlapping field semantics (e.g. duplicate SV_TARGET -> @location) on
-// structs reachable from the module's entry points that are not themselves
-// entry-point parameters/return types. Run as a standalone pass, separate from
-// entry-point varying-parameter legalization. (See issue #10802.)
-void legalizeReachableStructVaryingSemanticsForMetal(IRModule* module, DiagnosticSink* sink);
+// structs used by functions reachable from the given entry points but not
+// themselves entry-point parameters/return types. Run as a standalone pass,
+// separate from entry-point varying-parameter legalization. (See issue #10802.)
+void legalizeStructVaryingSemanticsForMetal(
+    IRModule* module,
+    DiagnosticSink* sink,
+    List<EntryPointInfo>& entryPoints);
 
-void legalizeReachableStructVaryingSemanticsForWGSL(IRModule* module, DiagnosticSink* sink);
+void legalizeStructVaryingSemanticsForWGSL(
+    IRModule* module,
+    DiagnosticSink* sink,
+    List<EntryPointInfo>& entryPoints);
 
 void depointerizeInputParams(IRFunc* entryPoint);
 

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -37,6 +37,14 @@ void legalizeEntryPointVaryingParamsForWGSL(
     DiagnosticSink* sink,
     List<EntryPointInfo>& entryPoints);
 
+// Fix overlapping field semantics (e.g. duplicate SV_TARGET -> @location) on
+// structs reachable from the module's entry points that are not themselves
+// entry-point parameters/return types. Run as a standalone pass, separate from
+// entry-point varying-parameter legalization. (See issue #10802.)
+void legalizeReachableStructVaryingSemanticsForMetal(IRModule* module, DiagnosticSink* sink);
+
+void legalizeReachableStructVaryingSemanticsForWGSL(IRModule* module, DiagnosticSink* sink);
+
 void depointerizeInputParams(IRFunc* entryPoint);
 
 // SystemValueSemanticName member definition macro

--- a/source/slang/slang-ir-legalize-varying-params.h
+++ b/source/slang/slang-ir-legalize-varying-params.h
@@ -43,13 +43,13 @@ void legalizeEntryPointVaryingParamsForWGSL(
 // separate from entry-point varying-parameter legalization. (See issue #10802.)
 void legalizeStructVaryingSemanticsForMetal(
     IRModule* module,
-    DiagnosticSink* sink,
-    List<EntryPointInfo>& entryPoints);
+    List<EntryPointInfo>& entryPoints,
+    DiagnosticSink* sink);
 
 void legalizeStructVaryingSemanticsForWGSL(
     IRModule* module,
-    DiagnosticSink* sink,
-    List<EntryPointInfo>& entryPoints);
+    List<EntryPointInfo>& entryPoints,
+    DiagnosticSink* sink);
 
 void depointerizeInputParams(IRFunc* entryPoint);
 

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -418,7 +418,7 @@ void legalizeIRForMetal(IRModule* module, TargetProgram* targetProgram, Diagnost
 
     // Fix duplicate [[color]] on structs reachable from the entry points that
     // are not themselves entry-point parameters/return types. (See issue #10802.)
-    legalizeStructVaryingSemanticsForMetal(module, sink, entryPoints);
+    legalizeStructVaryingSemanticsForMetal(module, entryPoints, sink);
 
     processInst(module->getModuleInst(), targetProgram, sink);
 }

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -418,7 +418,7 @@ void legalizeIRForMetal(IRModule* module, TargetProgram* targetProgram, Diagnost
 
     // Fix duplicate [[color]] on structs reachable from the entry points that
     // are not themselves entry-point parameters/return types. (See issue #10802.)
-    legalizeReachableStructVaryingSemanticsForMetal(module, sink);
+    legalizeStructVaryingSemanticsForMetal(module, sink, entryPoints);
 
     processInst(module->getModuleInst(), targetProgram, sink);
 }

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -416,6 +416,10 @@ void legalizeIRForMetal(IRModule* module, TargetProgram* targetProgram, Diagnost
 
     legalizeEntryPointVaryingParamsForMetal(module, sink, entryPoints);
 
+    // Fix duplicate [[color]] on structs reachable from the entry points that
+    // are not themselves entry-point parameters/return types. (See issue #10802.)
+    legalizeReachableStructVaryingSemanticsForMetal(module, sink);
+
     processInst(module->getModuleInst(), targetProgram, sink);
 }
 

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -234,7 +234,7 @@ void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, Diagnosti
 
     // Fix duplicate @location on structs reachable from the entry points that
     // are not themselves entry-point parameters/return types. (See issue #10802.)
-    legalizeReachableStructVaryingSemanticsForWGSL(module, sink);
+    legalizeStructVaryingSemanticsForWGSL(module, sink, entryPoints);
 
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -232,6 +232,10 @@ void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, Diagnosti
 
     legalizeEntryPointVaryingParamsForWGSL(module, sink, entryPoints);
 
+    // Fix duplicate @location on structs reachable from the entry points that
+    // are not themselves entry-point parameters/return types. (See issue #10802.)
+    legalizeReachableStructVaryingSemanticsForWGSL(module, sink);
+
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);
 

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -234,7 +234,7 @@ void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, Diagnosti
 
     // Fix duplicate @location on structs reachable from the entry points that
     // are not themselves entry-point parameters/return types. (See issue #10802.)
-    legalizeStructVaryingSemanticsForWGSL(module, sink, entryPoints);
+    legalizeStructVaryingSemanticsForWGSL(module, entryPoints, sink);
 
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);

--- a/tests/metal/non-entrypoint-struct-location.slang
+++ b/tests/metal/non-entrypoint-struct-location.slang
@@ -1,0 +1,46 @@
+//TEST:SIMPLE(filecheck=METAL): -target metal
+
+// Metal cross-backend twin of tests/wgsl/non-entrypoint-struct-location.slang
+// (issue #10802). The same legalization change is shared between WGSL and Metal,
+// so lock the Metal behavior too.
+//
+// Unlike WGSL, Metal does not emit per-field location attributes on a plain
+// (non-entry-point) struct, so `FragmentColorOutput` here is just a normal
+// struct. The entry-point output struct must still get unique, ascending
+// [[color(N)]] indices, and the shared helper struct must compile cleanly.
+
+struct FragmentColorOutput
+{
+    float4 color : SV_TARGET0;
+    float4 target1 : SV_TARGET1;
+};
+
+FragmentColorOutput helperFunction(float4 inColor)
+{
+    FragmentColorOutput output;
+    output.color = inColor;
+    output.target1 = float4(0.5, 0.5, 1.0, 1.0);
+    return output;
+}
+
+struct FragmentOut
+{
+    float4 color : SV_TARGET0;
+    float4 target1 : SV_TARGET1;
+    float depth : SV_DEPTH;
+};
+
+// METAL: color(0)
+// METAL: color(1)
+// METAL: depth(any)
+
+[shader("fragment")]
+FragmentOut fragmentMain(float4 inColor : COLOR)
+{
+    FragmentOut output;
+    FragmentColorOutput helperOut = helperFunction(inColor);
+    output.color = helperOut.color;
+    output.target1 = helperOut.target1;
+    output.depth = 0.5;
+    return output;
+}

--- a/tests/wgsl/non-entrypoint-struct-location.slang
+++ b/tests/wgsl/non-entrypoint-struct-location.slang
@@ -1,0 +1,49 @@
+//TEST:SIMPLE(filecheck=CHECK): -target wgsl -stage fragment -entry fragmentMain
+
+// Regression test for issue #10802.
+//
+// A struct carrying SV_TARGET semantics that is NOT used directly as an
+// entry-point parameter/return type (here it is only produced by a helper
+// function) must still get unique @location indices in WGSL output. Previously
+// both fields were emitted as @location(0), which is invalid WGSL.
+
+struct FragmentColorOutput
+{
+    //CHECK: @location(0) color
+    float4 color : SV_TARGET0;
+
+    //CHECK: @location(1) target1
+    float4 target1 : SV_TARGET1;
+};
+
+FragmentColorOutput helperFunction(float4 inColor)
+{
+    FragmentColorOutput output;
+    output.color = inColor;
+    output.target1 = float4(0.5, 0.5, 1.0, 1.0);
+    return output;
+}
+
+// Entry point returns a DIFFERENT struct that wraps the helper result.
+struct FragmentOut
+{
+    //CHECK: @location(0) color
+    float4 color : SV_TARGET0;
+
+    //CHECK: @location(1) target1
+    float4 target1 : SV_TARGET1;
+
+    //CHECK: @builtin(frag_depth) depth
+    float depth : SV_DEPTH;
+};
+
+[shader("fragment")]
+FragmentOut fragmentMain(float4 inColor : COLOR)
+{
+    FragmentOut output;
+    FragmentColorOutput helperOut = helperFunction(inColor);
+    output.color = helperOut.color;
+    output.target1 = helperOut.target1;
+    output.depth = 0.5;
+    return output;
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10802

## Summary of the problem from the end user perspective

A struct carrying `SV_TARGET` semantics that is shared across modules and used only by a helper function (not directly as an entry-point return/parameter) is emitted with duplicate `@location(0)` on every field in WGSL, which is invalid WGSL. SPIR-V is unaffected.

### Minimal repro shader

```slang
// Helper struct used by a function, NOT directly as an entry-point output
struct FragmentColorOutput {
  float4 color   : SV_TARGET0;
  float4 target1 : SV_TARGET1;
};

FragmentColorOutput helperFunction(float4 inColor) {
  FragmentColorOutput output;
  output.color = inColor;
  output.target1 = float4(0.5, 0.5, 1.0, 1.0);
  return output;
}

struct FragmentOut {
  float4 color   : SV_TARGET0;
  float4 target1 : SV_TARGET1;
  float  depth   : SV_DEPTH;
};

[shader("fragment")]
FragmentOut fragmentMain(float4 inColor : COLOR) {
  FragmentOut output;
  FragmentColorOutput helperOut = helperFunction(inColor);
  output.color = helperOut.color;
  output.target1 = helperOut.target1;
  output.depth = 0.5;
  return output;
}
```

Before the fix, `FragmentColorOutput` emits `@location(0)` for both `color` and `target1`.

## Root cause

`fixFieldSemanticsOfFlatStruct()` parses the index out of names like `SV_TARGET0`/`SV_TARGET1` (the raw `IRSemanticDecoration` index is `-1`) and assigns unique indices, but it was only ever called for entry-point parameter and return structs. Non-entry-point structs kept index `-1`, which the emitter maps to `@location(0)` for every field.

## Solution in this PR

Run a standalone pass — separate from entry-point varying-parameter legalization — that applies `fixFieldSemanticsOfFlatStruct()` to structs used by functions reachable from the entry points but not themselves entry-point parameters/return types, so their semantic indices are parsed and made unique.

The shared struct-field-semantic routines now live in a dedicated `LegalizeShaderVaryingStructContext` base class. `LegalizeShaderEntryPointContext` derives from it, and the new pass uses its own `LegalizeWGSLVaryingStructContext` / `LegalizeMetalVaryingStructContext` (which only override the target-specific user-semantic naming) — so the new pass does not go through the entry-point contexts.

### Notes to the reviewers; where to focus on

- New base class `LegalizeShaderVaryingStructContext` in `slang-ir-legalize-varying-params.cpp` owns `fixFieldSemanticsOfFlatStruct()` and the reachable-struct sweep `legalizeVaryingStructTypes(entryPoints)`.
- New free functions `legalizeStructVaryingSemanticsForWGSL/ForMetal(module, sink, entryPoints)` are invoked as their own pass right after `legalizeEntryPointVaryingParamsFor*` in `slang-ir-wgsl-legalize.cpp` / `slang-ir-metal-legalize.cpp`.
- The sweep is limited to functions reachable from the supplied `entryPoints` via `buildEntryPointReferenceGraph()`; a pre-filter skips structs without field semantics, and `fixFieldSemanticsOfFlatStruct()` is idempotent.
- Only the WGSL/Metal paths call these; SPIR-V/HLSL/GLSL/CUDA are unaffected.

## Related PRs in the past

- #6063 — introduced `fixFieldSemanticsOfFlatStruct` (Darren Wihandi)
- #5498 — WGSL `emitSemanticsPrefixImpl` (Jay Kwak)
- #9752 — recent WGSL semantic fixes (aidanfnv)


## Reviewer Directives (maintained by agent)

- [human @jkwak-work] (2026-06-09, supersedes earlier guidance) Minimize the change to only what is relevant to issue #10802, and do NOT use inheritance — the diff is too large to review. This supersedes the earlier directives below about a standalone pass / dedicated context class / base-class extraction. (ref: #issuecomment-4655259575)
- [human @jkwak-work] Parameter convention: `DiagnosticSink* sink` goes LAST. (ref: #discussion_r3376939349) — note: the standalone functions this applied to are being removed under the minimize directive.
- [SUPERSEDED] [human @jkwak-work] (earlier) The fix should be its own standalone pass invoked from the WGSL/Metal legalize drivers; use a dedicated new context class; do not reuse `Legalize{WGSL,Metal}EntryPointContext`. Superseded by the 2026-06-09 minimize/no-inheritance directive above. (refs: #discussion_r3369580521, #discussion_r3369583226, and the 2026-06-07 "doesn't seem like a place for this" comment)

### Pending design discussion

- [human @jkwak-work] Proposed: legalize entry-point I/O varying params, then **remove** field semantics from structs not connected to the varying params (rather than renumbering). Finding: a prototype of the remove approach regresses existing tests (WGSL `nested-varying-input`, `entry-point-legalization`; Metal `stage-in`, `stage-in-2`, `sv_target-complex-1`, `sv_target-complex-2`), because varying **input**/**nested** structs carry semantics the emitter needs and are reached via the function body (not the signature) — so a connected-struct protect-set cannot be derived cheaply, and removal breaks them. Recommended minimal alternative: keep the **renumber** approach (reuse `fixFieldSemanticsOfFlatStruct`) as a small no-inheritance method. Awaiting reviewer decision (renumber vs. remove + scope). (ref: #discussion_r3376976681, #discussion_r3377527432)

