### PR TITLE
Add [nodiscard] attribute

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -701,7 +701,7 @@ interface IForwardDifferentiable<FType> where __hasDiffTypeInfo(FType)
 {
     __builtin_requirement($( (int)BuiltinRequirementKind::ForwardDerivativeFunc))
     [MaybeDifferentiable]
-    static __associatedfunc FwdDiffFuncType<FType> fwd_diff; // -> fwd_diff 
+    static __associatedfunc FwdDiffFuncType<FType> fwd_diff; // -> fwd_diff
 };
 
 // Core library interfaces:
@@ -718,10 +718,10 @@ __magic_type(BwdDiffFuncInterfaceType)
 [__FunctionInterface]
 interface IBackwardDifferentiable<FType> where __hasDiffTypeInfo(FType)
 {
-    __builtin_requirement($( (int)BuiltinRequirementKind::BwdCallableContextType)) 
+    __builtin_requirement($( (int)BuiltinRequirementKind::BwdCallableContextType))
     associatedtype BwdCallable : IBwdCallable<FType>; // -> intermediate_context_type
 
-    __builtin_requirement($( (int)BuiltinRequirementKind::MinimalContextType)) 
+    __builtin_requirement($( (int)BuiltinRequirementKind::MinimalContextType))
     associatedtype MinimalContext; // -> minimal_context_type
 
     __builtin_requirement($( (int)BuiltinRequirementKind::BwdApplyFunc))
@@ -1322,7 +1322,7 @@ $}
         {
             return a + b;
         }
-        
+
 ${
         break;
     }
@@ -2455,7 +2455,7 @@ extension matrix<T,N,M,L> : IFloat
     [__unsafeForceInlineEarly]
     __implicit_conversion($(kConversionCost_ScalarToMatrix))
     __init(float v) { this = matrix<T,N,M>(T(v)); }
-    
+
     /// Initialize a matrix where all elements have the same scalar `value`.
     [OverloadRank(-1)]
     [Differentiable]
@@ -4524,6 +4524,28 @@ attribute_syntax [mutating] : MutatingAttribute;
 ///
 __attributeTarget(AccessorDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;
+
+/// Marks a function whose return value should not be discarded. When a call to a
+/// function marked with `[nodiscard]` is used as a statement and its result is
+/// ignored, the compiler emits a warning.
+/// @remarks
+/// This is useful for functions that look like they mutate the object they are called
+/// on, but instead return a result. For example, a member function `Load` that returns
+/// the loaded value rather than mutating `this`:
+/// ```
+/// struct MyType
+/// {
+///    [nodiscard]
+///    MyType load() { ... }
+/// }
+/// MyType t;
+/// t.load(); // warning: result of '[nodiscard]' function is discarded.
+/// let loaded = t.load(); // OK
+/// ```
+/// The C++ spelling `[[nodiscard]]` is also accepted.
+///
+__attributeTarget(FunctionDeclBase)
+attribute_syntax [nodiscard] : NoDiscardAttribute;
 
 /// @internal
 /// Marks a member function to make `this` argument passed by const reference.

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4542,7 +4542,6 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// t.load(); // warning: result of '[nodiscard]' function is discarded.
 /// let loaded = t.load(); // OK
 /// ```
-/// The C++ spelling `[[nodiscard]]` is also accepted.
 ///
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [nodiscard] : NoDiscardAttribute;

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1385,6 +1385,17 @@ class NonmutatingAttribute : public Attribute
     FIDDLE(...)
 };
 
+// A `[nodiscard]` attribute, which indicates that the result of a
+// function call should not be discarded. When a call to a function
+// marked with this attribute is used as a statement (its result is
+// ignored), the compiler emits a warning.
+//
+FIDDLE()
+class NoDiscardAttribute : public Attribute
+{
+    FIDDLE(...)
+};
+
 // A `[constref]` attribute, which indicates that the `this` parameter of
 // a member function should be passed by const reference.
 //

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14636,6 +14636,16 @@ void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
         }
     }
 
+    // `[nodiscard]` is meaningless on a function with no result to discard, so reject it
+    // on a `void`-returning function.
+    if (decl->findModifier<NoDiscardAttribute>())
+    {
+        if (decl->returnType.type && decl->returnType.type->equals(m_astBuilder->getVoidType()))
+        {
+            getSink()->diagnose(Diagnostics::NodiscardOnVoidFunction{.decl = decl});
+        }
+    }
+
     checkInterfaceRequirement(decl);
     checkVisibility(decl);
 }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3725,6 +3725,11 @@ struct SemanticsStmtVisitor : public SemanticsVisitor, StmtVisitor<SemanticsStmt
 
     void visitRequireCapabilityStmt(RequireCapabilityStmt* stmt);
 
