### PR TITLE
Build DXC from source by default on macOS

### DIFF
--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -191,6 +191,13 @@ jobs:
               exit 1
             fi
 
+            # macOS now builds DXC from source by default (#11438). Opt out for
+            # every macOS job that uses this reusable build workflow (PR CI and
+            # sccache population) to keep them fast.
+            if [[ "${{ inputs.os }}" == "macos" ]]; then
+              cmake_launcher_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
+            fi
+
             if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" ]]; then
               # Doing a debug build will try to link against a release built llvm, this
               # is a problem on Windows, so make slang-llvm in release build and use

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -185,6 +185,12 @@ jobs:
             echo "ℹ️  ccache_symlinks_path not set - building without ccache"
           fi
 
+          # macOS now builds DXC from source by default (#11438). Opt out here too:
+          # coverage-macos is a required gate for the nightly coverage merge.
+          if [[ "${{ inputs.os }}" == "macos" ]]; then
+            cmake_launcher_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
+          fi
+
           if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" ]]; then
             # Doing a debug build will try to link against a release built llvm, this
             # is a problem on Windows, so make slang-llvm in release build and use

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -458,6 +458,24 @@ elseif(
         )
     endif()
     return()
+elseif(
+    NOT DEFINED SLANG_DXC_BUILD_FROM_SOURCE
+    AND NOT DEFINED SLANG_DXC_BINARY_URL
+    AND CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+)
+    # macOS: Microsoft publishes no prebuilt DXC binary, so a source build is
+    # the only way to get DXIL/DXC support. Default to building from source when
+    # the user has neither opted out with -DSLANG_DXC_BUILD_FROM_SOURCE=OFF nor
+    # supplied a custom prebuilt via -DSLANG_DXC_BINARY_URL. The first
+    # configure clones and builds DXC + LLVM/Clang from source (tens of
+    # minutes), then results are stamp-cached for subsequent reconfigures.
+    message(
+        STATUS
+        "macOS: building DXC from source by default (no prebuilt DXC binary "
+        "is published for macOS). Set -DSLANG_DXC_BUILD_FROM_SOURCE=OFF to "
+        "disable, or -DSLANG_DXC_BINARY_URL=<url> to use a custom prebuilt."
+    )
+    set(_dxc_build_from_source ON)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/docs/building.md
+++ b/docs/building.md
@@ -245,7 +245,7 @@ works for any given binary.
 | ------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `SLANG_VERSION`                       | Latest `v*` tag               | The project version, detected using git if available                                                                                     |
 | `SLANG_DXC_BINARY_URL`                | Stable DXC release URL        | URL of the prebuilt DXC binary archive to download; overrides the default release URL and skips GLIBC auto-detection on Linux            |
