### PR TITLE
Share front-end IR across test targets in slang-test

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1057,6 +1057,11 @@ Enable loop inversion in the code-gen optimization. Default is off
 Generate code for all entry points in a single output (library mode). 
 
 
+<a id="use-shared-front-end-ir"></a>
+### -use-shared-front-end-ir
+Allow the lowered, target-agnostic IR for the input to be cached on the session and reused by a later compilation of the same source with the same front-end options. Intended for slang-test to share front-end work across targets. 
+
+
 
 <a id="deprecated"></a>
 ## Deprecated

--- a/include/slang.h
+++ b/include/slang.h
@@ -1187,7 +1187,7 @@ typedef uint32_t SlangSizeT;
                  //   artifact carries coverage metadata and must not overlap any emitted
                  //   artifact path. Query/set with the string option APIs.
 
-        UseSharedFrontEndIR = 150, // bool: when set, the lowered (target-agnostic) IR for a
+        UseSharedFrontEndIR = 151, // bool: when set, the lowered (target-agnostic) IR for a
                                    //   command-line translation unit may be cached on the
                                    //   session and reused by a later compilation of the same
                                    //   source with the same front-end options (e.g. for a

--- a/include/slang.h
+++ b/include/slang.h
@@ -1187,6 +1187,14 @@ typedef uint32_t SlangSizeT;
                  //   artifact carries coverage metadata and must not overlap any emitted
                  //   artifact path. Query/set with the string option APIs.
 
+        UseSharedFrontEndIR = 150, // bool: when set, the lowered (target-agnostic) IR for a
+                                   //   command-line translation unit may be cached on the
+                                   //   session and reused by a later compilation of the same
+                                   //   source with the same front-end options (e.g. for a
+                                   //   different -target), skipping the front end. Purely an
+                                   //   optimization used by slang-test; reuse is validated to
+                                   //   produce identical artifacts.
+
         CountOf,
     };
 

--- a/include/slang.h
+++ b/include/slang.h
@@ -1187,7 +1187,7 @@ typedef uint32_t SlangSizeT;
                  //   artifact carries coverage metadata and must not overlap any emitted
                  //   artifact path. Query/set with the string option APIs.
 
-        UseSharedFrontEndIR = 151, // bool: when set, the lowered (target-agnostic) IR for a
+        UseSharedFrontEndIR = 153, // bool: when set, the lowered (target-agnostic) IR for a
                                    //   command-line translation unit may be cached on the
                                    //   session and reused by a later compilation of the same
                                    //   source with the same front-end options (e.g. for a