+    // If `expr` is the discarded result of a call to a `[nodiscard]` function,
+    // emit a warning. Used for any context where an expression's result is
+    // ignored (an expression statement, or a `for` loop's side-effect expression).
+    void maybeDiagnoseDiscardedNodiscardResult(Expr* expr);
+
     // Try to infer the max number of iterations the loop will run.
     void tryInferLoopMaxIterations(ForStmt* stmt);
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -685,6 +685,24 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
             }
         }
     }
+
+    // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
+    // the result is being ignored.
+    if (auto invokeExpr = as<InvokeExpr>(stmt->expression))
+    {
+        if (auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr))
+        {
+            if (auto calleeDecl = funcDeclRefExpr->declRef.getDecl())
+            {
+                if (calleeDecl->findModifier<NoDiscardAttribute>())
+                {
+                    getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
+                        .name = calleeDecl->getName(),
+                        .expr = invokeExpr});
+                }
+            }
+        }
+    }
 }
 
 void SemanticsStmtVisitor::visitRequireCapabilityStmt(RequireCapabilityStmt*)

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -715,8 +715,11 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     if (!invokeExpr)
         return;
 
-    // A `void`-returning function has no result to discard, so `[nodiscard]` on it never
-    // warns (matching C++ behavior).
+    // `[nodiscard]` on a `void`-returning function is already rejected at the declaration
+    // (see `NodiscardOnVoidFunction` in `checkCallableDeclCommon`). That diagnostic is an
+    // error but not fatal, so checking continues and calls to such a function still reach
+    // here; this guard suppresses an additional, nonsensical "result is discarded" warning
+    // at every call site on top of the declaration error.
     if (invokeExpr->type.type && invokeExpr->type.type->equals(m_astBuilder->getVoidType()))
         return;
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -295,6 +295,9 @@ void SemanticsStmtVisitor::visitForStmt(ForStmt* stmt)
         SemanticsContext sideEffectContext = withInForLoopSideEffect();
         SemanticsExprVisitor subExprVisitor(sideEffectContext);
         stmt->sideEffectExpression = subExprVisitor.CheckExpr(stmt->sideEffectExpression);
+
+        // A `for` loop's side-effect expression also discards its result.
+        maybeDiagnoseDiscardedNodiscardResult(stmt->sideEffectExpression);
     }
     subContext.checkStmt(stmt->statement);
 
@@ -686,22 +689,35 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
         }
     }
 
