### PR TITLE
[Falcor] Split build from test

### DIFF
--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -14,21 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  # Build Slang on the self-hosted build pool, NOT on the Falcor self-hosted
-  # runner. The Falcor runner's value is its preinstalled Falcor binaries and
-  # GPU; spending its cycles on a non-GPU build is waste. We use this pool
-  # rather than a free windows-latest runner because the build needs the CUDA
-  # toolkit for -DSLANG_ENABLE_CUDA=1 — assumed present here, since the build
-  # previously ran on the CUDA-equipped falcor pool; common-setup does not
-  # install CUDA, so configure fails loud here if the pool lacks it. LLVM is
-  # fetched by common-setup's setup-llvm-from-gcs from a public GCS bucket (a
-  # plain curl, no auth). sccache is available on this pool but not wired here —
-  # deliberate follow-up; see ci-slang-build.yml.
+  # Build Slang on a free GitHub-hosted Windows runner, freeing the Falcor
+  # self-hosted runner from non-GPU build work. LLVM is fetched by
+  # common-setup's setup-llvm-from-gcs from a public GCS bucket (plain curl,
+  # no auth required).
   build:
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    runs-on: [Windows, self-hosted, build]
+    runs-on: windows-latest
     defaults:
       run:
         shell: bash
@@ -50,7 +44,6 @@ jobs:
           cmake --preset default --fresh \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
-            -DSLANG_ENABLE_CUDA=1 \
             -DSLANG_ENABLE_EXAMPLES=0 \
             -DSLANG_ENABLE_GFX=0 \
             -DSLANG_ENABLE_TESTS=0 \

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -14,24 +14,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  # Build Slang on the self-hosted build pool, NOT on the Falcor self-hosted
+  # runner. The Falcor runner's value is its preinstalled Falcor binaries and
+  # GPU; spending its cycles on a non-GPU build is waste. We use this pool
+  # rather than a free windows-latest runner because the build needs the CUDA
+  # toolkit for -DSLANG_ENABLE_CUDA=1 — assumed present here, since the build
+  # previously ran on the CUDA-equipped falcor pool; common-setup does not
+  # install CUDA, so configure fails loud here if the pool lacks it. LLVM is
+  # fetched by common-setup's setup-llvm-from-gcs from a public GCS bucket (a
+  # plain curl, no auth). sccache is available on this pool but not wired here —
+  # deliberate follow-up; see ci-slang-build.yml.
   build:
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows]
-        config: [release]
-        compiler: [cl]
-        platform: [x86_64]
-        include:
-          # Self-hosted falcor tests
-          - warnings-as-errors: true
-            test-category: full
-            full-gpu-tests: false
-            runs-on: [Windows, self-hosted, falcor]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: [Windows, self-hosted, build]
     defaults:
       run:
         shell: bash
@@ -43,11 +40,80 @@ jobs:
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
-          os: ${{matrix.os}}
-          compiler: ${{matrix.compiler}}
-          platform: ${{matrix.platform}}
-          config: ${{matrix.config}}
+          os: windows
+          compiler: cl
+          platform: x86_64
+          config: release
           build-llvm: true