--- a/source/compiler-core/slang-diagnostic-sink.cpp
+++ b/source/compiler-core/slang-diagnostic-sink.cpp
@@ -526,6 +526,7 @@ static void formatDiagnostic(DiagnosticSink* sink, Diagnostic const& diagnostic,
 void DiagnosticSink::init(SourceManager* sourceManager, SourceLocationLexer sourceLocationLexer)
 {
     m_errorCount = 0;
+    m_diagnosticCount = 0;
     m_internalErrorLocsNoted = 0;
 
     m_sourceManager = sourceManager;
@@ -544,6 +545,7 @@ void DiagnosticSink::init(SourceManager* sourceManager, SourceLocationLexer sour
 void DiagnosticSink::reset()
 {
     m_errorCount = 0;
+    m_diagnosticCount = 0;
     m_internalErrorLocsNoted = 0;
 
     outputBuffer.clear();
@@ -597,6 +599,7 @@ bool DiagnosticSink::diagnoseImpl(
     DiagnosticInfo const& info,
     const UnownedStringSlice& formattedMessage)
 {
+    m_diagnosticCount++;
     if (info.severity >= Severity::Error)
     {
         m_errorCount++;
@@ -652,6 +655,7 @@ bool DiagnosticSink::diagnoseRichImpl(
     GenericDiagnostic effectiveDiagnostic = diagnostic;
     effectiveDiagnostic.severity = effectiveSeverity;
 
+    m_diagnosticCount++;
     if (effectiveSeverity >= Severity::Error)
     {
         m_errorCount++;
@@ -789,6 +793,7 @@ void DiagnosticSink::diagnoseRaw(Severity severity, char const* message)
 
 void DiagnosticSink::diagnoseRaw(Severity severity, const UnownedStringSlice& message)
 {
+    m_diagnosticCount++;
     if (severity >= Severity::Error)
     {
         m_errorCount++;

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -182,6 +182,11 @@ public:
     /// Get the total amount of errors that have taken place on this DiagnosticSink
     SLANG_FORCE_INLINE int getErrorCount() { return m_errorCount; }
 
+    /// Get the total number of diagnostics (of any severity, including warnings and
+    /// notes) that have been emitted on this DiagnosticSink. This is useful for callers
+    /// that need to detect whether *any* diagnostic was produced, not just errors.
+    SLANG_FORCE_INLINE int getDiagnosticCount() { return m_diagnosticCount; }
+
     template<typename P, typename... Args>
     bool diagnose(P const& pos, DiagnosticInfo const& info, Args const&... args)
     {
@@ -404,6 +409,7 @@ protected:
     DiagnosticSink* m_parentSink = nullptr;
 
     int m_errorCount = 0;
+    int m_diagnosticCount = 0;
     int m_internalErrorLocsNoted = 0;
 
     /// If 0, then there is no limit, otherwise max amount of chars of the source line location

--- a/source/slang/slang-compile-request.cpp
+++ b/source/slang/slang-compile-request.cpp
@@ -573,7 +573,22 @@ void FrontEndCompileRequest::generateIR()
 
 bool FrontEndCompileRequest::canUseFrontEndIRCache(TranslationUnitRequest* translationUnit)
 {
+    if (!translationUnit)
+        return false;
+
     if (!optionSet.getBoolOption(CompilerOptionName::UseSharedFrontEndIR))
+        return false;
+
+    // Restrict to a single-translation-unit request. With more than one translation unit, a
+    // later unit may `import` an earlier one; reusing a cached unit marks it checked and would
+    // skip registering it in the per-request loaded-module set, breaking intra-request imports.
+    // Command-line single-file compiles (the slang-test case) always have exactly one unit.
+    if (translationUnits.getCount() != 1)
+        return false;
+
+    // Semantic checking can depend on externally supplied modules that the cache key does not
+    // capture, so don't reuse when any are present.
+    if (additionalLoadedModules && additionalLoadedModules->getCount() != 0)
         return false;
 
     // Only ordinary Slang source is serialized/deserialized as a module here.
@@ -588,8 +603,13 @@ bool FrontEndCompileRequest::canUseFrontEndIRCache(TranslationUnitRequest* trans
     if (!sourceFile || !sourceFile->getPathInfo().hasFoundPath())
         return false;
 
-    // Preprocessor-only output never reaches IR, so there is nothing to share.
-    if (optionSet.getBoolOption(CompilerOptionName::PreprocessorOutput))
+    // A cache hit skips `parseTranslationUnit`, which is also where preprocessor output,
+    // `-output-includes`, and `-dump-ast` are produced, and skips the optional debug
+    // serialization verification in `generateIR`. Don't share when any of those front-end
+    // side effects are requested, since reuse would suppress their output.
+    if (optionSet.getBoolOption(CompilerOptionName::PreprocessorOutput) ||
+        optionSet.getBoolOption(CompilerOptionName::OutputIncludes) ||
+        optionSet.getBoolOption(CompilerOptionName::DumpAst) || verifyDebugSerialization)
         return false;
 
     // Core module code follows a specialized compilation path.

--- a/source/slang/slang-compile-request.cpp
+++ b/source/slang/slang-compile-request.cpp
@@ -571,6 +571,120 @@ void FrontEndCompileRequest::generateIR()
     }
 }
 
+bool FrontEndCompileRequest::canUseFrontEndIRCache(TranslationUnitRequest* translationUnit)
+{
+    if (!optionSet.getBoolOption(CompilerOptionName::UseSharedFrontEndIR))
+        return false;
+
+    // Only ordinary Slang source is serialized/deserialized as a module here.
+    if (translationUnit->sourceLanguage != SourceLanguage::Slang)
+        return false;
+
+    // The cache key is derived from a single file-backed source.
+    const auto& sourceFiles = translationUnit->getSourceFiles();
+    if (sourceFiles.getCount() != 1)
+        return false;
+    auto sourceFile = sourceFiles[0];
+    if (!sourceFile || !sourceFile->getPathInfo().hasFoundPath())
+        return false;
+
+    // Preprocessor-only output never reaches IR, so there is nothing to share.
+    if (optionSet.getBoolOption(CompilerOptionName::PreprocessorOutput))
+        return false;
+
+    // Core module code follows a specialized compilation path.
+    if (m_isCoreModuleCode)
+        return false;
+
+    // Entry points introduced via a library reference add state that the serialized module
+    // would not capture, so don't risk reuse in that case.
+    if (m_extraEntryPoints.getCount() != 0)
+        return false;
+
+    return true;
+}
+
+bool FrontEndCompileRequest::computeFrontEndIRCacheKey(
+    TranslationUnitRequest* translationUnit,
+    String& outKey)
+{
+    const auto& sourceFiles = translationUnit->getSourceFiles();
+    if (sourceFiles.getCount() != 1 || !sourceFiles[0])
+        return false;
+    auto sourceFile = sourceFiles[0];
+
+    DigestBuilder<SHA1> builder;
+    builder.append(UnownedStringSlice("slang-front-end-ir-cache-v1"));
+    builder.append(String(getBuildTagString()));
+    builder.append((uint32_t)translationUnit->sourceLanguage);
+    builder.append(sourceFile->getPathInfo().getMostUniqueIdentity());
+    builder.append(sourceFile->getDigest());
+    // Hash the front-end-affecting compiler options. Target/back-end options live on the
+    // per-target option sets (not this one), so compilations differing only by `-target`
+    // produce the same key and can share the cached IR.
+    optionSet.buildHash(builder);
+    outKey = builder.finalize().toString();
+    return true;
+}
+
+bool FrontEndCompileRequest::tryLoadTranslationUnitFromCache(
+    TranslationUnitRequest* translationUnit)
+{
+    if (!canUseFrontEndIRCache(translationUnit))
+        return false;
+
+    String key;
+    if (!computeFrontEndIRCacheKey(translationUnit, key))
+        return false;
+
+    auto session = getLinkage()->getSessionImpl();
+    auto blob = session->findFrontEndIRCacheEntry(key);
+    if (!blob)
+        return false;
+
+    auto sourceFile = translationUnit->getSourceFiles()[0];
+    auto pathInfo = sourceFile->getPathInfo();
+
+    if (SLANG_FAILED(getLinkage()->loadCachedTranslationUnitModule(
+            translationUnit->getModule(),
+            translationUnit->moduleName,
+            pathInfo,
+            blob,
+            getSink())))
+    {
+        // The cached IR was stale or could not be decoded. Discard any partial state and fall
+        // back to compiling this translation unit from scratch.
+        translationUnit->module = new Module(getLinkage());
+        if (translationUnit->moduleName)
+            translationUnit->module->setName(translationUnit->moduleName);
+        return false;
+    }
+
+    translationUnit->isChecked = true;
+    session->noteFrontEndIRCacheHit();
+    return true;
+}
+
+void FrontEndCompileRequest::storeTranslationUnitToCache(TranslationUnitRequest* translationUnit)
+{
+    if (!canUseFrontEndIRCache(translationUnit))
+        return;
+
+    auto module = translationUnit->getModule();
+    if (!module || !module->getIRModule() || !module->getModuleDecl())
+        return;
+
+    String key;
+    if (!computeFrontEndIRCacheKey(translationUnit, key))
+        return;
+
+    ComPtr<ISlangBlob> blob;
+    if (SLANG_FAILED(getLinkage()->serializeModuleToBlobForCache(module, blob.writeRef())))
+        return;
+
+    getLinkage()->getSessionImpl()->addFrontEndIRCacheEntry(key, blob);
+}
+
 SlangResult FrontEndCompileRequest::executeActionsInner()
 {
     SLANG_PROFILE_SECTION(frontEndExecute);
@@ -582,10 +696,29 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
         SLANG_RETURN_ON_FAIL(translationUnit->requireSourceFiles());
     }
 
+    // Track which translation units were satisfied from the front-end IR cache so that we can
+    // skip parsing/checking/lowering for them, and avoid re-storing them afterwards.
+    const Index translationUnitCount = translationUnits.getCount();
+    List<bool> loadedFromCache;
+    loadedFromCache.setCount(translationUnitCount);
+    for (Index i = 0; i < translationUnitCount; ++i)
+        loadedFromCache[i] = false;
 
-    // Parse everything from the input files requested
-    for (TranslationUnitRequest* translationUnit : translationUnits)
+    // Snapshot the diagnostic count so we can later detect whether parsing/checking/lowering
+    // emitted any diagnostics. We only populate the cache for a fully diagnostic-free front
+    // end, because a later cache hit skips those steps and so would not reproduce any
+    // warnings or notes the original compile emitted.
+    const int diagnosticCountBeforeFrontEnd = getSink()->getDiagnosticCount();
+
+    // Parse everything from the input files requested (reusing cached IR where possible).
+    for (Index i = 0; i < translationUnitCount; ++i)
     {
+        auto translationUnit = translationUnits[i];
+        if (tryLoadTranslationUnitFromCache(translationUnit))
+        {
+            loadedFromCache[i] = true;
+            continue;
+        }
         parseTranslationUnit(translationUnit);
     }
 
@@ -636,6 +769,20 @@ SlangResult FrontEndCompileRequest::executeActionsInner()
     generateIR();
     if (getSink()->getErrorCount() != 0)
         return SLANG_FAIL;
+
+    // If the target-agnostic front end (parse/check/lower) completed without emitting any
+    // diagnostics, cache the lowered IR so a later compilation of the same source (e.g. for a
+    // different `-target`) can reuse it. The diagnostic-free requirement keeps reuse
+    // correctness-preserving: a cache hit skips the steps above, so it must not have hidden any
+    // diagnostics that the original compile produced.
+    if (getSink()->getDiagnosticCount() == diagnosticCountBeforeFrontEnd)
+    {
+        for (Index i = 0; i < translationUnitCount; ++i)
+        {
+            if (!loadedFromCache[i])
+                storeTranslationUnitToCache(translationUnits[i]);
+        }
+    }
 
     // Do parameter binding generation, for each compilation target.
     //

--- a/source/slang/slang-compile-request.h
+++ b/source/slang/slang-compile-request.h
@@ -154,6 +154,21 @@ public:
 
     SlangResult executeActionsInner();
 
+    /// Returns true if the front-end IR cache may be used for `translationUnit`.
+    /// The cache is only safe for a single, file-backed Slang translation unit.
+    bool canUseFrontEndIRCache(TranslationUnitRequest* translationUnit);
+
+    /// Compute the cache key for `translationUnit` from the source file digest and the
+    /// front-end-affecting compiler options. Returns false if no stable key can be formed.
+    bool computeFrontEndIRCacheKey(TranslationUnitRequest* translationUnit, String& outKey);
+
+    /// Attempt to populate `translationUnit`'s module from the front-end IR cache. On success
+    /// the translation unit is marked checked and parsing/checking/lowering can be skipped.
+    bool tryLoadTranslationUnitFromCache(TranslationUnitRequest* translationUnit);
+
+    /// Store `translationUnit`'s freshly-compiled module into the front-end IR cache.
+    void storeTranslationUnitToCache(TranslationUnitRequest* translationUnit);
+
     /// Add a translation unit to be compiled.
     ///
     /// @param language The source language that the translation unit will use (e.g.,

--- a/source/slang/slang-global-session.cpp
+++ b/source/slang/slang-global-session.cpp
@@ -326,6 +326,20 @@ TypeCheckingCache* Session::getTypeCheckingCache()
     return static_cast<TypeCheckingCache*>(m_typeCheckingCache.get());
 }
 
+ComPtr<ISlangBlob> Session::findFrontEndIRCacheEntry(const String& key)
+{
+    std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
+    if (auto found = m_frontEndIRCache.tryGetValue(key))
+        return *found;
+    return ComPtr<ISlangBlob>();
+}
+
+void Session::addFrontEndIRCacheEntry(const String& key, ISlangBlob* blob)
+{
+    std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
+    m_frontEndIRCache[key] = ComPtr<ISlangBlob>(blob);
+}
+
 Session::BuiltinModuleInfo Session::getBuiltinModuleInfo(slang::BuiltinModuleName name)
 {
     Session::BuiltinModuleInfo result;
@@ -1258,3 +1272,10 @@ SlangResult checkExternalCompilerSupport(Session* session, PassThroughMode passT
 }
 
 } // namespace Slang
+
+SLANG_API int64_t slang_getFrontEndIRCacheHitCount(slang::IGlobalSession* globalSession)
+{
+    if (!globalSession)
+        return 0;
+    return static_cast<Slang::Session*>(globalSession)->getFrontEndIRCacheHitCount();
+}

--- a/source/slang/slang-global-session.cpp
+++ b/source/slang/slang-global-session.cpp
@@ -336,6 +336,8 @@ ComPtr<ISlangBlob> Session::findFrontEndIRCacheEntry(const String& key)
 
 void Session::addFrontEndIRCacheEntry(const String& key, ISlangBlob* blob)
 {
+    if (!blob)
+        return;
     std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
     m_frontEndIRCache[key] = ComPtr<ISlangBlob>(blob);
 }

--- a/source/slang/slang-global-session.cpp
+++ b/source/slang/slang-global-session.cpp
@@ -339,7 +339,21 @@ void Session::addFrontEndIRCacheEntry(const String& key, ISlangBlob* blob)
     if (!blob)
         return;
     std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
+    if (!m_frontEndIRCacheEnabled)
+        return;
     m_frontEndIRCache[key] = ComPtr<ISlangBlob>(blob);
+}
+
+void Session::clearFrontEndIRCache()
+{
+    std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
+    m_frontEndIRCache.clear();
+}
+
+void Session::setFrontEndIRCacheEnabled(bool enabled)
+{
+    std::lock_guard<std::mutex> lock(m_frontEndIRCacheMutex);
+    m_frontEndIRCacheEnabled = enabled;
 }
 
 Session::BuiltinModuleInfo Session::getBuiltinModuleInfo(slang::BuiltinModuleName name)
@@ -1280,4 +1294,18 @@ SLANG_API int64_t slang_getFrontEndIRCacheHitCount(slang::IGlobalSession* global
     if (!globalSession)
         return 0;
     return static_cast<Slang::Session*>(globalSession)->getFrontEndIRCacheHitCount();
+}
+
+SLANG_API void slang_clearFrontEndIRCache(slang::IGlobalSession* globalSession)
+{
+    if (!globalSession)
+        return;
+    static_cast<Slang::Session*>(globalSession)->clearFrontEndIRCache();
+}
+
+SLANG_API void slang_setFrontEndIRCacheEnabled(slang::IGlobalSession* globalSession, bool enabled)
+{
+    if (!globalSession)
+        return;
+    static_cast<Slang::Session*>(globalSession)->setFrontEndIRCacheEnabled(enabled);
 }

--- a/source/slang/slang-global-session.h
+++ b/source/slang/slang-global-session.h
@@ -349,6 +349,38 @@ public:
     RefPtr<RefObject> m_typeCheckingCache;
     TypeCheckingCache* getTypeCheckingCache();
     std::mutex m_typeCheckingCacheMutex;
+
+    // Front-end IR cache.
+    //
+    // When the `UseSharedFrontEndIR` option is set (typically by slang-test), the lowered,
+    // target-agnostic IR for a command-line translation unit is serialized after the front end
+    // completes and stored here, keyed by a digest of the source file(s) and
+    // front-end-affecting options. A later compilation of the same source with the same
+    // front-end options (e.g. a different `-target`) can then reuse the cached IR and skip
+    // lexing/parsing/checking/lowering.
+    //
+    // This is purely an optimization: the cache is consulted only when that option is set. The
+    // key fully captures the front-end-affecting inputs (build tag, source path + content
+    // digest, and the front-end option-set hash) and the cache lives only for the lifetime of
+    // the session, so a hit reproduces the same lowered IR that recompilation would.
+    Dictionary<String, ComPtr<ISlangBlob>> m_frontEndIRCache;
+    std::mutex m_frontEndIRCacheMutex;
+    // Number of times a cached front-end IR blob was successfully reused. Used by tests to
+    // confirm the optimization is actually engaged (and for diagnostics).
+    std::atomic<int64_t> m_frontEndIRCacheHitCount = 0;
+
+    /// Look up a serialized module blob previously stored under `key`. Returns null on miss.
+    ComPtr<ISlangBlob> findFrontEndIRCacheEntry(const String& key);
+
+    /// Store a serialized module `blob` under `key` for later reuse.
+    void addFrontEndIRCacheEntry(const String& key, ISlangBlob* blob);
+
+    /// Record that a cached front-end IR blob was successfully reused for a translation unit.
+    void noteFrontEndIRCacheHit() { m_frontEndIRCacheHitCount++; }
+
+    /// Total number of successful front-end IR cache reuses on this session.
+    int64_t getFrontEndIRCacheHitCount() { return m_frontEndIRCacheHitCount.load(); }
+
     // GenericCCpp probing can recurse into per-compiler loads while holding the same lock.
     std::recursive_mutex m_downstreamCompilerMutex;
     // Backend compilation threads update and read these aggregate timing counters concurrently.

--- a/source/slang/slang-global-session.h
+++ b/source/slang/slang-global-session.h
@@ -368,12 +368,25 @@ public:
     // Number of times a cached front-end IR blob was successfully reused. Used by tests to
     // confirm the optimization is actually engaged (and for diagnostics).
     std::atomic<int64_t> m_frontEndIRCacheHitCount = 0;
+    // When false, addFrontEndIRCacheEntry() becomes a no-op so the cache stops growing
+    // ("do-not-keep" mode); existing entries are still reused on lookup. Defaults to true.
+    // Embedders can toggle this (and clear the cache) to bound memory on a long-lived session.
+    // Guarded by m_frontEndIRCacheMutex.
+    bool m_frontEndIRCacheEnabled = true;
 
     /// Look up a serialized module blob previously stored under `key`. Returns null on miss.
     ComPtr<ISlangBlob> findFrontEndIRCacheEntry(const String& key);
 
-    /// Store a serialized module `blob` under `key` for later reuse.
+    /// Store a serialized module `blob` under `key` for later reuse. No-op when retention is
+    /// disabled (see setFrontEndIRCacheEnabled).
     void addFrontEndIRCacheEntry(const String& key, ISlangBlob* blob);
+
+    /// Drop all cached front-end IR blobs, freeing their memory. Does not reset the hit count.
+    void clearFrontEndIRCache();
+
+    /// Enable or disable retention of new front-end IR cache entries. When disabled, entries
+    /// already present are still reused but no new entries are stored. Defaults to enabled.
+    void setFrontEndIRCacheEnabled(bool enabled);
 
     /// Record that a cached front-end IR blob was successfully reused for a translation unit.
     void noteFrontEndIRCacheHit() { m_frontEndIRCacheHitCount++; }

--- a/source/slang/slang-internal.h
+++ b/source/slang/slang-internal.h
@@ -18,4 +18,9 @@ SLANG_API SlangResult slang_createGlobalSessionImpl(
 
 SLANG_API void spSetCommandLineCompilerMode(SlangCompileRequest* request);
 
+/// Test/diagnostic hook: returns the number of times this global session reused front-end IR
+/// from its cache (see the `UseSharedFrontEndIR` option). Used by unit tests to confirm the
+/// optimization is actually engaged.
+SLANG_API int64_t slang_getFrontEndIRCacheHitCount(slang::IGlobalSession* globalSession);
+
 #endif

--- a/source/slang/slang-internal.h
+++ b/source/slang/slang-internal.h
@@ -23,4 +23,14 @@ SLANG_API void spSetCommandLineCompilerMode(SlangCompileRequest* request);
 /// optimization is actually engaged.
 SLANG_API int64_t slang_getFrontEndIRCacheHitCount(slang::IGlobalSession* globalSession);
 
+/// Explicit cache control: drop all front-end IR blobs cached on this session, freeing their
+/// memory. The hit count is left unchanged. Safe to call at any time; subsequent compilations
+/// repopulate the cache as needed.
+SLANG_API void slang_clearFrontEndIRCache(slang::IGlobalSession* globalSession);
+
+/// Explicit cache control: enable or disable retention of new front-end IR cache entries on this
+/// session. When disabled ("do-not-keep" mode), entries already present are still reused but no
+/// new entries are stored, so memory stops growing. Defaults to enabled.
+SLANG_API void slang_setFrontEndIRCacheEnabled(slang::IGlobalSession* globalSession, bool enabled);
+
 #endif

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1205,6 +1205,12 @@ void initCommandOptions(CommandOptions& options)
          "-whole-program",
          nullptr,
          "Generate code for all entry points in a single output (library mode)."},
+        {OptionKind::UseSharedFrontEndIR,
+         "-use-shared-front-end-ir",
+         nullptr,
+         "Allow the lowered, target-agnostic IR for the input to be cached on the session "
+         "and reused by a later compilation of the same source with the same front-end "
+         "options. Intended for slang-test to share front-end work across targets."},
     };
     _addOptions(makeConstArrayView(internalOpts), options);
 
@@ -2629,6 +2635,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::PreserveParameters:
         case OptionKind::UseMSVCStyleBitfieldPacking:
         case OptionKind::ExperimentalFeature:
+        case OptionKind::UseSharedFrontEndIR:
             linkage->m_optionSet.set(optionKind, true);
             break;
         case OptionKind::EnableRichDiagnostics:

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -1,7 +1,9 @@
 // slang-session.cpp
 #include "slang-session.h"
 
+#include "../core/slang-blob.h"
 #include "../core/slang-shared-library.h"
+#include "../core/slang-stream.h"
 #include "compiler-core/slang-artifact-util.h"
 #include "slang-check-impl.h"
 #include "slang-compiler.h"
@@ -2070,7 +2072,8 @@ SlangResult Linkage::loadSerializedModuleContents(
     ISlangBlob* blobHoldingSerializedData,
     ModuleChunk const* moduleChunk,
     RIFF::ListChunk const* containerChunk,
-    DiagnosticSink* sink)
+    DiagnosticSink* sink,
+    bool discoverEntryPoints)
 {
     // At this point we've dealt with basically all of
     // the formalities, and we just need to get down
@@ -2231,7 +2234,8 @@ SlangResult Linkage::loadSerializedModuleContents(
             module->addModuleDependency(req);
     }
 
-    module->_discoverEntryPoints(sink, targets);
+    if (discoverEntryPoints)
+        module->_discoverEntryPoints(sink, targets);
 
     // Hook up fileDecl's scope to module's scope.
     for (auto fileDecl : moduleDecl->getDirectMemberDeclsOfType<FileDecl>())
@@ -2241,6 +2245,61 @@ SlangResult Linkage::loadSerializedModuleContents(
     if (sink->getErrorCount() != 0)
         return SLANG_FAIL;
     return SLANG_OK;
+}
+
+SlangResult Linkage::serializeModuleToBlobForCache(Module* module, ISlangBlob** outBlob)
+{
+    SLANG_AST_BUILDER_RAII(getASTBuilder());
+
+    SerialContainerUtil::WriteOptions writeOptions;
+    // Serialize source locations against this linkage's source manager so that the
+    // deserialized IR carries valid debug information when reused in a later request.
+    writeOptions.sourceManagerToUseWhenSerializingSourceLocs = getSourceManager();
+
+    OwnedMemoryStream memoryStream(FileAccess::Write);
+    SLANG_RETURN_ON_FAIL(SerialContainerUtil::write(module, writeOptions, &memoryStream));
+
+    auto contents = memoryStream.getContents();
+    *outBlob = RawBlob::create(contents.getBuffer(), (size_t)contents.getCount()).detach();
+    return SLANG_OK;
+}
+
+SlangResult Linkage::loadCachedTranslationUnitModule(
+    Module* module,
+    Name* moduleName,
+    const PathInfo& moduleFilePathInfo,
+    ISlangBlob* blob,
+    DiagnosticSink* sink)
+{
+    auto rootChunk = RIFF::RootChunk::getFromBlob(blob);
+    if (!rootChunk)
+        return SLANG_FAIL;
+
+    auto moduleChunk = ModuleChunk::find(rootChunk);
+    if (!moduleChunk)
+        return SLANG_FAIL;
+
+    // Correctness here is guaranteed by the cache key computed in
+    // `FrontEndCompileRequest::computeFrontEndIRCacheKey`, which incorporates the compiler
+    // build tag, the source file's canonical path and content digest, and the hash of the
+    // front-end-affecting compiler options. Any difference in those inputs yields a different
+    // key (and thus a miss). The cache is held only in memory for the lifetime of the session,
+    // so the contents of the source files cannot change between a store and a matching hit.
+    module->setName(moduleName);
+
+    // Deserialize directly into the translation unit's module. Entry-point discovery is
+    // intentionally skipped here so that the normal front-end entry-point logic
+    // (`FrontEndCompileRequest::checkEntryPoints`) runs afterwards exactly as it would for a
+    // from-scratch compile, handling both explicit `-entry` requests and `[shader]`
+    // attribute discovery identically.
+    return loadSerializedModuleContents(
+        module,
+        moduleFilePathInfo,
+        blob,
+        moduleChunk,
+        rootChunk,
+        sink,
+        /* discoverEntryPoints: */ false);
 }
 
 void Linkage::setRequireCacheFileSystem(bool requireCacheFileSystem)

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -1,10 +1,10 @@
 // slang-session.cpp
 #include "slang-session.h"
 
-#include "../core/slang-blob.h"
-#include "../core/slang-shared-library.h"
-#include "../core/slang-stream.h"
 #include "compiler-core/slang-artifact-util.h"
+#include "core/slang-blob.h"
+#include "core/slang-shared-library.h"
+#include "core/slang-stream.h"
 #include "slang-check-impl.h"
 #include "slang-compiler.h"
 #include "slang-lower-to-ir.h"

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -2249,6 +2249,9 @@ SlangResult Linkage::loadSerializedModuleContents(
 
 SlangResult Linkage::serializeModuleToBlobForCache(Module* module, ISlangBlob** outBlob)
 {
+    if (!module || !outBlob)
+        return SLANG_E_INVALID_ARG;
+
     SLANG_AST_BUILDER_RAII(getASTBuilder());
 
     SerialContainerUtil::WriteOptions writeOptions;
@@ -2271,6 +2274,9 @@ SlangResult Linkage::loadCachedTranslationUnitModule(
     ISlangBlob* blob,
     DiagnosticSink* sink)
 {
+    if (!module || !blob)
+        return SLANG_E_INVALID_ARG;
+
     auto rootChunk = RIFF::RootChunk::getFromBlob(blob);
     if (!rootChunk)
         return SLANG_FAIL;

--- a/source/slang/slang-session.h
+++ b/source/slang/slang-session.h
@@ -372,6 +372,23 @@ public:
         ISlangBlob* blobHoldingSerializedData,
         ModuleChunk const* moduleChunk,
         RIFF::ListChunk const* containerChunk, //< The outer container, if there is one.
+        DiagnosticSink* sink,
+        bool discoverEntryPoints = true);
+
+    /// Serialize a (command-line) translation unit's `module` into a self-contained blob
+    /// suitable for storing in the front-end IR cache. Source locations are serialized using
+    /// this linkage's source manager so that diagnostics remain accurate after reuse.
+    SlangResult serializeModuleToBlobForCache(Module* module, ISlangBlob** outBlob);
+
+    /// Attempt to populate `module` (an as-yet-uncompiled translation-unit module) from a
+    /// previously serialized cache `blob`. Returns SLANG_OK only if the blob is valid and
+    /// up-to-date with the current files and options. Entry-point discovery is intentionally
+    /// skipped so that the normal front-end entry-point logic runs unchanged afterwards.
+    SlangResult loadCachedTranslationUnitModule(
+        Module* module,
+        Name* moduleName,
+        const PathInfo& moduleFilePathInfo,
+        ISlangBlob* blob,
         DiagnosticSink* sink);
 
     SourceFile* loadSourceFile(String pathFrom, String path);

--- a/tests/autodiff/hlsl-torch-cross-compile.slang
+++ b/tests/autodiff/hlsl-torch-cross-compile.slang
@@ -1,6 +1,6 @@
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -line-directive-mode none -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=CUDA): -target cuda -line-directive-mode none
-//TEST:SIMPLE(filecheck=TORCH): -target torch -line-directive-mode none
+//TEST:SIMPLE(filecheck=TORCH): -target torch -line-directive-mode none -no-share-front-end-ir
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/compute/front-end-ir-cache-share.slang
+++ b/tests/compute/front-end-ir-cache-share.slang
@@ -1,0 +1,35 @@
+// Regression test for issue 11176: multiple //TEST: lines compile the same source for
+// different targets while sharing the target-agnostic front-end IR (-use-shared-front-end-ir).
+// Under slang-test's shared-library / test-server spawn modes the first line computes and
+// caches the lowered IR and the later lines reuse it. This test verifies that sharing produces
+// correct code generation for each target. (The option is passed explicitly so the test
+// exercises sharing regardless of the slang-test default.)
+
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -use-shared-front-end-ir
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -stage compute -entry computeMain -use-shared-front-end-ir
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -stage compute -entry computeMain -use-shared-front-end-ir
+
+RWStructuredBuffer<float> gBuffer;
+
+float helper(uint i)
+{
+    float acc = 0.0f;
+    for (uint k = 0; k < i; ++k)
+        acc += float(k) * 0.5f;
+    return acc;
+}
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    gBuffer[tid.x] = helper(tid.x) + float(tid.x) * 2.0f;
+}
+
+//SPIRV: OpEntryPoint
+//SPIRV: OpFunction
+
+//HLSL: RWStructuredBuffer
+//HLSL: void computeMain
+
+//GLSL: buffer
+//GLSL: void main(

--- a/tests/glsl-intrinsic/intrinsic-basic-scalar.slang
+++ b/tests/glsl-intrinsic/intrinsic-basic-scalar.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -allow-glsl -stage compute -entry computeMain -target glsl
 //TEST:SIMPLE(filecheck=CHECK_GLSL_SPIRV): -allow-glsl -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl
 //TEST:SIMPLE(filecheck=CHECK_SPIR): -allow-glsl -stage compute -entry computeMain -target spirv -emit-spirv-directly
-//TEST:SIMPLE(filecheck=CHECK_HLSL): -allow-glsl -stage compute -entry computeMain -target hlsl
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -allow-glsl -stage compute -entry computeMain -target hlsl -no-share-front-end-ir
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -output-using-type -emit-spirv-directly

--- a/tests/spirv/spec-constant-enum-numthreads.slang
+++ b/tests/spirv/spec-constant-enum-numthreads.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=GLSL): -target glsl
-//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -no-share-front-end-ir
 // NOTE: Validates target-specific specialization ID/local size emission in
 // generated GLSL/SPIR-V text output.
 

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -96,6 +96,8 @@ static bool _isSubCommand(const char* arg)
         "  -shuffle-seed <seed>           Set shuffle seed (default: 1)\n"
         "  -explicit-test-order           Run tests in the order specified on command line\n"
         "                                 (alphabetical for prefixes matching multiple tests)\n"
+        "  -share-front-end-ir            Reuse target-agnostic front-end IR across a test's\n"
+        "                                 //TEST: lines (shared-library/test-server modes)\n"
         "  -dry-run                       List tests that would be run without running them\n"
         "  -disable-retries               Disable automatic retries of failed tests\n"
         "  -synthesize-compile-targets    Synthesize compile-only tests for all available\n"
@@ -294,6 +296,10 @@ static bool _isSubCommand(const char* arg)
         else if (strcmp(arg, "-disable-retries") == 0)
         {
             optionsOut->disableRetries = true;
+        }
+        else if (strcmp(arg, "-share-front-end-ir") == 0)
+        {
+            optionsOut->shareFrontEndIR = true;
         }
         else if (strcmp(arg, "-synthesize-compile-targets") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -190,6 +190,18 @@ struct Options
     /// When true, only run synthesized compile-target tests (skip original tests).
     /// Implies -synthesize-compile-targets.
     bool onlySynthesized = false;
+
+    /// When true, pass `-use-shared-front-end-ir` to slangc/slangi for tests that run against a
+    /// persistent session (shared-library or test-server spawn modes), so the target-agnostic
+    /// front-end IR is computed once per source and reused across the remaining `//TEST:` lines
+    /// (e.g. different `-target`s). Enabled with `-share-front-end-ir`.
+    ///
+    /// This is OFF by default: reusing serialized front-end IR is byte-identical for code
+    /// generation, but a few back-end paths are sensitive to the round-trip (e.g. diagnostics
+    /// lose caret token-widths, and some specialized targets are not yet supported), so it is
+    /// not yet safe to apply blanket-wide to the whole suite. Individual tests can still opt in
+    /// by passing `-use-shared-front-end-ir` directly in their `//TEST:` line.
+    bool shareFrontEndIR = false;
 };
 
 #endif // OPTIONS_H_INCLUDED

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2642,7 +2642,7 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
 // modes, where nothing would be reused.
 static bool _shouldShareFrontEndIR(TestContext* context, const TestInput& input)
 {
-    if (!context->options.shareFrontEndIR)
+    if (!context->options.shareFrontEndIR || !input.testOptions)
         return false;
 
     // Diagnostic tests assert on exact source-location spans (the `^^^^` carets). Reusing the

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -62,6 +62,8 @@ using namespace Slang;
 
 // Constants for slang-test specific options
 static const char* kPreserveEmbeddedSourceOption = "-preserve-embedded-source";
+// Per-test opt-out for broad `slang-test -share-front-end-ir` runs; not passed to slangc.
+static const char* kNoShareFrontEndIROption = "-no-share-front-end-ir";
 
 // Options for a particular test
 struct TestOptions
@@ -2657,6 +2659,9 @@ static bool _shouldShareFrontEndIR(TestContext* context, const TestInput& input)
     if (input.testOptions->getDiagTestPrefix(diagPrefix))
         return false;
 
+    if (input.testOptions->args.indexOf(kNoShareFrontEndIROption) != Index(-1))
+        return false;
+
     switch (context->getFinalSpawnType(input.spawnType))
     {
     case SpawnType::UseSharedLibrary:
@@ -2692,7 +2697,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
     for (auto arg : input.testOptions->args)
     {
         // Filter out slang-test specific options that shouldn't be passed to slangc
-        if (arg == kPreserveEmbeddedSourceOption)
+        if (arg == kPreserveEmbeddedSourceOption || arg == kNoShareFrontEndIROption)
             continue;
         cmdLine.addArg(arg);
     }
@@ -2768,6 +2773,8 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
 
     for (auto arg : input.testOptions->args)
     {
+        if (arg == kNoShareFrontEndIROption)
+            continue;
         cmdLine.addArg(arg);
     }
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2635,6 +2635,35 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     return result;
 }
 
+// Decide whether the front-end IR sharing option should be passed to slangc/slangi for this
+// test. Sharing only helps when the compiler runs against a session that persists across the
+// test file's `//TEST:` lines, i.e. the in-process shared-library mode or a (persistent)
+// test server. It is intentionally skipped for separate-process and fully-isolated-server
+// modes, where nothing would be reused.
+static bool _shouldShareFrontEndIR(TestContext* context, const TestInput& input)
+{
+    if (!context->options.shareFrontEndIR)
+        return false;
+
+    // Diagnostic tests assert on exact source-location spans (the `^^^^` carets). Reusing the
+    // serialized front-end IR reconstructs source files with size but no content, so a
+    // back-end diagnostic pointing into reused IR cannot re-lex token widths and would render
+    // a single-column caret. Codegen output is unaffected, but to keep diagnostics byte-exact
+    // we never share front-end IR for diagnostic-test lines.
+    String diagPrefix;
+    if (input.testOptions->getDiagTestPrefix(diagPrefix))
+        return false;
+
+    switch (context->getFinalSpawnType(input.spawnType))
+    {
+    case SpawnType::UseSharedLibrary:
+    case SpawnType::UseTestServer:
+        return true;
+    default:
+        return false;
+    }
+}
+
 TestResult runSimpleTest(TestContext* context, TestInput& input)
 {
     // need to execute the stand-alone Slang compiler on the file, and compare its output to what we
@@ -2663,6 +2692,11 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
         if (arg == kPreserveEmbeddedSourceOption)
             continue;
         cmdLine.addArg(arg);
+    }
+
+    if (_shouldShareFrontEndIR(context, input))
+    {
+        cmdLine.addArg("-use-shared-front-end-ir");
     }
 
     // If we can't set up for simple compilation, it's because some external resource isn't
@@ -2732,6 +2766,11 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     for (auto arg : input.testOptions->args)
     {
         cmdLine.addArg(arg);
+    }
+
+    if (_shouldShareFrontEndIR(context, input))
+    {
+        cmdLine.addArg("-use-shared-front-end-ir");
     }
 
     ExecuteResult exeRes;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2649,7 +2649,10 @@ static bool _shouldShareFrontEndIR(TestContext* context, const TestInput& input)
     // serialized front-end IR reconstructs source files with size but no content, so a
     // back-end diagnostic pointing into reused IR cannot re-lex token widths and would render
     // a single-column caret. Codegen output is unaffected, but to keep diagnostics byte-exact
-    // we never share front-end IR for diagnostic-test lines.
+    // we never share front-end IR for diagnostic tests. Exclude both the `DIAGNOSTIC_TEST`
+    // command (Type::Diagnostic) and any `diag=`-style annotated SIMPLE line.
+    if (input.testOptions->type == TestOptions::Type::Diagnostic)
+        return false;
     String diagPrefix;
     if (input.testOptions->getDiagTestPrefix(diagPrefix))
         return false;

--- a/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
+++ b/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
@@ -7,8 +7,8 @@
 // artifacts are byte-identical whether the IR is recomputed from scratch or loaded from the
 // cache, including across different targets sharing one front-end result.
 
-#include "../../source/core/slang-io.h"
-#include "../../source/slang/slang-internal.h"
+#include "core/slang-io.h"
+#include "slang/slang-internal.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
 #include "unit-test/slang-unit-test.h"

--- a/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
+++ b/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
@@ -1,0 +1,145 @@
+// unit-test-front-end-ir-cache.cpp
+
+// Tests the `-use-shared-front-end-ir` optimization (slang issue 11176): when enabled, the
+// lowered, target-agnostic IR for a command-line translation unit is cached on the session and
+// reused by a later compilation of the same source with the same front-end options (e.g. for a
+// different target). This test asserts that reuse is *correctness-preserving*: the generated
+// artifacts are byte-identical whether the IR is recomputed from scratch or loaded from the
+// cache, including across different targets sharing one front-end result.
+
+#include "../../source/core/slang-io.h"
+#include "../../source/slang/slang-internal.h"
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+using namespace Slang;
+
+namespace
+{
+void _appendDiagnostic(char const* message, void* userData)
+{
+    ((StringBuilder*)userData)->append(message);
+}
+
+// Compile entry point `computeMain` of `path` to `targetName`, writing the result to `outPath`,
+// through the slangc command-line compile path (an `ICompileRequest` in command-line mode) so
+// that the front-end IR cache hooks are exercised exactly as they are by slang-test. Optionally
+// enables the shared front-end IR cache. Returns the generated artifact ("" on failure).
+String compileToTarget(
+    slang::IGlobalSession* globalSession,
+    const char* path,
+    const char* targetName,
+    const char* outPath,
+    bool useCache)
+{
+    SlangCompileRequest* request = spCreateCompileRequest(globalSession);
+    if (!request)
+        return String();
+
+    StringBuilder diagnostics;
+    spSetDiagnosticCallback(request, _appendDiagnostic, &diagnostics);
+    spSetCommandLineCompilerMode(request);
+
+    List<const char*> args;
+    args.add(path);
+    args.add("-target");
+    args.add(targetName);
+    args.add("-entry");
+    args.add("computeMain");
+    args.add("-stage");
+    args.add("compute");
+    args.add("-o");
+    args.add(outPath);
+    if (useCache)
+        args.add("-use-shared-front-end-ir");
+
+    SlangResult result =
+        spProcessCommandLineArguments(request, args.getBuffer(), (int)args.getCount());
+    if (SLANG_SUCCEEDED(result))
+        result = spCompile(request);
+    spDestroyCompileRequest(request);
+
+    if (SLANG_FAILED(result))
+    {
+        fprintf(stderr, "front-end-ir-cache: compile failed: %s\n", diagnostics.getBuffer());
+        return String();
+    }
+
+    String contents;
+    if (SLANG_FAILED(File::readAllText(outPath, contents)))
+        return String();
+    return contents;
+}
+} // namespace
+
+SLANG_UNIT_TEST(frontEndIRCache)
+{
+    // Write a small, target-agnostic compute shader to a real file so the cache (which keys on
+    // the source path and content digest) has a stable identity to work with.
+    const char* source = R"(
+        RWStructuredBuffer<float> gBuffer;
+
+        float helper(uint i)
+        {
+            float acc = 0.0f;
+            for (uint k = 0; k < i; ++k)
+                acc += float(k) * 0.5f;
+            return acc;
+        }
+
+        [numthreads(4, 1, 1)]
+        void computeMain(uint3 tid : SV_DispatchThreadID)
+        {
+            gBuffer[tid.x] = helper(tid.x) + float(tid.x) * 2.0f;
+        }
+    )";
+
+    String tempPath = "unit-test-front-end-ir-cache-tmp.slang";
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(File::writeAllText(tempPath, source)));
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK_ABORT(
+        slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    const char* pathStr = tempPath.getBuffer();
+
+    // Authoritative references computed with the cache disabled: these never touch the cache.
+    String baselineSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", false);
+    String baselineHlsl =
+        compileToTarget(globalSession, pathStr, "hlsl", "fe-ir-cache-hlsl.tmp", false);
+    SLANG_CHECK(baselineSpirv.getLength() != 0);
+    SLANG_CHECK(baselineHlsl.getLength() != 0);
+    // Disabled-cache compiles must not populate or consult the cache.
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == 0);
+
+    // First cache-enabled compile: a miss that populates the cache with the lowered IR.
+    String coldSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == 0);
+
+    // Second cache-enabled compile of the same source/target: a hit that reuses the cached IR.
+    int64_t hitsBeforeWarm = slang_getFrontEndIRCacheHitCount(globalSession);
+    String warmSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeWarm + 1);
+
+    // Cache-enabled compile for a *different* target: the front end is target-agnostic, so this
+    // reuses the same cached IR (the core scenario from issue 11176).
+    int64_t hitsBeforeCross = slang_getFrontEndIRCacheHitCount(globalSession);
+    String warmHlsl = compileToTarget(globalSession, pathStr, "hlsl", "fe-ir-cache-hlsl.tmp", true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeCross + 1);
+
+    // The whole point: reused IR must produce byte-identical artifacts to recomputed IR.
+    SLANG_CHECK(coldSpirv == baselineSpirv);
+    SLANG_CHECK(warmSpirv == baselineSpirv);
+    SLANG_CHECK(warmHlsl == baselineHlsl);
+
+    File::remove("fe-ir-cache-spirv.tmp");
+    File::remove("fe-ir-cache-hlsl.tmp");
+    File::remove(tempPath);
+}

--- a/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
+++ b/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
@@ -98,7 +98,29 @@ SLANG_UNIT_TEST(frontEndIRCache)
         }
     )";
 
-    String tempPath = "unit-test-front-end-ir-cache-tmp.slang";
+    // Use unique temp paths (in the system temp dir) so parallel or retried runs cannot race on
+    // shared filenames, and clean them up via RAII so nothing leaks if a check aborts.
+    struct TempFiles
+    {
+        List<String> paths;
+        ~TempFiles()
+        {
+            for (auto& p : paths)
+                File::remove(p);
+        }
+    } tempFiles;
+
+    String base;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(File::generateTemporary(UnownedStringSlice("slang-fe-ir-cache"), base)));
+    String tempPath = base + ".slang";
+    String spirvOut = base + ".spirv-asm";
+    String hlslOut = base + ".hlsl";
+    tempFiles.paths.add(base);
+    tempFiles.paths.add(tempPath);
+    tempFiles.paths.add(spirvOut);
+    tempFiles.paths.add(hlslOut);
+
     SLANG_CHECK_ABORT(SLANG_SUCCEEDED(File::writeAllText(tempPath, source)));
 
     ComPtr<slang::IGlobalSession> globalSession;
@@ -109,9 +131,9 @@ SLANG_UNIT_TEST(frontEndIRCache)
 
     // Authoritative references computed with the cache disabled: these never touch the cache.
     String baselineSpirv =
-        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", false);
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), false);
     String baselineHlsl =