-| `SLANG_DXC_BUILD_FROM_SOURCE`         | Unset (auto on native Linux x86_64; otherwise prebuilt when available) | `ON`: build DXC from source on Windows, Linux, and macOS; `OFF`: use prebuilt when available; unset: auto-select on native Linux x86_64, otherwise use prebuilt when available (see [DXC GLIBC auto-detection](#dxc-glibc-auto-detection)) |
+| `SLANG_DXC_BUILD_FROM_SOURCE`         | Unset (auto on native Linux x86_64; source build on macOS; otherwise prebuilt when available) | `ON`: build DXC from source on Windows, Linux, and macOS; `OFF`: use prebuilt when available; unset: auto-select on native Linux x86_64, build from source on macOS, otherwise use prebuilt when available (see [DXC GLIBC auto-detection](#dxc-glibc-auto-detection)) |
 | `SLANG_EMBED_CORE_MODULE`             | `TRUE`                        | Build slang with an embedded version of the core module                                                                                  |
 | `SLANG_EMBED_CORE_MODULE_SOURCE`      | `TRUE`                        | Embed the core module source in the binary                                                                                               |
 | `SLANG_ENABLE_DXIL`                   | `TRUE`                        | Enable generating DXIL using DXC                                                                                                         |
@@ -285,9 +285,10 @@ provides, or if the requirement or system GLIBC version cannot be detected, DXC
 is built from source instead. Successful detection results are cached in stamp
 files so subsequent reconfigures are fast. For example, if a DXC Linux prebuilt
 requires GLIBC 2.38 and the host provides an older GLIBC, CMake selects the
-source-build path. On macOS, Microsoft does not publish a prebuilt DXC package;
-set `-DSLANG_DXC_BUILD_FROM_SOURCE=ON` to build DXC locally. The default macOS
-configuration leaves DXC unavailable to avoid the large clone and build cost.
+source-build path. On macOS, Microsoft does not publish a prebuilt DXC package,
+so DXC is built from source by default. Set `-DSLANG_DXC_BUILD_FROM_SOURCE=OFF`
+to opt out (leaving DXC unavailable), or `-DSLANG_DXC_BINARY_URL=<url>` to use a
+custom prebuilt binary.
 
 ```mermaid
 flowchart TD
@@ -296,7 +297,9 @@ flowchart TD
     BuildFromSource -->|OFF| Prebuilt["Use a prebuilt binary when available"]
     BuildFromSource -->|unset| CustomUrl{"SLANG_DXC_BINARY_URL set?"}
     CustomUrl -->|yes| CustomPrebuilt["Use custom prebuilt URL and skip GLIBC detection"]
-    CustomUrl -->|no| NativeLinux{"Native Linux x86_64?"}
+    CustomUrl -->|no| Darwin{"macOS?"}
+    Darwin -->|yes| Source
+    Darwin -->|no| NativeLinux{"Native Linux x86_64?"}
     NativeLinux -->|yes| Probe["Download Linux prebuilt and inspect GLIBC requirements"]
     Probe --> Compatible{"Detected requirements are compatible with host GLIBC?"}
     Compatible -->|yes| LinuxPrebuilt["Use Linux prebuilt binary"]
@@ -311,7 +314,7 @@ flowchart TD
   non-x86_64 Linux and macOS, DXC is unavailable unless `SLANG_DXC_BINARY_URL`
   is set to a custom prebuilt for that architecture/platform.
 - unset on native non-x86_64 Linux (e.g. ARM64): DXC is unavailable because no official prebuilt binary exists; set `ON` to build DXC from source.
-- unset on macOS: DXC is unavailable because no official prebuilt binary exists; set `ON` to build DXC from source.
+- unset on macOS: DXC is built from source because no official prebuilt binary exists; set `OFF` to leave DXC unavailable, or `SLANG_DXC_BINARY_URL` to use a custom prebuilt.
 - unset while cross-compiling for Linux x86_64: skip GLIBC detection because the target system cannot be probed at configure time.
 
 The source-build path clones DXC plus LLVM/Clang submodules on the first run


### PR DESCRIPTION
Fixes shader-slang/slang#11438

## Summary of the problem from the end user perspective

On macOS, DXC was silently unavailable by default: Microsoft publishes no prebuilt DXC binary for macOS, and the CMake decision cascade had no branch that built it from source unless the user explicitly passed `-DSLANG_DXC_BUILD_FROM_SOURCE=ON`.

## Root cause

After #11434 made the opt-in macOS source build work, `cmake/FetchDXC.cmake` still left `_dxc_build_from_source = OFF` for Darwin with the flag unset — every auto-detect branch was Windows/Linux-specific, so DXC fell through to prebuilt resolution and ended up unavailable.

## Solution in this PR

Add a Darwin branch that defaults `_dxc_build_from_source` to `ON` when `SLANG_DXC_BUILD_FROM_SOURCE` is unset and no `SLANG_DXC_BINARY_URL` is supplied, mirroring the existing Linux auto-detect branch shape. The two CI workflows that build macOS opt back out so they stay fast and the required nightly gate is unaffected.

### Notes to the reviewers; where to focus on

- `cmake/FetchDXC.cmake`: the new `elseif` is gated on `NOT DEFINED SLANG_DXC_BUILD_FROM_SOURCE` (keeps `=OFF` working) and `NOT DEFINED SLANG_DXC_BINARY_URL` (keeps the custom-prebuilt escape hatch). Behavior: macOS unset/no-URL -> source build; macOS + URL -> custom prebuilt; macOS `=OFF` -> unavailable; macOS `=ON` -> unchanged; Linux/Windows -> unchanged.
- `.github/workflows/ci-slang-build.yml` opts macOS out to protect PR CI / sccache-population latency.
- `.github/workflows/ci-slang-coverage.yml` opts macOS out because `coverage-macos` is a required gate for the nightly coverage merge.
- `docs/building.md`: option table, prose, mermaid flowchart, and bullets updated.

Validation note: the decision cascade was verified with a standalone `cmake -P` simulation of the five behavior cases (all pass); a real macOS DXC-from-source build was not run (no Apple toolchain available) and is left to CI / a Mac runner.

## Related PRs in the past

- #11434 — made the opt-in macOS DXC source build work (prerequisite).
- #11439 — bot-authored PR for this same change; it could only commit the cmake + docs edits because the bot's token lacked `workflows` permission. This PR additionally applies the two workflow opt-outs.