+    maybeDiagnoseDiscardedNodiscardResult(stmt->expression);
+}
+
+void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
+{
     // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
     // the result is being ignored.
-    if (auto invokeExpr = as<InvokeExpr>(stmt->expression))
+    auto invokeExpr = as<InvokeExpr>(expr);
+    if (!invokeExpr)
+        return;
+
+    // A `void`-returning function has no result to discard, so `[nodiscard]` on it never
+    // warns (matching C++ behavior).
+    if (invokeExpr->type.type && invokeExpr->type.type->equals(m_astBuilder->getVoidType()))
+        return;
+
+    auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr);
+    if (!funcDeclRefExpr)
+        return;
+
+    auto calleeDecl = funcDeclRefExpr->declRef.getDecl();
+    if (!calleeDecl)
+        return;
+
+    if (calleeDecl->findModifier<NoDiscardAttribute>())
     {
-        if (auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr))
-        {
-            if (auto calleeDecl = funcDeclRefExpr->declRef.getDecl())
-            {
-                if (calleeDecl->findModifier<NoDiscardAttribute>())
-                {
-                    getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
-                        .name = calleeDecl->getName(),
-                        .expr = invokeExpr});
-                }
-            }
-        }
+        getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
+            .name = calleeDecl->getName(),
+            .expr = invokeExpr});
     }
 }
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -694,6 +694,21 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
 
 void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
 {
+    // A comma operator in a discarded context discards each of its operands, so recurse
+    // into them (e.g. `for (int i = 0; i < n; t.load(), i++)` discards `t.load()`).
+    if (auto operatorExpr = as<OperatorExpr>(expr))
+    {
+        if (auto func = as<VarExpr>(operatorExpr->functionExpr))
+        {
+            if (func->name && func->name->text == ",")
+            {
+                for (auto arg : operatorExpr->arguments)
+                    maybeDiagnoseDiscardedNodiscardResult(arg);
+                return;
+            }
+        }
+    }
+
     // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
     // the result is being ignored.
     auto invokeExpr = as<InvokeExpr>(expr);

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1301,6 +1301,13 @@ warning(
 )
 
 err(
+    "nodiscard-on-void-function",
+    30069,
+    "'[nodiscard]' applied to a function returning 'void'",
+    span { loc = "decl:Decl", message = "'[nodiscard]' has no effect on a function that returns 'void'." }
+)
+
+err(
     "expected-a-type",
     30060,
     "expected a type",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1293,6 +1293,13 @@ warning(
     span { loc = "expr:Expr", message = "result of '==' not used, did you intend '='?" }
 )
 
+warning(
+    "discarded-nodiscard-result",
+    30059,
+    "result of '[nodiscard]' function is discarded",
+    span { loc = "expr:Expr", message = "the result of calling '~name:Name' is discarded; this function is marked '[nodiscard]'." }
+)
+
 err(
     "expected-a-type",
     30060,

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+//DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
 // `[nodiscard]` on a function that returns `void` has no result to discard,
 // so it is rejected at the declaration with an error.
@@ -9,7 +9,7 @@ struct MyType
 
     [nodiscard]
     void touch() {}
-/*diag:
+/*DIAG:
          ^^^^^ '[nodiscard]' applied to a function returning 'void'
          ^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
 */
@@ -17,7 +17,7 @@ struct MyType
 
 [nodiscard]
 void freeVoid() {}
-/*diag:
+/*DIAG:
      ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
      ^^^^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
 */

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -1,0 +1,30 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+
+// `[nodiscard]` on a function that returns `void` has no result to discard,
+// so it is rejected at the declaration with an error.
+
+struct MyType
+{
+    int val;
+
+    [nodiscard]
+    void touch() {}
+/*diag:
+         ^^^^^ '[nodiscard]' applied to a function returning 'void'
+         ^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+*/
+}
+
+[nodiscard]
+void freeVoid() {}
+/*diag:
+     ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
+     ^^^^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+*/
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyType t;
+    t.val = 0;
+}

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -13,11 +13,6 @@ struct MyType
     [nodiscard]
     int compute() { return val * 2; }
 
-    // `[nodiscard]` on a `void` function has no result to discard, so discarding
-    // a call to it never warns.
-    [nodiscard]
-    void touch() {}
-
     int regular() { return val; }
 }
 
@@ -66,9 +61,6 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 */
     {
     }
-
-    // `[nodiscard]` on a `void` function does not warn even when discarded.
-    t.touch();
 
     // Storing the result is fine, no warning.
     let loaded = t.load();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -10,9 +10,13 @@ struct MyType
     [nodiscard]
     MyType load() { MyType r; r.val = 42; return r; }
 
-    // The C++ `[[nodiscard]]` spelling is also accepted.
-    [[nodiscard]]
+    [nodiscard]
     int compute() { return val * 2; }
+
+    // `[nodiscard]` on a `void` function has no result to discard, so discarding
+    // a call to it never warns.
+    [nodiscard]
+    void touch() {}
 
     int regular() { return val; }
 }
@@ -43,6 +47,19 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
             ^ result of '[nodiscard]' function is discarded
             ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
+
+    // The result is discarded in a `for` loop's side-effect expression too.
+    for (int i = 0; i < 1; t.load())
+/*diag:
+                                 ^ result of '[nodiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+    {
+        i++;
+    }
+
+    // `[nodiscard]` on a `void` function does not warn even when discarded.
+    t.touch();
 
     // Storing the result is fine, no warning.
     let loaded = t.load();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+//DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
 // Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
 // and discarding its result produces a warning.
@@ -26,26 +26,26 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     t.val = 0;
 
     t.load(); // warn
-/*diag:
+/*DIAG:
           ^ result of '[nodiscard]' function is discarded
           ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
 
     t.compute(); // warn
-/*diag:
+/*DIAG:
              ^ result of '[nodiscard]' function is discarded
              ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
 */
 
     freeFunc(); // warn