-        compileToTarget(globalSession, pathStr, "hlsl", "fe-ir-cache-hlsl.tmp", false);
+        compileToTarget(globalSession, pathStr, "hlsl", hlslOut.getBuffer(), false);
     SLANG_CHECK(baselineSpirv.getLength() != 0);
     SLANG_CHECK(baselineHlsl.getLength() != 0);
     // Disabled-cache compiles must not populate or consult the cache.
@@ -119,27 +141,23 @@ SLANG_UNIT_TEST(frontEndIRCache)
 
     // First cache-enabled compile: a miss that populates the cache with the lowered IR.
     String coldSpirv =
-        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", true);
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
     SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == 0);
 
     // Second cache-enabled compile of the same source/target: a hit that reuses the cached IR.
     int64_t hitsBeforeWarm = slang_getFrontEndIRCacheHitCount(globalSession);
     String warmSpirv =
-        compileToTarget(globalSession, pathStr, "spirv-asm", "fe-ir-cache-spirv.tmp", true);
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
     SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeWarm + 1);
 
     // Cache-enabled compile for a *different* target: the front end is target-agnostic, so this
     // reuses the same cached IR (the core scenario from issue 11176).
     int64_t hitsBeforeCross = slang_getFrontEndIRCacheHitCount(globalSession);
