### PR TITLE
Allow scalar alignment for byte-address buffer vector/matrix loads

### DIFF
--- a/docs/target-compatibility.md
+++ b/docs/target-compatibility.md
@@ -36,7 +36,7 @@ Items with ^ means there is some discussion about support later in the document 
 | [tex.Load](#tex-load)                                         | Yes   | Yes       | Yes     | Limited ^      | Yes   | Yes       |
 | [Full bool](#full-bool)                                       | Yes   | Yes       | Yes     | No             | Yes   | Yes ^     |
 | [Mesh Shader](#mesh-shader)                                   | No    | Yes       | Yes     | No             | Yes   | No        |
-| [`[unroll]`](#unroll]                                         | Yes   | Yes       | Yes ^   | Yes            | No ^  | Limited + |
+| [`[unroll]`](#unroll)                                         | Yes   | Yes       | Yes ^   | Yes            | No ^  | Limited + |
 | Atomics                                                       | Yes   | Yes       | Yes     | Yes            | Yes   | No +      |
 | [Atomics on RWBuffer](#rwbuffer-atomics)                      | Yes   | Yes       | Yes     | No             | Yes   | No +      |
 | [Sampler Feedback](#sampler-feedback)                         | No    | Yes       | No +    | No             | No    | Yes ^     |

--- a/docs/target-compatibility.md
+++ b/docs/target-compatibility.md
@@ -6,45 +6,46 @@ OpenGL compatibility is not listed here, because OpenGL isn't an officially supp
 Items with a + means that the feature is anticipated to be added in the future.
 Items with ^ means there is some discussion about support later in the document for this target.
 
-| Feature                                              | D3D11 | D3D12     | VK      | CUDA           | Metal | CPU       |
-| ---------------------------------------------------- | ----- | --------- | ------- | -------------- | ----- | --------- |
-| [Half Type](#half)                                   | No    | Yes ^     | Yes     | Yes ^          | Yes   | No +      |
-| Double Type                                          | Yes   | Yes       | Yes     | Yes            | No    | Yes       |
-| Double Intrinsics                                    | No    | Limited + | Limited | Most           | No    | Yes       |
-| [u/int8_t Type](#int8_t)                             | No    | No        | Yes ^   | Yes            | Yes   | Yes       |
-| [u/int16_t Type](#int16_t)                           | No    | Yes ^     | Yes ^   | Yes            | Yes   | Yes       |
-| [u/int64_t Type](#int64_t)                           | No    | Yes ^     | Yes     | Yes            | Yes   | Yes       |
-| u/int64_t Intrinsics                                 | No    | No        | Yes     | Yes            | Yes   | Yes       |
-| [int matrix](#int-matrix)                            | Yes   | Yes       | No +    | Yes            | No    | Yes       |
-| [tex.GetDimensions](#tex-get-dimensions)             | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
-| [SM6.0 Wave Intrinsics](#sm6-wave)                   | No    | Yes       | Partial | Yes ^          | No    | No        |
-| SM6.0 Quad Intrinsics                                | No    | Yes       | No +    | No             | No    | No        |
-| [SM6.5 Wave Intrinsics](#sm6.5-wave)                 | No    | Yes ^     | No +    | Yes ^          | No    | No        |
-| [WaveMask Intrinsics](#wave-mask)                    | Yes ^ | Yes ^     | Yes +   | Yes            | No    | No        |
-| [WaveShuffle](#wave-shuffle)                         | No    | Limited ^ | Yes     | Yes            | No    | No        |
-| [Tesselation](#tesselation)                          | Yes ^ | Yes ^     | No +    | No             | No    | No        |
-| [Graphics Pipeline](#graphics-pipeline)              | Yes   | Yes       | Yes     | No             | Yes   | No        |
-| [Ray Tracing DXR 1.0](#ray-tracing-1.0)              | No    | Yes ^     | Yes ^   | No             | No    | No        |
-| Ray Tracing DXR 1.1                                  | No    | Yes       | No +    | No             | No    | No        |
-| [Native Bindless](#native-bindless)                  | No    | No        | No      | Yes            | No    | Yes       |
-| [Buffer bounds](#buffer-bounds)                      | Yes   | Yes       | Yes     | Limited ^      | No ^  | Limited ^ |
-| [Resource bounds](#resource-bounds)                  | Yes   | Yes       | Yes     | Yes (optional) | Yes   | Yes       |
-| Atomics                                              | Yes   | Yes       | Yes     | Yes            | Yes   | Yes       |
-| Group shared mem/Barriers                            | Yes   | Yes       | Yes     | Yes            | Yes   | No +      |
-| [TextureArray.Sample float](#tex-array-sample-float) | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
-| [Separate Sampler](#separate-sampler)                | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
-| [tex.Load](#tex-load)                                | Yes   | Yes       | Yes     | Limited ^      | Yes   | Yes       |
-| [Full bool](#full-bool)                              | Yes   | Yes       | Yes     | No             | Yes   | Yes ^     |
-| [Mesh Shader](#mesh-shader)                          | No    | Yes       | Yes     | No             | Yes   | No        |
-| [`[unroll]`](#unroll]                                | Yes   | Yes       | Yes ^   | Yes            | No ^  | Limited + |
-| Atomics                                              | Yes   | Yes       | Yes     | Yes            | Yes   | No +      |
-| [Atomics on RWBuffer](#rwbuffer-atomics)             | Yes   | Yes       | Yes     | No             | Yes   | No +      |
-| [Sampler Feedback](#sampler-feedback)                | No    | Yes       | No +    | No             | No    | Yes ^     |
-| [RWByteAddressBuffer Atomic](#byte-address-atomic)   | No    | Yes ^     | Yes ^   | Yes            | Yes   | No +      |
-| [Shader Execution Reordering](#ser)                  | No    | Yes ^     | Yes ^   | No             | No    | No        |
-| [debugBreak](#debug-break)                           | No    | No        | Yes     | Yes            | No    | Yes       |
-| [realtime clock](#realtime-clock)                    | No    | Yes ^     | Yes     | Yes            | No    | No        |
-| [Switch Fall-Through](#switch-fallthrough)           | No ^  | Yes       | Yes     | Yes            | Yes   | Yes       |
+| Feature                                                       | D3D11 | D3D12     | VK      | CUDA           | Metal | CPU       |
+| ------------------------------------------------------------- | ----- | --------- | ------- | -------------- | ----- | --------- |
+| [Half Type](#half)                                            | No    | Yes ^     | Yes     | Yes ^          | Yes   | No +      |
+| Double Type                                                   | Yes   | Yes       | Yes     | Yes            | No    | Yes       |
+| Double Intrinsics                                             | No    | Limited + | Limited | Most           | No    | Yes       |
+| [u/int8_t Type](#int8_t)                                      | No    | No        | Yes ^   | Yes            | Yes   | Yes       |
+| [u/int16_t Type](#int16_t)                                    | No    | Yes ^     | Yes ^   | Yes            | Yes   | Yes       |
+| [u/int64_t Type](#int64_t)                                    | No    | Yes ^     | Yes     | Yes            | Yes   | Yes       |
+| u/int64_t Intrinsics                                          | No    | No        | Yes     | Yes            | Yes   | Yes       |
+| [int matrix](#int-matrix)                                     | Yes   | Yes       | No +    | Yes            | No    | Yes       |
+| [tex.GetDimensions](#tex-get-dimensions)                      | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
+| [SM6.0 Wave Intrinsics](#sm6-wave)                            | No    | Yes       | Partial | Yes ^          | No    | No        |
+| SM6.0 Quad Intrinsics                                         | No    | Yes       | No +    | No             | No    | No        |
+| [SM6.5 Wave Intrinsics](#sm6.5-wave)                          | No    | Yes ^     | No +    | Yes ^          | No    | No        |
+| [WaveMask Intrinsics](#wave-mask)                             | Yes ^ | Yes ^     | Yes +   | Yes            | No    | No        |
+| [WaveShuffle](#wave-shuffle)                                  | No    | Limited ^ | Yes     | Yes            | No    | No        |
+| [Tesselation](#tesselation)                                   | Yes ^ | Yes ^     | No +    | No             | No    | No        |
+| [Graphics Pipeline](#graphics-pipeline)                       | Yes   | Yes       | Yes     | No             | Yes   | No        |
+| [Ray Tracing DXR 1.0](#ray-tracing-1.0)                       | No    | Yes ^     | Yes ^   | No             | No    | No        |
+| Ray Tracing DXR 1.1                                           | No    | Yes       | No +    | No             | No    | No        |
+| [Native Bindless](#native-bindless)                           | No    | No        | No      | Yes            | No    | Yes       |
+| [Buffer bounds](#buffer-bounds)                               | Yes   | Yes       | Yes     | Limited ^      | No ^  | Limited ^ |
+| [Resource bounds](#resource-bounds)                           | Yes   | Yes       | Yes     | Yes (optional) | Yes   | Yes       |
+| Atomics                                                       | Yes   | Yes       | Yes     | Yes            | Yes   | Yes       |
+| Group shared mem/Barriers                                     | Yes   | Yes       | Yes     | Yes            | Yes   | No +      |
+| [TextureArray.Sample float](#tex-array-sample-float)          | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
+| [Separate Sampler](#separate-sampler)                         | Yes   | Yes       | Yes     | No             | Yes   | Yes       |
+| [tex.Load](#tex-load)                                         | Yes   | Yes       | Yes     | Limited ^      | Yes   | Yes       |
+| [Full bool](#full-bool)                                       | Yes   | Yes       | Yes     | No             | Yes   | Yes ^     |
+| [Mesh Shader](#mesh-shader)                                   | No    | Yes       | Yes     | No             | Yes   | No        |
+| [`[unroll]`](#unroll]                                         | Yes   | Yes       | Yes ^   | Yes            | No ^  | Limited + |
+| Atomics                                                       | Yes   | Yes       | Yes     | Yes            | Yes   | No +      |
+| [Atomics on RWBuffer](#rwbuffer-atomics)                      | Yes   | Yes       | Yes     | No             | Yes   | No +      |
+| [Sampler Feedback](#sampler-feedback)                         | No    | Yes       | No +    | No             | No    | Yes ^     |
+| [RWByteAddressBuffer Atomic](#byte-address-atomic)            | No    | Yes ^     | Yes ^   | Yes            | Yes   | No +      |
+| [ByteAddressBuffer Load/Store Alignment](#byte-address-align) | Yes ^ | Yes ^     | Yes ^   | Yes            | Yes   | Yes       |
+| [Shader Execution Reordering](#ser)                           | No    | Yes ^     | Yes ^   | No             | No    | No        |
+| [debugBreak](#debug-break)                                    | No    | No        | Yes     | Yes            | No    | Yes       |
+| [realtime clock](#realtime-clock)                             | No    | Yes ^     | Yes     | Yes            | No    | No        |
+| [Switch Fall-Through](#switch-fallthrough)                    | No ^  | Yes       | Yes     | Yes            | Yes   | Yes       |
 
 <a id="half"></a>
 
@@ -279,6 +280,55 @@ in the separate [NVAPI Support](nvapi-support.md) document.
 On Vulkan, for float the [`GL_EXT_shader_atomic_float`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_shader_atomic_float.html) extension is required. For int64 the [`GL_EXT_shader_atomic_int64`](https://raw.githubusercontent.com/KhronosGroup/GLSL/master/extensions/ext/GL_EXT_shader_atomic_int64.txt) extension is required.
 
 CUDA requires SM6.0 or higher for int64 support.
+
+<a id="byte-address-align"></a>
+
+## ByteAddressBuffer Load/Store Alignment
+
+The templated `(RW)ByteAddressBuffer` accessors — `Load<T>`, `Store<T>`,
+`LoadAligned<T>(offset, alignment)`, and `StoreAligned<T>(offset, data, alignment)`
+— only require the access to be aligned to the buffer element's **scalar
+component**, not to the size of the whole aggregate. This matches the HLSL
+rules for the templated accessors (the non-templated `Load2`/`Load3`/`Load4`
+and `Store2`/`Store3`/`Store4` overloads keep their stricter 4-byte / `uint`
+alignment requirement).
+
+When an explicit `alignment` is smaller than the full aggregate but still a
+multiple of the scalar-component alignment, Slang scalarizes the access into
+per-component loads/stores rather than emitting a wide operation. An explicit
+alignment smaller than the scalar component (e.g. `1` for a `uint16_t2`) is
+still invalid and is diagnosed as error 41300.
+
+The minimum valid alignment is therefore the natural alignment of the scalar
+component type:
+
+| Scalar component      | Minimum alignment (bytes) |
+| --------------------- | ------------------------- |
+| `u/int8_t`            | 1                         |
+| `u/int16_t`, `half`   | 2                         |
+| `u/int`, `float`      | 4                         |
+| `u/int64_t`, `double` | 8                         |
+
+Whether a given scalar width is usable in a `ByteAddressBuffer` at all is a
+separate, pre-existing capability of each target (it is the same requirement
+that the type itself has — see [Half Type](#half), [u/int8_t Type](#int8_t),
+and [u/int16_t Type](#int16_t)). The scalar-alignment relaxation above does not
+make a width newly usable on a target that did not already support it:
+
+| Target               | 8-bit element | 16-bit element | 32-bit element | Notes                                                                                                                      |
+| -------------------- | ------------- | -------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| D3D12 (HLSL/DXIL)    | No            | Yes (SM6.2)    | Yes            | 16-bit needs Shader Model 6.2 + `-enable-16bit-types`; see [u/int16_t Type](#int16_t)                                      |
+| D3D11 (DXBC)         | No            | No             | Yes            | DXBC has no 16-bit scalar types                                                                                            |
+| Vulkan (SPIR-V/GLSL) | Yes ^         | Yes ^          | Yes            | 8-bit needs `GL_EXT_shader_8bit_storage`; 16-bit needs `GL_EXT_shader_16bit_storage`                                       |
+| CUDA                 | Yes           | Yes            | Yes            | Lowered to native pointer access                                                                                           |
+| Metal                | Yes           | Yes            | Yes            |                                                                                                                            |
+| WGSL (WebGPU)        | No            | No             | Yes            | 16-bit / 8-bit scalar storage types are not representable in WGSL; rejected as a type error before alignment is considered |
+| CPU                  | Yes           | Yes            | Yes            |                                                                                                                            |
+
+In short, a 2-byte-aligned `uint16_t2` access works on every target that
+supports the 16-bit element type (D3D12 with SM6.2, Vulkan, CUDA, Metal, CPU);
+WGSL is the only listed target that rejects it, and it does so because it has no
+16-bit storage type at all — independent of the alignment.
 
 <a id="mesh-shader"></a>
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -448,11 +448,16 @@ struct ByteAddressBuffer
 
     /// Load a value with type `T` from the buffer at the specified location.
     ///@param T The type of the value to load from the buffer.
-    ///@param location The input address in bytes, which must be a multiple of 4.
+    ///@param location The input address in bytes, which must be a multiple of the
+    /// alignment of `T`'s scalar components (for example 2 for `half`/`uint16_t`,
+    /// 4 for 32-bit scalars, 8 for 64-bit scalars).
     ///@return The value loaded from the buffer.
     ///@remarks
-    /// This overload does not assume alignment beyond 4 bytes and may be lowered to scalar 4-byte loads.
-    /// Use `LoadAligned<T>` when `location` has a stronger alignment guarantee.
+    /// This overload makes no alignment promise beyond the scalar-component alignment
+    /// of `T`. Unless the compiler can prove `location` covers the whole `T` (for
+    /// example a constant, sufficiently aligned offset), the access is lowered to
+    /// per-component loads. Use `LoadAligned<T>` to promise a stronger alignment and
+    /// request a single wide load.
     [__readNone]
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, byteaddressbuffer)]
@@ -461,14 +466,24 @@ struct ByteAddressBuffer
         return __byteAddressBufferLoad<T>(this, location, 0);
     }
 
-    /// Load a value with type `T` from the buffer at the specified location with a known alignment.
+    /// Load a value with type `T` from the buffer at the specified location, promising
+    /// that `location` is aligned to `alignment` bytes so the compiler can issue a
+    /// single wide load instead of per-component loads.
     ///@param T The type of the value to load from the buffer.
-    ///@param location The input address in bytes, which must be a multiple of 4.
-    ///@param alignment The known alignment of `location`, which must be a multiple of 4 and compatible with `T`.
+    ///@param location The input address in bytes, which must be a multiple of the
+    /// scalar-component size of `T`.
+    ///@param alignment The known alignment of `location` in bytes. It must be a
+    /// multiple of `T`'s scalar-component alignment; a smaller value is reported as
+    /// error 41300.
     ///@return The value loaded from the buffer.
     ///@remarks
-    /// On HLSL, `alignment` is informational only and does not affect the emitted intrinsic.
-    /// On other targets, `alignment` is forwarded to the lowered load instruction.
+    /// When `alignment` covers the whole `T` (for example 8 for `half4`), a single
+    /// wide load is emitted. When `alignment` only satisfies the scalar-component
+    /// alignment but not the full `T` (for example 2 for `half4`), the access falls
+    /// back to per-component loads — the same lowering as `Load<T>`. Only an
+    /// `alignment` (or `location`) below the scalar-component alignment is an error.
+    /// On HLSL the value is informational and does not change the emitted intrinsic;
+    /// on other targets it is forwarded to the lowered load instruction.
     [__readNone]
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, byteaddressbuffer)]
@@ -6364,11 +6379,16 @@ struct $(item.name)
 
     /// Load a value with type `T` from the buffer at the specified location.
     ///@param T The type of the value to load from the buffer.
-    ///@param location The input address in bytes, which must be a multiple of 4.
+    ///@param location The input address in bytes, which must be a multiple of the
+    /// alignment of `T`'s scalar components (for example 2 for `half`/`uint16_t`,
+    /// 4 for 32-bit scalars, 8 for 64-bit scalars).
     ///@return The value loaded from the buffer.
     ///@remarks
-    /// This overload does not assume alignment beyond 4 bytes and may be lowered to scalar 4-byte loads.
-    /// Use `LoadAligned<T>` when `location` has a stronger alignment guarantee.
+    /// This overload makes no alignment promise beyond the scalar-component alignment
+    /// of `T`. Unless the compiler can prove `location` covers the whole `T` (for
+    /// example a constant, sufficiently aligned offset), the access is lowered to
+    /// per-component loads. Use `LoadAligned<T>` to promise a stronger alignment and
+    /// request a single wide load.
     [__NoSideEffect]
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, byteaddressbuffer_rw)]
@@ -6377,14 +6397,24 @@ struct $(item.name)
         return __byteAddressBufferLoad<T>(this, location, 0);
     }
 
-    /// Load a value with type `T` from the buffer at the specified location with a known alignment.
+    /// Load a value with type `T` from the buffer at the specified location, promising
+    /// that `location` is aligned to `alignment` bytes so the compiler can issue a
+    /// single wide load instead of per-component loads.
     ///@param T The type of the value to load from the buffer.
-    ///@param location The input address in bytes, which must be a multiple of 4.
-    ///@param alignment The known alignment of `location`, which must be a multiple of 4 and compatible with `T`.
+    ///@param location The input address in bytes, which must be a multiple of the
+    /// scalar-component size of `T`.
+    ///@param alignment The known alignment of `location` in bytes. It must be a
+    /// multiple of `T`'s scalar-component alignment; a smaller value is reported as
+    /// error 41300.
     ///@return The value loaded from the buffer.
     ///@remarks
-    /// On HLSL, `alignment` is informational only and does not affect the emitted intrinsic.
-    /// On other targets, `alignment` is forwarded to the lowered load instruction.
+    /// When `alignment` covers the whole `T` (for example 8 for `half4`), a single
+    /// wide load is emitted. When `alignment` only satisfies the scalar-component
+    /// alignment but not the full `T` (for example 2 for `half4`), the access falls
+    /// back to per-component loads — the same lowering as `Load<T>`. Only an
+    /// `alignment` (or `location`) below the scalar-component alignment is an error.
+    /// On HLSL the value is informational and does not change the emitted intrinsic;
+    /// on other targets it is forwarded to the lowered load instruction.
     [__NoSideEffect]
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, byteaddressbuffer_rw)]

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -354,7 +354,7 @@ struct ByteAddressBuffer
     }
 
     /// Load three 32-bit unsigned integers from the buffer at the specified location with natural alignment.
-    ///@param location The input address in bytes, which must be a multiple of 12.
+    ///@param location The input address in bytes, which must be a multiple of 16 (the natural stride of `uint3`).
     ///@return Three 32-bit unsigned integers loaded from the buffer.
     [__readNone]
     [ForceInline]
@@ -6262,7 +6262,7 @@ struct $(item.name)
     }
 
     /// Load three 32-bit unsigned integers from the buffer at the specified location with natural alignment.
-    ///@param location The input address in bytes, which must be a multiple of 12.
+    ///@param location The input address in bytes, which must be a multiple of 16 (the natural stride of `uint3`).
     ///@return Three 32-bit unsigned integers loaded from the buffer.
     [__NoSideEffect]
     [ForceInline]
@@ -7040,8 +7040,8 @@ $}
     }
 
     /// Set three values to the buffer at the specified location, the address will be aligned
-    /// to the alignment of `uint3`, which is 12.
-    ///@param address The input address in bytes, which must be a multiple of 12.
+    /// to the natural stride of `uint3`, which is 16.
+    ///@param address The input address in bytes, which must be a multiple of 16 (the natural stride of `uint3`).
     ///@param value Three input values.
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -242,11 +242,25 @@ struct ByteAddressBufferLegalizationContext
 
     // Returns true if a vectorized load or store of `alignmentVal` bytes at
     // `baseOffset + immediateOffset` is known to be sufficiently aligned.
+    //
+    // `alignmentVal` is the size of the whole access (e.g. the full composite
+    // type); a single wide operation is only possible when the access is
+    // aligned to that size.
+    //
+    // `minAlignmentVal` is the alignment required by the individual element
+    // accesses if we fall back to scalarizing the load/store. Per the HLSL
+    // spec a byte-address buffer access only needs to be aligned to its scalar
+    // components, so an explicit alignment that satisfies `minAlignmentVal` but
+    // not `alignmentVal` is still valid; it simply forces us to scalarize
+    // instead of issuing a wide operation. Callers that cannot scalarize pass
+    // `alignmentVal` here to keep the strict "must cover the whole access"
+    // behavior.
     bool isAligned(
         IRInst* baseOffset,
         IRIntegerValue immediateOffset,
         IRInst* unknownOffsetAlignment,
-        IRIntegerValue alignmentVal)
+        IRIntegerValue alignmentVal,
+        IRIntegerValue minAlignmentVal)
     {
         if (alignmentVal <= 0)
             return false;
@@ -268,18 +282,26 @@ struct ByteAddressBufferLegalizationContext
             if (!alignInst->getValue())
                 return false;
 
+            // An explicit alignment that is smaller than the alignment required by
+            // the scalar components is genuinely invalid, so we diagnose it.
+            if ((alignInst->getValue() % minAlignmentVal) != 0)
+            {
+                m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
+                    .alignment = alignInst->getValue(),
+                    .elementSize = minAlignmentVal,
+                    .location = baseOffset->sourceLoc,
+                });
+                return false;
+            }
+
+            // The access is at least scalar-aligned. We can only issue a single
+            // wide load/store when both the immediate offset and the explicit
+            // alignment cover the whole access; otherwise we fall back to
+            // scalarizing the access (which only requires scalar alignment).
             if ((immediateOffset % alignmentVal) != 0)
                 return false;
 
-            if ((alignInst->getValue() % alignmentVal) == 0)
-            {
-                return true;
-            }
-            m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
-                .alignment = alignInst->getValue(),
-                .elementSize = alignmentVal,
-                .location = baseOffset->sourceLoc,
-            });
+            return (alignInst->getValue() % alignmentVal) == 0;
         }
         return false;
     }
@@ -442,7 +464,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -554,7 +576,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -628,7 +650,12 @@ struct ByteAddressBufferLegalizationContext
                 SLANG_RETURN_NULL_ON_FAIL(
                     getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
                 if (sizeAlignment.size == 8 &&
-                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                    !isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        sizeAlignment.getStride(),
+                        sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitLoadFromTwoUInts(
                         type,
@@ -1396,7 +1423,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1506,7 +1533,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1558,7 +1585,12 @@ struct ByteAddressBufferLegalizationContext
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_ON_FAIL(getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
                 if (sizeAlignment.size == 8 &&
-                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                    !isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        sizeAlignment.getStride(),
+                        sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitStoreAsTwoUInts(
                         buffer,

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -464,7 +464,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (!isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        alignmentVal,
+                        elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -575,8 +580,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (m_options.scalarizeVectorLoadStore || !isAligned(
+                                                              baseOffset,
+                                                              immediateOffset,
+                                                              alignment,
+                                                              alignmentVal,
+                                                              elementLayout.alignment))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -649,13 +658,12 @@ struct ByteAddressBufferLegalizationContext
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_NULL_ON_FAIL(
                     getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
-                if (sizeAlignment.size == 8 &&
-                    !isAligned(
-                        baseOffset,
-                        immediateOffset,
-                        alignment,
-                        sizeAlignment.getStride(),
-                        sizeAlignment.getStride()))
+                if (sizeAlignment.size == 8 && !isAligned(
+                                                   baseOffset,
+                                                   immediateOffset,
+                                                   alignment,
+                                                   sizeAlignment.getStride(),
+                                                   sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitLoadFromTwoUInts(
                         type,
@@ -1423,7 +1431,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (!isAligned(
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        alignmentVal,
+                        elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1532,8 +1545,12 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal, elementLayout.alignment))
+                if (m_options.scalarizeVectorLoadStore || !isAligned(
+                                                              baseOffset,
+                                                              immediateOffset,
+                                                              alignment,
+                                                              alignmentVal,
+                                                              elementLayout.alignment))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1584,13 +1601,12 @@ struct ByteAddressBufferLegalizationContext
             {
                 IRSizeAndAlignment sizeAlignment;
                 SLANG_RETURN_ON_FAIL(getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
-                if (sizeAlignment.size == 8 &&
-                    !isAligned(
-                        baseOffset,
-                        immediateOffset,
-                        alignment,
-                        sizeAlignment.getStride(),
-                        sizeAlignment.getStride()))
+                if (sizeAlignment.size == 8 && !isAligned(
+                                                   baseOffset,
+                                                   immediateOffset,
+                                                   alignment,
+                                                   sizeAlignment.getStride(),
+                                                   sizeAlignment.getStride()))
                 {
                     return emitLegalUnaligned64BitStoreAsTwoUInts(
                         buffer,

--- a/tests/compute/byte-address-buffer-scalar-aligned.slang
+++ b/tests/compute/byte-address-buffer-scalar-aligned.slang
@@ -1,0 +1,34 @@
+// byte-address-buffer-scalar-aligned.slang
+
+// Regression test for https://github.com/shader-slang/slang/issues/9958
+//
+// A manually-aligned vector load/store from a `(RW)ByteAddressBuffer` only
+// requires the access to be aligned to the vector's *scalar* components, not
+// to the full vector size. When the explicit alignment is smaller than the
+// full vector size we must fall back to scalarized element loads/stores
+// instead of diagnosing an error.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -profile spirv_1_6 -entry computeMain -stage compute -fvk-use-c-layout
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -profile spirv_1_6 -entry computeMain -stage compute -fvk-use-c-layout
+
+RWByteAddressBuffer buffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // The offset is not known at compile time, so the explicit alignment of
+    // `2` is what drives the legalization. `uint16_t2` is 4 bytes wide but its
+    // scalar components only need 2-byte alignment, so this must scalarize
+    // into two `ushort` (16-bit) loads and two `ushort` stores rather than
+    // emitting error 41300.
+    int offset = int(tid.x);
+
+    // CHECK-NOT: E41300
+    // CHECK: OpLoad %ushort
+    // CHECK: OpLoad %ushort
+    // CHECK: OpStore {{.*}}
+    // CHECK: OpStore {{.*}}
+    uint16_t2 data = buffer.LoadAligned<uint16_t2>(offset, 2);
+    buffer.Store(offset, data, 2);
+}


### PR DESCRIPTION
Fixes shader-slang/slang#9958

Recreated from #243 (which was merged into this fork's master and then reverted; a merged PR cannot be reopened). Same branch (`issue-9958`), same fix.

## Summary of the problem from the end user perspective

Loading or storing a vector/matrix from a `(RW)ByteAddressBuffer` with a custom alignment failed to compile when the alignment was only large enough for the type's scalar components, even though the HLSL spec only requires scalar alignment.

### Minimal repro shader

```hlsl
[shader("compute")]
[numthreads(1, 1, 1)]
void main(uniform RWByteAddressBuffer buffer, uniform int offset)
{
  uint16_t2 data = buffer.LoadAligned<uint16_t2>(offset, 2);
  buffer.Store(offset, data, 2);
}
```

Previously failed with `error 41300: invalid alignment 2 ... element size of 4`.

## Root cause

The byte-address legalization pass required the explicit alignment to be a multiple of the whole composite type size; when it wasn't, `isAligned` emitted error 41300 instead of falling back to scalarized accesses.

## Solution in this PR

`isAligned` distinguishes the minimum scalar-component alignment from the full composite size: an alignment satisfying scalar alignment but not the full size scalarizes the load/store; only alignments below scalar alignment are diagnosed.

### Notes to the reviewers

- Reconciled on top of upstream #11430 (which refactored `isAligned`); array/vector call sites pass `elementLayout.alignment` (scalar), and the basic-type 8-byte split paths keep the strict whole-access behavior.
- Locally validated: 40/40 byte-address-buffer tests pass; reproducer compiles; sub-scalar alignment still errors.
- Documentation: `docs/target-compatibility.md` gains a "ByteAddressBuffer Load/Store Alignment" section with the scalar-component minimum-alignment table and a per-target (D3D11/D3D12/VK/CUDA/Metal/WGSL/CPU) element-width support table.

## Related PRs

- shader-slang/slang#11430 -- Fix unaligned byte-address descriptor loads (#9931); this builds on it. #11430 does not fix #9958.
- shader-slang/slang#4066 -- introduced the alignment check refined here.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Commit to the component-wise **fallback** behavior of `LoadAligned<T>` (do not error when alignment only satisfies scalar-component alignment) and document it officially; the only error condition is alignment/location below the scalar-component size. (https://github.com/jkwak-work/slang/pull/250#issuecomment-4661165844)

- [human @jkwak-work] Document which scalar types each target supports for byte-address access (incl. the HLSL SM6.2 requirement for `u/int16_t`) in a user-facing doc with a comparison table. Added to `docs/target-compatibility.md`. (https://github.com/jkwak-work/slang/pull/250#issuecomment-4639872354)