+      - name: Build Slang
+        run: |
+          cmake --preset default --fresh \
+            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_ENABLE_CUDA=1 \
+            -DSLANG_ENABLE_EXAMPLES=0 \
+            -DSLANG_ENABLE_GFX=0 \
+            -DSLANG_ENABLE_TESTS=0 \
+            -DSLANG_EXCLUDE_DAWN=1 \
+            -DSLANG_EXCLUDE_TINT=1 \
+            -DSLANG_ENABLE_SLANG_RHI=0
+          cmake --workflow --preset release
+      - name: Stage Slang artifact
+        run: |
+          # Stage the bin tree the test job will copy into Falcor. Exclude
+          # debug-info files; the test job does not need them.
+          # Layout contract: uploading `path: artifact-staging/bin` roots the
+          # artifact at bin's CONTENTS (no `bin/` segment), so after download
+          # they land flat under `slang-bin/` and `slang-bin/*` matches the
+          # former `build/Release/bin/*` copy. Uploading `artifact-staging`
+          # instead would nest under `slang-bin/bin/` and the copy would move
+          # nothing useful.
+          mkdir -p artifact-staging
+          cp -r build/Release/bin artifact-staging/
+          find artifact-staging -type f \( -name "*.pdb" -o -name "*.ilk" \) -delete
+      # NOTE: download-artifact@v4 is attempt-scoped — `gh run rerun --failed`
+      # (or "Re-run failed jobs") on a green build + failed test will not find
+      # this artifact in the new attempt. Re-run ALL jobs, or push a new commit.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: artifact-staging/bin
+          retention-days: 1
+          if-no-files-found: error
+
+  # No `if: draft` guard needed here — `needs: build` propagates the skip: a
+  # draft PR skips `build` (its own draft guard), and GitHub skips a job whose
+  # dependency was skipped.
+  test:
+    needs: build
+    timeout-minutes: 100
+    continue-on-error: false
+    runs-on: [Windows, self-hosted, falcor]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # This job no longer runs common-setup, which is what previously put Git
+      # Bash on PATH. The "Copy Slang to Falcor" step below uses `shell: bash`
+      # (GNU cp long-flags), and self-hosted Windows runners do not guarantee
+      # Git Bash on PATH. Add it explicitly, mirroring ci-slang-build.yml.
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      # Checkout establishes the workspace (and `git clean` between attempts on
+      # sticky self-hosted runners). No submodules: the test job consumes only
+      # the prebuilt `slang-bin` artifact + Falcor's preinstalled tree; nothing
+      # reads the slang source.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: slang-bin
       - name: setup-falcor
         shell: pwsh
         run: |
@@ -60,22 +126,9 @@ jobs:
           Copy-Item -Path 'C:\Falcor\media_internal' -Destination '.\' -Recurse
           Copy-Item -Path 'C:\Falcor\scripts' -Destination '.\' -Recurse
           cd ..\
-      - name: Build Slang
-        run: |
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}} \
-            -DSLANG_ENABLE_CUDA=1 \
-            -DSLANG_ENABLE_EXAMPLES=0 \
-            -DSLANG_ENABLE_GFX=0 \
-            -DSLANG_ENABLE_TESTS=0 \
-            -DSLANG_EXCLUDE_DAWN=1 \
-            -DSLANG_EXCLUDE_TINT=1 \
-            -DSLANG_ENABLE_SLANG_RHI=0
-          cmake --workflow --preset "${{matrix.config}}"
       - name: Copy Slang to Falcor
         run: |
-          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release build/Release/bin/*
+          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release slang-bin/*
       - name: falcor-unit-test
         shell: pwsh
         run: |


### PR DESCRIPTION
Fixes shader-slang/slang#11495

## Summary of the problem from the end user perspective

The Falcor CI machine was a bottleneck for CI turnaround because it spent time building Slang before running GPU tests, wasting the Falcor machine's resources on a non-GPU build task.

## Solution in this PR

Split `falcor-test.yml` into two jobs: a `build` job on `windows-latest` (GitHub-hosted free runner) that compiles Slang and uploads the binaries as a GitHub artifact, and a `test` job (`needs: build`) on the `[Windows, self-hosted, falcor]` pool that downloads the artifact and runs the Falcor unit and image tests exactly as before. The Falcor machine now focuses exclusively on GPU testing.

### Notes to the reviewers; where to focus on

- The `build` job runs on `windows-latest` (free GitHub runner). `-DSLANG_ENABLE_CUDA=1` was removed because the GitHub-hosted image does not include a CUDA toolkit.
- The `test` job no longer runs `common-setup`, so Git Bash is added to PATH explicitly via a PowerShell step (mirroring `ci-slang-build.yml`).
- Artifact upload uses `path: artifact-staging/bin` so the artifact roots at the `bin` directory's contents — matching the previous `build/Release/bin/*` glob used in the copy step.
- `download-artifact@v4` is attempt-scoped: re-running only the failed `test` job will not find the artifact. Users must re-run all jobs or push a new commit.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Use `windows-latest` (free GitHub runner) for the build job, not a self-hosted runner. Removing `-DSLANG_ENABLE_CUDA=1` follows from this — the GitHub-hosted image has no CUDA toolkit. ([comment](https://github.com/jkwak-work/slang/pull/252#discussion_r3369517333))