-    String warmHlsl = compileToTarget(globalSession, pathStr, "hlsl", "fe-ir-cache-hlsl.tmp", true);
+    String warmHlsl = compileToTarget(globalSession, pathStr, "hlsl", hlslOut.getBuffer(), true);
     SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeCross + 1);
 
     // The whole point: reused IR must produce byte-identical artifacts to recomputed IR.
     SLANG_CHECK(coldSpirv == baselineSpirv);
     SLANG_CHECK(warmSpirv == baselineSpirv);
     SLANG_CHECK(warmHlsl == baselineHlsl);
-
-    File::remove("fe-ir-cache-spirv.tmp");
-    File::remove("fe-ir-cache-hlsl.tmp");
-    File::remove(tempPath);
 }

--- a/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
+++ b/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
@@ -8,9 +8,9 @@
 // cache, including across different targets sharing one front-end result.
 
 #include "core/slang-io.h"
-#include "slang/slang-internal.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
+#include "slang/slang-internal.h"
 #include "unit-test/slang-unit-test.h"
 
 #include <stdio.h>

--- a/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
+++ b/tools/slang-unit-test/unit-test-front-end-ir-cache.cpp
@@ -160,4 +160,45 @@ SLANG_UNIT_TEST(frontEndIRCache)
     SLANG_CHECK(coldSpirv == baselineSpirv);
     SLANG_CHECK(warmSpirv == baselineSpirv);
     SLANG_CHECK(warmHlsl == baselineHlsl);