-/*diag:
+/*DIAG:
             ^ result of '[nodiscard]' function is discarded
             ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
 
     // The result is discarded in a `for` loop's side-effect expression too.
     for (int i = 0; i < 1; t.load())
-/*diag:
+/*DIAG:
                                  ^ result of '[nodiscard]' function is discarded
                                  ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
@@ -55,7 +55,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // The result is also discarded in a comma operand of a `for` loop side effect.
     for (int j = 0; j < 1; t.load(), j++)
-/*diag:
+/*DIAG:
                                  ^ result of '[nodiscard]' function is discarded
                                  ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -58,6 +58,15 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
         i++;
     }
 
+    // The result is also discarded in a comma operand of a `for` loop side effect.
+    for (int j = 0; j < 1; t.load(), j++)
+/*diag:
+                                 ^ result of '[nodiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+    {
+    }
+
     // `[nodiscard]` on a `void` function does not warn even when discarded.
     t.touch();
 

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -19,6 +19,11 @@ struct MyType
 [nodiscard]
 int freeFunc() { return 1; }
 
+void consume(int x) {}
+
+// Returning the result is using it, not discarding it, so no warning.
+int useResult() { return freeFunc(); }
+
 [numthreads(1, 1, 1)]
 void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
@@ -68,6 +73,13 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // A function not marked `[nodiscard]` does not warn even when discarded.
     t.regular();
+
+    // Using the result in a sub-expression is not discarding it, so none of these warn:
+    // as a call argument, ...
+    consume(t.compute());
+    // ... and as an operand of a larger, non-`[nodiscard]` expression whose own result is
+    // then discarded (the `[nodiscard]` call's result is consumed by `+`, not discarded).
+    t.compute() + c;
 
     // Silence unused-variable concerns.
     t.val = loaded.val + c;

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,0 +1,56 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+
+// Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
+// and discarding its result produces a warning.
+
+struct MyType
+{
+    int val;
+
+    [nodiscard]
+    MyType load() { MyType r; r.val = 42; return r; }
+
+    // The C++ `[[nodiscard]]` spelling is also accepted.
+    [[nodiscard]]
+    int compute() { return val * 2; }
+
+    int regular() { return val; }
+}
+
+[nodiscard]
+int freeFunc() { return 1; }
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyType t;
+    t.val = 0;
+
+    t.load(); // warn
+/*diag:
+          ^ result of '[nodiscard]' function is discarded
+          ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    t.compute(); // warn
+/*diag:
+             ^ result of '[nodiscard]' function is discarded
+             ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    freeFunc(); // warn
+/*diag:
+            ^ result of '[nodiscard]' function is discarded
+            ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // Storing the result is fine, no warning.
+    let loaded = t.load();
+    int c = t.compute();
+
+    // A function not marked `[nodiscard]` does not warn even when discarded.
+    t.regular();
+
+    // Silence unused-variable concerns.
+    t.val = loaded.val + c;
+}


### PR DESCRIPTION
Fixes shader-slang/slang#11454

## Summary of the problem from the end user perspective

Some member functions look like they mutate the object they are called on but actually return a result; discarding that result is usually a mistake. Slang had no way to flag it, unlike C++'s `[[nodiscard]]`.

### Minimal repro shader; if applicable

```slang
linalg::CoopMat<...> matA;
matA.Load<...>(...); // Load() returns the loaded value; it does not mutate matA
```

## Root cause

Not a bug — a missing language feature. There was no attribute to mark a function whose return value must not be ignored.

## Solution in this PR

Add a `[nodiscard]` function attribute. When a call to a `[nodiscard]`-marked function is evaluated purely for its side effects and its result is discarded — as an expression statement or as a `for` loop's side-effect expression — the compiler emits a warning. Applying `[nodiscard]` to a `void`-returning function is an error (it has no result to discard).

### Notes to the reviewers; where to focus on

- `NoDiscardAttribute` AST node in `slang-ast-modifier.h` and the `attribute_syntax [nodiscard]` declaration in `core.meta.slang` (targets `FunctionDeclBase`).
- The warning is emitted by the shared helper `SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult` (`slang-check-stmt.cpp`), called from both `visitExpressionStmt` (beside the existing dangling-`==` warning) and `visitForStmt` for the side-effect expression. The helper skips `void`-returning calls and recurses through comma-operator operands (so a discarded call in `t.load(), i++` is still flagged).
- New warning `discarded-nodiscard-result` (E30059) and new error `nodiscard-on-void-function` (E30069) in `slang-diagnostics.lua`. The void error is checked in `SemanticsDeclHeaderVisitor::checkCallableDeclCommon` (beside the CUDA-kernel return-type check).
- Regression test: `tests/diagnostics/nodiscard.slang` (covers member/free functions, the `for`-loop side-effect context (including a comma operand), and the non-warning stored-result cases); `tests/diagnostics/nodiscard-void.slang` covers the void-declaration error.

This PR is intentionally scoped to the attribute mechanism only. Two follow-ups were left out on purpose: (1) annotating the core-module `CoopMat::Load` overloads with `[nodiscard]` (would surface new warnings in GPU cooperative-matrix tests), and (2) Yong's separate suggestion to warn when a static method is called as an instance method.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] `[nodiscard]` on a `void`-returning function is an **error** (E30069), reported at the declaration — chosen over a warning/no-op; easy to relax later. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356392886))

- [human @jkwak-work] `[nodiscard]` on a `void`-returning function intentionally does not warn — a `void` call has no result to discard. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356392886))
- [human @jkwak-work] Do not mention the C++ `[[nodiscard]]` double-bracket spelling in the attribute docs or tests. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356395692))
- [LLM gemini-code-assist] The `[nodiscard]` discard check must cover every discarded-expression context — both `ExpressionStmt::expression` and `ForStmt::sideEffectExpression` — via the shared helper. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3353271943))


