### PR TITLE
Split Falcor workflow: build on build pool, test on falcor pool

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+self-hosted-runner:
+  labels:
+    - arc
+    - benchmark
+    - build
+    - falcor
+    - GCP-T4
+    - GPU
+    - perf
+    - regression-test
+    - SM80Plus
+    - vulkancts

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -18,35 +18,73 @@ jobs:
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows]
-        config: [release]
-        compiler: [cl]
-        platform: [x86_64]
-        include:
-          # Self-hosted falcor tests
-          - warnings-as-errors: true
-            full-gpu-tests: false
-            runs-on: [Windows, self-hosted, falcor]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: [Windows, self-hosted, build]
     defaults:
       run:
         shell: bash
     steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
-          os: ${{matrix.os}}
-          compiler: ${{matrix.compiler}}
-          platform: ${{matrix.platform}}
-          config: ${{matrix.config}}
+          os: windows
+          compiler: cl
+          platform: x86_64
+          config: release
           build-llvm: true
+      - name: Build Slang
+        run: |
+          cmake --preset default --fresh \
+            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_ENABLE_CUDA=1 \
+            -DSLANG_ENABLE_EXAMPLES=0 \
+            -DSLANG_ENABLE_GFX=0 \
+            -DSLANG_ENABLE_TESTS=0 \
+            -DSLANG_EXCLUDE_DAWN=1 \
+            -DSLANG_EXCLUDE_TINT=1 \
+            -DSLANG_ENABLE_SLANG_RHI=0
+          cmake --workflow --preset release
+      - name: Upload Slang build
+        uses: actions/upload-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: build/Release/bin/
+  test:
+    name: Test (Falcor)
+    needs: build
+    if: github.event.pull_request.draft != true
+    timeout-minutes: 100
+    continue-on-error: false
+    runs-on: [Windows, self-hosted, falcor]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: "false"
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: slang-bin
       - name: setup-falcor
         shell: pwsh
         run: |
@@ -59,22 +97,9 @@ jobs:
           Copy-Item -Path 'C:\Falcor\media_internal' -Destination '.\' -Recurse
           Copy-Item -Path 'C:\Falcor\scripts' -Destination '.\' -Recurse
           cd ..\
-      - name: Build Slang
-        run: |
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}} \
-            -DSLANG_ENABLE_CUDA=1 \
-            -DSLANG_ENABLE_EXAMPLES=0 \
-            -DSLANG_ENABLE_GFX=0 \
-            -DSLANG_ENABLE_TESTS=0 \
-            -DSLANG_EXCLUDE_DAWN=1 \
-            -DSLANG_EXCLUDE_TINT=1 \
-            -DSLANG_ENABLE_SLANG_RHI=0
-          cmake --workflow --preset "${{matrix.config}}"
       - name: Copy Slang to Falcor
         run: |
-          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release build/Release/bin/*
+          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release slang-bin/*
       - name: falcor-unit-test
         shell: pwsh
         run: |

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build:
     name: Build

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -63,6 +63,7 @@ jobs:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
           if-no-files-found: error
+          retention-days: 7
   test:
     name: Test (Falcor)
     needs: build
@@ -107,16 +108,22 @@ jobs:
       - name: falcor-unit-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_unit_tests.py --config windows-vs2022-Release -t "-slow"
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }
       - name: falcor-image-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_image_tests.py --config windows-vs2022-Release --run-only
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -63,7 +63,7 @@ jobs:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
   test:
     name: Test (Falcor)
     needs: build

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    name: Build
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
@@ -28,7 +29,7 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: "recursive"
@@ -55,10 +56,11 @@ jobs:
             -DSLANG_ENABLE_SLANG_RHI=0
           cmake --workflow --preset release
       - name: Upload Slang build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
         with:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
+          if-no-files-found: error
   test:
     name: Test (Falcor)
     needs: build
@@ -75,13 +77,13 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: "false"
           fetch-depth: "1"
       - name: Download Slang build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
         with:
           name: slang-falcor-build-windows-release
           path: slang-bin


### PR DESCRIPTION
Fixes shader-slang/slang#11495

## Summary of the problem from the end user perspective

The Falcor CI test machine was spending significant time building Slang before running Falcor tests, causing CI bottlenecks and wasting Falcor machine resources.

## Root cause

The `falcor-test.yml` workflow ran both the Slang build and Falcor tests in a single job on the Falcor test machine, preventing the machine from focusing on GPU testing.

## Solution in this PR

Split the workflow into two jobs:
1. **`build` job** — runs on `[Windows, self-hosted, build]` (which has the CUDA toolkit), builds Slang, and uploads `build/Release/bin/` as artifact `slang-falcor-build-windows-release`.
2. **`test` job** (`name: Test (Falcor)`) — runs on `[Windows, self-hosted, falcor]` (`needs: build`), downloads the artifact into `slang-bin/`, and runs the existing Falcor unit and image tests.

### Notes to the reviewers

- The build pool is used (not a free `windows-latest` runner) because the build requires the CUDA toolkit (`-DSLANG_ENABLE_CUDA=1`).
- The `test` job does a shallow checkout without submodules since it only needs the repo for the Falcor test scripts — the binary comes from the artifact.
- The CMake flags and Falcor test invocations are preserved from the original single-job workflow; the PowerShell test steps now use explicit stop-on-error and Python exit-code propagation.
- Both jobs get `Add Git Bash to PATH` for Windows shell tool compatibility.
- Upload path uses `build/Release/bin/` (trailing slash, no glob) so `actions/upload-artifact@v4` strips the directory prefix; binaries land directly in `slang-bin/` after download.
- `persist-credentials: false` added to both checkouts to prevent credential leakage.

## Reviewer Directives (maintained by agent)

- [LLM CodeRabbit] Do not pin `actions/upload-artifact` and `actions/download-artifact` to commit hashes — the project uses tag references (`@v4`) consistently across most workflows and selective pinning would be inconsistent. ([comment](https://github.com/jkwak-work/slang/pull/256#discussion_r3377621384))