+
+    // --- Explicit cache controls (issue 11176) ----------------------------------------------
+    // These let an embedder bound memory on a long-lived session.
+
+    // clearFrontEndIRCache() drops cached entries: the next compile of an already-seen
+    // source/target is a miss again (no new hit), and only the compile after that re-hits.
+    int64_t hitsBeforeClear = slang_getFrontEndIRCacheHitCount(globalSession);
+    slang_clearFrontEndIRCache(globalSession);
+    String afterClearSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeClear);
+    String reWarmSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeClear + 1);
+    SLANG_CHECK(afterClearSpirv == baselineSpirv);
+    SLANG_CHECK(reWarmSpirv == baselineSpirv);
+
+    // Disabling retention ("do-not-keep" mode) stops new entries from being stored: after a
+    // clear, repeated compiles never accumulate hits because nothing is retained.
+    slang_setFrontEndIRCacheEnabled(globalSession, false);
+    slang_clearFrontEndIRCache(globalSession);
+    int64_t hitsBeforeDisabled = slang_getFrontEndIRCacheHitCount(globalSession);
+    String disabledSpirv1 =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    String disabledSpirv2 =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeDisabled);
+    SLANG_CHECK(disabledSpirv1 == baselineSpirv);
+    SLANG_CHECK(disabledSpirv2 == baselineSpirv);
+
+    // Re-enabling restores normal caching: the first compile repopulates (miss), the next hits.
+    slang_setFrontEndIRCacheEnabled(globalSession, true);
+    int64_t hitsBeforeReenable = slang_getFrontEndIRCacheHitCount(globalSession);
+    String reenableMissSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeReenable);
+    String reenableWarmSpirv =
+        compileToTarget(globalSession, pathStr, "spirv-asm", spirvOut.getBuffer(), true);
+    SLANG_CHECK(slang_getFrontEndIRCacheHitCount(globalSession) == hitsBeforeReenable + 1);
+    SLANG_CHECK(reenableMissSpirv == baselineSpirv);
+    SLANG_CHECK(reenableWarmSpirv == baselineSpirv);
 }


