### PR TITLE
Fix WGSL locations for non-entry-point SV_TARGET structs

### DIFF
--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -2,6 +2,7 @@
 
 #include "slang-ir-layout.h"
 #include "slang-ir-util.h"
+#include "slang-parameter-binding.h"
 #include "slang-rich-diagnostics.h"
 
 // A note on row/column "terminology reversal".
@@ -263,6 +264,22 @@ static bool isPowerOf2(const uint32_t n)
     return (n != 0U) && ((n - 1U) & n) == 0U;
 }
 
+static int getWGSLLocationIndex(IRSemanticDecoration* semanticDecoration)
+{
+    auto index = semanticDecoration->getSemanticIndex();
+    if (index >= 0)
+        return index;
+
+    UnownedStringSlice semanticName;
+    UnownedStringSlice semanticIndexDigits;
+    if (splitNameAndIndex(semanticDecoration->getSemanticName(), semanticName, semanticIndexDigits))
+    {
+        return stringToInt(String(semanticIndexDigits));
+    }
+
+    return 0;
+}
+
 bool WGSLSourceEmitter::maybeEmitSystemSemantic(IRInst* inst)
 {
     if (auto sysSemanticDecor = inst->findDecoration<IRTargetSystemValueDecoration>())
@@ -282,7 +299,7 @@ void WGSLSourceEmitter::emitSemanticsPrefixImpl(IRInst* inst)
         if (auto semanticDecoration = inst->findDecoration<IRSemanticDecoration>())
         {
             m_writer->emit("@location(");
-            m_writer->emit(semanticDecoration->getEffectiveSemanticIndex());
+            m_writer->emit(getWGSLLocationIndex(semanticDecoration));
             m_writer->emit(")");
             return;
         }

--- a/tests/wgsl/non-entrypoint-struct-location.slang
+++ b/tests/wgsl/non-entrypoint-struct-location.slang
@@ -1,4 +1,7 @@
 //TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=SPIRV): -target wgsl-spirv-asm -stage fragment -entry fragmentMain
+
+//SPIRV: %fragmentMain = OpFunction
 
 struct HelperOutput
 {
@@ -13,7 +16,12 @@ struct HelperOutput
 
 struct FragmentOutput
 {
+    //WGSL-LABEL: struct FragmentOutput
+    //WGSL-DAG: @location(0) entryTarget0
     float4 entryTarget0 : SV_TARGET0;
+
+    //WGSL-DAG: @location(1) entryTarget1
+    //WGSL: }
     float4 entryTarget1 : SV_TARGET1;
 };
 

--- a/tests/wgsl/non-entrypoint-struct-location.slang
+++ b/tests/wgsl/non-entrypoint-struct-location.slang
@@ -1,0 +1,36 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage fragment -entry fragmentMain
+
+struct HelperOutput
+{
+    //WGSL-LABEL: struct HelperOutput
+    //WGSL-DAG: @location(0) helperTarget0
+    float4 helperTarget0 : SV_TARGET0;
+
+    //WGSL-DAG: @location(1) helperTarget1
+    //WGSL: }
+    float4 helperTarget1 : SV_TARGET1;
+};
+
+struct FragmentOutput
+{
+    float4 entryTarget0 : SV_TARGET0;
+    float4 entryTarget1 : SV_TARGET1;
+};
+
+HelperOutput makeHelperOutput()
+{
+    HelperOutput output;
+    output.helperTarget0 = float4(1.0);
+    output.helperTarget1 = float4(0.0);
+    return output;
+}
+
+FragmentOutput fragmentMain()
+{
+    HelperOutput helperOutput = makeHelperOutput();
+
+    FragmentOutput output;
+    output.entryTarget0 = helperOutput.helperTarget0;
+    output.entryTarget1 = helperOutput.helperTarget1;
+    return output;
+}


### PR DESCRIPTION
Fixes shader-slang/slang#10802

## Motivation

WGSL output can contain duplicate `@location(0)` attributes for non-entry-point structs whose fields use indexed `SV_TARGET` semantics. In the regression case, `HelperOutput` in `tests/wgsl/non-entrypoint-struct-location.slang:3` is returned by `makeHelperOutput()` rather than directly by the fragment entry point, so the existing entry-point varying legalization does not normalize `SV_TARGET1` into an explicit semantic index before emission.

## Proposed solution

Teach the WGSL emitter to derive the location index from the semantic decoration it is about to emit. `getWGSLLocationIndex()` in `source/slang/slang-emit-wgsl.cpp:267` preserves an explicit IR semantic index when one exists, and otherwise reuses `splitNameAndIndex()` to parse a trailing numeric suffix such as the `1` in `SV_TARGET1`. `emitSemanticsPrefixImpl()` then emits that computed index at `source/slang/slang-emit-wgsl.cpp:295`.

## Change summary

`source/slang/slang-emit-wgsl.cpp:267` adds a small WGSL-local helper for computing `@location` indices from `IRSemanticDecoration` values. `source/slang/slang-emit-wgsl.cpp:302` uses that helper instead of treating an unspecified semantic index as zero unconditionally.

`tests/wgsl/non-entrypoint-struct-location.slang:1` adds a focused WGSL regression. It verifies that a helper-returned `HelperOutput` struct emits `helperTarget0` at `@location(0)` and `helperTarget1` at `@location(1)`.

## Process report

The bug sits at the boundary between semantic decoration creation and WGSL source emission. Entry-point structs already pass through varying-parameter legalization that can split names like `SV_TARGET1` into a base semantic and explicit index, but ordinary helper structs can still reach WGSL emission with a semantic name that includes the numeric suffix and an IR index of `-1`.

Changing the WGSL emitter is intentionally narrow: WGSL is the backend emitting these semantics as `@location`, and `emitSemanticsPrefixImpl()` is the point where an unspecified IR index would otherwise collapse to zero. The input shape is therefore valid for this layer to handle: the semantic spelling still carries the author-provided index, and the emitter can recover it using the same `splitNameAndIndex()` convention already used by varying legalization.

The review follow-up extends the same regression rather than adding a separate scenario. `FragmentOutput` checks keep the existing entry-point path covered next to the fixed helper-struct path, and the `wgsl-spirv-asm` variant uses the established Tint downstream target to confirm the generated WGSL can be consumed beyond text emission.

