### PR TITLE
Fail fast when loadModuleFromSource sees name collisions

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4037,6 +4037,13 @@ err(
     span { loc = "location", message = "'glsl' module is not available from the current global session. To enable GLSL compatibility mode, specify 'SlangGlobalSessionDesc::enableGLSL' when creating the global session." }
 )
 
+err(
+    "module-already-loaded-with-different-source",
+    38204,
+    "module already loaded with different source",
+    span { loc = "location", message = "a module named '~moduleName:Name' is already loaded from different source contents in this session. Use a different module name or drop references to the previous module before reloading." }
+)
+
 -- Note: compilationCeased is a fatal diagnostic that is locationless
 fatal(
     "compilation-ceased",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4039,7 +4039,7 @@ err(
 
 err(
     "module-already-loaded-with-different-source",
-    38204,
+    38202,
     "module already loaded with different source",
     span { loc = "location", message = "a module named '~moduleName:Name' is already loaded from different source contents in this session. Use a different module name or drop references to the previous module before reloading." }
 )
@@ -5343,4 +5343,3 @@ if #validation_errors > 0 then
 end
 
 return processed_diagnostics
-

--- a/source/slang/slang-module.h
+++ b/source/slang/slang-module.h
@@ -305,6 +305,13 @@ public:
     void setDigest(SHA1::Digest const& digest) { m_digest = digest; }
     SHA1::Digest computeDigest();
 
+    /// Set / get a digest of the raw source that produced this module.
+    ///
+    /// Currently populated by `Linkage::loadModuleFromBlob` so that subsequent
+    /// load attempts with the same module name can be compared for equivalence.
+    void setSourceDigest(SHA1::Digest const& digest) { m_sourceDigest = digest; }
+    SHA1::Digest const& getSourceDigest() const { return m_sourceDigest; }
+
     /// Create a module (initially empty).
     Module(Linkage* linkage, ASTBuilder* astBuilder = nullptr);
 
@@ -479,6 +486,11 @@ private:
 
     // A digest that uniquely identifies the contents of the module.
     SHA1::Digest m_digest;
+
+    // Digest of the raw source blob that produced this module, when loaded via
+    // `Linkage::loadModuleFromBlob`.  Zero-initialised for modules that were not
+    // loaded from a source blob (e.g. loaded from disk).
+    SHA1::Digest m_sourceDigest{};
 
     // List of modules this module depends on
     ModuleDependencyList m_moduleDependencyList;

--- a/source/slang/slang-module.h
+++ b/source/slang/slang-module.h
@@ -307,8 +307,8 @@ public:
 
     /// Set / get a digest of the raw source that produced this module.
     ///
-    /// Currently populated by `Linkage::loadModuleFromBlob` so that subsequent
-    /// load attempts with the same module name can be compared for equivalence.
+    /// Populated for source blobs and source files so that subsequent load
+    /// attempts with the same module name can be compared for equivalence.
     void setSourceDigest(SHA1::Digest const& digest) { m_sourceDigest = digest; }
     SHA1::Digest const& getSourceDigest() const { return m_sourceDigest; }
 

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -238,28 +238,46 @@ slang::IModule* Linkage::loadModuleFromBlob(
 
     try
     {
-        auto getDigestStr = [](auto x)
+        auto computeDigest = [](auto x)
         {
             DigestBuilder<SHA1> digestBuilder;
             digestBuilder.append(x);
-            return digestBuilder.finalize().toString();
+            return digestBuilder.finalize();
         };
+
+        SHA1::Digest sourceDigest = computeDigest(source);
+        auto digestToString = [](SHA1::Digest const& d) { return d.toString(); };
 
         String moduleNameStr = moduleName;
         if (!moduleName)
-            moduleNameStr = getDigestStr(source);
+            moduleNameStr = digestToString(sourceDigest);
 
         auto name = getNamePool()->getName(moduleNameStr);
         RefPtr<LoadedModule> loadedModule;
         if (mapNameToLoadedModules.tryGetValue(name, loadedModule))
         {
-            return loadedModule;
+            // Returning the cached module is only safe when the incoming source
+            // is identical to whatever produced the cached module; otherwise the
+            // caller expects a module they have never actually loaded, leading
+            // to silent wrong-module use (and sometimes crashes) downstream.
+            // See #10957.
+            if (loadedModule && loadedModule->getSourceDigest() == sourceDigest)
+            {
+                return loadedModule;
+            }
+
+            sink.diagnose(Diagnostics::ModuleAlreadyLoadedWithDifferentSource{
+                .moduleName = name,
+                .location = SourceLoc(),
+            });
+            sink.getBlobIfNeeded(outDiagnostics);
+            return nullptr;
         }
         String pathStr = path;
         if (pathStr.getLength() == 0)
         {
             // If path is empty, use a digest from source as path.
-            pathStr = getDigestStr(source);
+            pathStr = digestToString(sourceDigest);
         }
         auto pathInfo = PathInfo::makeFromString(pathStr);
         if (File::exists(pathStr))
@@ -272,6 +290,8 @@ slang::IModule* Linkage::loadModuleFromBlob(
         }
         RefPtr<Module> module =
             loadModuleImpl(name, pathInfo, source, SourceLoc(), &sink, nullptr, blobType);
+        if (module)
+            module->setSourceDigest(sourceDigest);
         sink.getBlobIfNeeded(outDiagnostics);
         return asExternal(module.get());
     }

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -53,6 +53,8 @@ static String findStandardModulePath(String const& stdModuleDirPath, String cons
 
 static SHA1::Digest computeSourceBlobDigest(ISlangBlob* blob)
 {
+    SLANG_RELEASE_ASSERT(blob);
+
     DigestBuilder<SHA1> digestBuilder;
     digestBuilder.append(blob);
     return digestBuilder.finalize();
@@ -258,6 +260,9 @@ slang::IModule* Linkage::loadModuleFromBlob(
         {
             if (!loadedModule)
                 return nullptr;
+
+            if (blobType != ModuleBlobType::Source)
+                return loadedModule;
 
             // Returning the cached module is only safe when the incoming source
             // is identical to whatever produced the cached module; otherwise the

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -51,6 +51,13 @@ static String findStandardModulePath(String const& stdModuleDirPath, String cons
     return String();
 }
 
+static SHA1::Digest computeSourceBlobDigest(ISlangBlob* blob)
+{
+    DigestBuilder<SHA1> digestBuilder;
+    digestBuilder.append(blob);
+    return digestBuilder.finalize();
+}
+
 Linkage::Linkage(Session* session, ASTBuilder* astBuilder, Linkage* builtinLinkage)
     : m_session(session)
     , m_retainedSession(session)
@@ -238,14 +245,7 @@ slang::IModule* Linkage::loadModuleFromBlob(
 
     try
     {
-        auto computeDigest = [](auto x)
-        {
-            DigestBuilder<SHA1> digestBuilder;
-            digestBuilder.append(x);
-            return digestBuilder.finalize();
-        };
-
-        SHA1::Digest sourceDigest = computeDigest(source);
+        SHA1::Digest sourceDigest = computeSourceBlobDigest(source);
         auto digestToString = [](SHA1::Digest const& d) { return d.toString(); };
 
         String moduleNameStr = moduleName;
@@ -1717,7 +1717,11 @@ RefPtr<Module> Linkage::findOrImportModule(
             // out any other options.
             //
             if (module)
+            {
+                if (type == ModuleBlobType::Source)
+                    module->setSourceDigest(computeSourceBlobDigest(fileContents));
                 return module;
+            }
         }
     }
 

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -256,12 +256,15 @@ slang::IModule* Linkage::loadModuleFromBlob(
         RefPtr<LoadedModule> loadedModule;
         if (mapNameToLoadedModules.tryGetValue(name, loadedModule))
         {
+            if (!loadedModule)
+                return nullptr;
+
             // Returning the cached module is only safe when the incoming source
             // is identical to whatever produced the cached module; otherwise the
             // caller expects a module they have never actually loaded, leading
             // to silent wrong-module use (and sometimes crashes) downstream.
             // See #10957.
-            if (loadedModule && loadedModule->getSourceDigest() == sourceDigest)
+            if (loadedModule->getSourceDigest() == sourceDigest)
             {
                 return loadedModule;
             }

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -1,0 +1,84 @@
+// unit-test-load-module-name-collision.cpp
+
+// Regression test for #10957: `ISession::loadModuleFromSource` used to silently
+// return a previously cached module when called a second time with the same
+// module name but different source contents.  That caused downstream code to
+// operate on the wrong module and sometimes crash.
+//
+// Expected behaviour after the fix:
+//   - Same name, same source        -> returns the cached module (no-op).
+//   - Same name, different source   -> returns nullptr and produces a
+//                                      diagnostic complaining about the
+//                                      collision.
+
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <cstring>
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
+{
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK_ABORT(
+        slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::TargetDesc targetDesc{};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = globalSession->findProfile("spirv_1_5");
+
+    slang::SessionDesc sessionDesc{};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK_ABORT(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    const char* sourceA = R"(
+        [shader("compute")][numthreads(1,1,1)]
+        void a() {}
+    )";
+    const char* sourceB = R"(
+        [shader("compute")][numthreads(1,1,1)]
+        void b() {}
+    )";
+
+    // First load of "mod" with source A -- should succeed.
+    ComPtr<slang::IBlob> diagA1;
+    auto modA1 = session->loadModuleFromSourceString(
+        "mod",
+        "mod.slang",
+        sourceA,
+        diagA1.writeRef());
+    SLANG_CHECK(modA1 != nullptr);
+
+    // Reloading "mod" with identical source is still allowed (no-op):
+    // should return the cached module and produce no diagnostic.
+    ComPtr<slang::IBlob> diagA2;
+    auto modA2 = session->loadModuleFromSourceString(
+        "mod",
+        "mod.slang",
+        sourceA,
+        diagA2.writeRef());
+    SLANG_CHECK(modA2 != nullptr);
+    SLANG_CHECK(modA2 == modA1);
+
+    // Loading "mod" with a *different* source must now fail and emit a
+    // diagnostic pointing at the collision, rather than silently returning
+    // the previously cached module.
+    ComPtr<slang::IBlob> diagB;
+    auto modB = session->loadModuleFromSourceString(
+        "mod",
+        "mod.slang",
+        sourceB,
+        diagB.writeRef());
+    SLANG_CHECK(modB == nullptr);
+    SLANG_CHECK(diagB != nullptr);
+
+    // The diagnostic should be the new E38204 collision error.
+    const char* diagText = diagB ? (const char*)diagB->getBufferPointer() : "";
+    SLANG_CHECK(strstr(diagText, "38204") != nullptr);
+    SLANG_CHECK(strstr(diagText, "mod") != nullptr);
+}

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -47,21 +47,15 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
 
     // First load of "mod" with source A -- should succeed.
     ComPtr<slang::IBlob> diagA1;
-    auto modA1 = session->loadModuleFromSourceString(
-        "mod",
-        "mod.slang",
-        sourceA,
-        diagA1.writeRef());
+    auto modA1 =
+        session->loadModuleFromSourceString("mod", "mod.slang", sourceA, diagA1.writeRef());
     SLANG_CHECK(modA1 != nullptr);
 
     // Reloading "mod" with identical source is still allowed (no-op):
     // should return the cached module and produce no diagnostic.
     ComPtr<slang::IBlob> diagA2;
-    auto modA2 = session->loadModuleFromSourceString(
-        "mod",
-        "mod.slang",
-        sourceA,
-        diagA2.writeRef());
+    auto modA2 =
+        session->loadModuleFromSourceString("mod", "mod.slang", sourceA, diagA2.writeRef());
     SLANG_CHECK(modA2 != nullptr);
     SLANG_CHECK(modA2 == modA1);
 
@@ -69,11 +63,7 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     // diagnostic pointing at the collision, rather than silently returning
     // the previously cached module.
     ComPtr<slang::IBlob> diagB;
-    auto modB = session->loadModuleFromSourceString(
-        "mod",
-        "mod.slang",
-        sourceB,
-        diagB.writeRef());
+    auto modB = session->loadModuleFromSourceString("mod", "mod.slang", sourceB, diagB.writeRef());
     SLANG_CHECK(modB == nullptr);
     SLANG_CHECK(diagB != nullptr);
 

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -7,6 +7,7 @@
 //
 // Expected behaviour after the fix:
 //   - Same name, same source        -> returns the cached module (no-op).
+//   - Different name, same source   -> creates a separate module.
 //   - Same name, different source   -> returns nullptr and produces a
 //                                      diagnostic complaining about the
 //                                      collision.
@@ -58,6 +59,14 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
         session->loadModuleFromSourceString("mod", "mod.slang", sourceA, diagA2.writeRef());
     SLANG_CHECK(modA2 != nullptr);
     SLANG_CHECK(modA2 == modA1);
+
+    // Loading the same source under a different module name is still allowed.
+    // The collision check is keyed by module name, not by source contents alone.
+    ComPtr<slang::IBlob> diagAlias;
+    auto modAlias = session->loadModuleFromSourceString(
+        "mod_alias", "mod-alias.slang", sourceA, diagAlias.writeRef());
+    SLANG_CHECK(modAlias != nullptr);
+    SLANG_CHECK(modAlias != modA1);
 
     // Loading "mod" with a *different* source must now fail and emit a
     // diagnostic pointing at the collision, rather than silently returning

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -79,8 +79,8 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     // later direct source-string load with matching contents.
     ComPtr<ISlangFileSystemExt> fileSystem = ComPtr<ISlangFileSystemExt>(new MemoryFileSystem());
     auto& memoryFileSystem = *static_cast<MemoryFileSystem*>(fileSystem.get());
-    SLANG_CHECK_ABORT(memoryFileSystem.saveFile("mod_file.slang", sourceA, strlen(sourceA)) ==
-                      SLANG_OK);
+    SLANG_CHECK_ABORT(
+        memoryFileSystem.saveFile("mod_file.slang", sourceA, strlen(sourceA)) == SLANG_OK);
     sessionDesc.fileSystem = fileSystem;
 
     ComPtr<slang::ISession> fileSession;

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -12,6 +12,7 @@
 //                                      diagnostic complaining about the
 //                                      collision.
 
+#include "core/slang-memory-file-system.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
 #include "unit-test/slang-unit-test.h"
@@ -33,6 +34,9 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     slang::SessionDesc sessionDesc{};
     sessionDesc.targetCount = 1;
     sessionDesc.targets = &targetDesc;
+    const char* searchPaths[] = {"."};
+    sessionDesc.searchPathCount = 1;
+    sessionDesc.searchPaths = searchPaths;
 
     ComPtr<slang::ISession> session;
     SLANG_CHECK_ABORT(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
@@ -71,6 +75,31 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     SLANG_CHECK(modAlias != nullptr);
     SLANG_CHECK(modAlias != modA1);
 
+    // A module loaded from a source file should also be comparable against a
+    // later direct source-string load with matching contents.
+    ComPtr<ISlangFileSystemExt> fileSystem = ComPtr<ISlangFileSystemExt>(new MemoryFileSystem());
+    auto& memoryFileSystem = *static_cast<MemoryFileSystem*>(fileSystem.get());
+    SLANG_CHECK_ABORT(memoryFileSystem.saveFile("mod_file.slang", sourceA, strlen(sourceA)) ==
+                      SLANG_OK);
+    sessionDesc.fileSystem = fileSystem;
+
+    ComPtr<slang::ISession> fileSession;
+    SLANG_CHECK_ABORT(
+        globalSession->createSession(sessionDesc, fileSession.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagFileLoad;
+    auto modFile = fileSession->loadModule("mod_file", diagFileLoad.writeRef());
+    SLANG_CHECK(modFile != nullptr);
+
+    ComPtr<slang::IBlob> diagFileReload;
+    auto modFileReload = fileSession->loadModuleFromSourceString(
+        "mod_file",
+        "mod_file.slang",
+        sourceA,
+        diagFileReload.writeRef());
+    SLANG_CHECK(modFileReload != nullptr);
+    SLANG_CHECK(modFileReload == modFile);
+
     // Loading "mod" with a *different* source must now fail and emit a
     // diagnostic pointing at the collision, rather than silently returning
     // the previously cached module.
@@ -79,8 +108,8 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     SLANG_CHECK(modB == nullptr);
     SLANG_CHECK(diagB != nullptr);
 
-    // The diagnostic should be the new E38204 collision error.
+    // The diagnostic should be the new E38202 collision error.
     const char* diagText = diagB ? (const char*)diagB->getBufferPointer() : "";
-    SLANG_CHECK(strstr(diagText, "38204") != nullptr);
+    SLANG_CHECK(strstr(diagText, "38202") != nullptr);
     SLANG_CHECK(strstr(diagText, "mod") != nullptr);
 }

--- a/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-name-collision.cpp
@@ -64,7 +64,10 @@ SLANG_UNIT_TEST(loadModuleFromSourceNameCollision)
     // The collision check is keyed by module name, not by source contents alone.
     ComPtr<slang::IBlob> diagAlias;
     auto modAlias = session->loadModuleFromSourceString(
-        "mod_alias", "mod-alias.slang", sourceA, diagAlias.writeRef());
+        "mod_alias",
+        "mod-alias.slang",
+        sourceA,
+        diagAlias.writeRef());
     SLANG_CHECK(modAlias != nullptr);
     SLANG_CHECK(modAlias != modA1);
 


### PR DESCRIPTION
Fixes #10957

## Summary

`Linkage::loadModuleFromBlob` used to treat a module-name cache hit as enough to return the cached module. The incoming source blob was ignored, so callers that reused a module name with different source contents could receive the wrong module and then fail later with misleading lookup/backend errors or crashes.

## Fix

Preserve the safe no-op case by tracking a SHA1 digest of the raw source that produced each source-backed module:

- same module name and same source digest: return the cached module.
- same module name and different source digest: emit `ModuleAlreadyLoadedWithDifferentSource` (E38202) and return `nullptr`.
- cached failed load (`nullptr`): return `nullptr` without reporting a misleading source-collision diagnostic.
- non-source blob cache hits: keep the previous cached-module behavior instead of applying a source-only diagnostic to IR blobs.

Changes:

- `source/slang/slang-session.cpp`: compute a reusable source-blob digest with an asserted non-null input, compare it on source-backed `loadModuleFromBlob` cache hits, record it for newly loaded source blobs, and also record it for source files loaded through `loadModule()` / imports.
- `source/slang/slang-module.h`: store the raw-source digest on `Module`.
- `source/slang/slang-diagnostics.lua`: add unique diagnostic E38202.
- `tools/slang-unit-test/unit-test-load-module-name-collision.cpp`: cover identical reloads, same-source/different-name loads, file-backed source reloads, and different-source collisions.

## Validation

- Earlier validation: build OK.
- Earlier validation: new unit test passed with all 200 existing unit tests.
- Earlier validation: full suite 6850/6852; the two failures were pre-existing bf16 Vulkan issues unrelated to module loading.
- Latest local check: `git diff --check` passes.
- Latest local formatting/test runs are blocked in this workspace because no local build artifacts are present and `clang-format`, `gersemi`, `prettier`, and `shfmt` are not installed. The CI formatting check printed one required wrap change, which is included in the latest push.