### PR DESCRIPTION
Fixes shader-slang/slang#11176

## Summary of the problem from the end user perspective

Many tests have multiple `//TEST:` lines that compile the same shader for different `-target`s. The front end (lex/parse/check/lower-to-IR) is target-agnostic yet re-runs for every line, inflating slang-test wall time.

## Root cause

The lowered, target-agnostic translation-unit IR is recomputed independently for each `//TEST:` line; there is no mechanism to reuse it across compilations in the same session.

## Solution in this PR

Add an in-process, session-scoped cache of the lowered translation-unit IR. When the new internal option `-use-shared-front-end-ir` is set, a diagnostic-free front end serializes its lowered module and stores it on the `Session`, keyed by a digest of `{build tag, source canonical path + content digest, front-end option-set hash}` (target/back-end options excluded, so lines differing only by `-target` share a key). A later compile with a matching key deserializes the IR into the translation-unit module and skips parse/check/lower; entry-point resolution and the per-target back end run unchanged, producing identical artifacts.

### Notes to the reviewers; where to focus on

- `source/slang/slang-compile-request.cpp` — the cache key, lookup/store hooks in `FrontEndCompileRequest::executeActionsInner`, and the diagnostic-free store gate.
- `source/slang/slang-session.cpp` — `serializeModuleToBlobForCache` / `loadCachedTranslationUnitModule`, which ride on the existing serialized-module (de)serialization path; entry-point discovery is intentionally skipped on load so the normal `checkEntryPoints` runs unchanged.
- `source/slang/slang-global-session.{h,cpp}` — the session cache storage + hit counter.
- slang-test integration is **opt-in** (`-share-front-end-ir`, off by default), and it excludes `diag=` test lines. This is deliberate: code generation is byte-identical (covered by the unit test), but a couple of back-end paths are still sensitive to the serialize/deserialize round-trip — diagnostic caret token-widths collapse (serialized source locs reconstruct content-less source files) and the `torch`/`[AutoPyBindCUDA]` path can hit an internal assert. Enabling it suite-wide should be a follow-up once those fidelity gaps are closed.

Tests:
- `tools/slang-unit-test/unit-test-front-end-ir-cache.cpp` (`frontEndIRCache`) — asserts byte-identical artifacts for cold/warm and cross-target reuse vs. cache-off baselines, and that the reuse path is actually exercised (session hit counter exposed via `slang-internal.h`).
- `tests/compute/front-end-ir-cache-share.slang` — end-to-end sharing across spirv-asm/hlsl/glsl through the slang-test harness.

## Related PRs in the past

- Builds on the existing IR (de)serialization used by precompiled modules and core-module embedding (`source/slang/slang-serialize-*`).


## Reviewer Directives (maintained by agent)

- [LLM CodeRabbit] The front-end IR cache is intentionally restricted to **single-translation-unit** requests and is skipped when `additionalLoadedModules` are supplied, so a cached unit can never be an uncaptured intra-request `import` dependency. (https://github.com/jkwak-work/slang/pull/247#discussion_r3358427923)
- [LLM CodeRabbit] The cache key intentionally keys on the primary source file's path + content digest plus the front-end option-set hash; transitive `__include`/`import` staleness within a single session is an accepted limitation because the cache is in-memory and per-session (those files do not change between a store and a matching hit in one process), and dependencies are unknown at lookup time before parsing. (https://github.com/jkwak-work/slang/pull/247#discussion_r3358427918)
- [LLM CodeRabbit] The cache is also skipped when a front-end side-effect mode (`-output-includes`, `-dump-ast`, preprocessor output, or debug-serialization verification) is requested, since a cache hit bypasses `parseTranslationUnit`/`generateIR`. (https://github.com/jkwak-work/slang/pull/247#discussion_r3358427905)

- [human @jkwak-work] Never use `../` on `#include` lines; use the source-relative form (e.g. `core/slang-blob.h`, not `../core/slang-blob.h`). (https://github.com/jkwak-work/slang/pull/247#discussion_r3367022182)


- [human @jkwak-work] Memory growth of the front-end IR cache is a real concern; provide explicit cache controls. Implemented as `slang_clearFrontEndIRCache()` (drop all entries) and `slang_setFrontEndIRCacheEnabled()` (do-not-keep mode: stop retaining new entries) on the global session. (https://github.com/jkwak-work/slang/pull/247#issuecomment-4639744369)


- [human @jkwak-work] Benchmark the full set of tests with at least two `TEST:SIMPLE` lines and compare wall timing with and without front-end IR sharing. Measured 512 files / 1606 subtests locally: baseline 1782.22s; sharing 1455.66s (18.3% wall-clock reduction), with per-line opt-outs for three unsafe sharing cases. (https://github.com/jkwak-work/slang/pull/247#issuecomment-4685885709)
