### PR TITLE
Require all CI needs to succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,11 +299,9 @@ jobs:
   #
   # The build jobs must be listed in `needs` even though every test job
   # already depends on a build job: when a needed job fails, GitHub
-  # Actions marks the dependent jobs "skipped" (not "failed"), and
-  # skipped must be allowed here because several test jobs intentionally
-  # skip on plain pull_request events (they only run in the merge queue).
-  # Without the build jobs listed explicitly, a broken build turns all
-  # its test jobs into allowed skips and the gate passes (see #11553).
+  # Actions marks the dependent jobs "skipped" (not "failed"). Requiring
+  # every needed job to succeed ensures skipped jobs cannot hide a failed
+  # dependency (see #11553).
   check-ci:
     needs:
       [
@@ -339,19 +337,19 @@ jobs:
           echo "=== CI Results Summary ==="
           echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
 
-          # Allow "success" and "skipped"; fail on "failure" or "cancelled".
-          # Checking the generic `needs` JSON (rather than enumerating each
-          # job) means any job added to `needs` above is gated automatically.
-          failed=$(echo "$NEEDS_JSON" | jq -r 'to_entries[]
-            | select(.value.result == "failure" or .value.result == "cancelled")
-            | .key')
-          if [[ -n "$failed" ]]; then
-            echo "These CI jobs failed or were cancelled:"
-            echo "$failed"
+          # Require every needed job to succeed. Checking the generic
+          # `needs` JSON (rather than enumerating each job) means any job
+          # added to `needs` above is gated automatically.
+          unsuccessful=$(echo "$NEEDS_JSON" | jq -r 'to_entries[]
+            | select(.value.result != "success")
+            | "\(.key): \(.value.result)"')
+          if [[ -n "$unsuccessful" ]]; then
+            echo "These CI jobs did not succeed:"
+            echo "$unsuccessful"
             exit 1
           fi
 
-          echo "All CI jobs completed successfully (passed or skipped)!"
+          echo "All CI jobs completed successfully!"
 
   # Automatically retry GPU health check failures by dispatching ci-retry.yml,
   # which watches this run until it completes, then reruns only failed jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
   # MaterialX Integration Tests (Windows only for initial validation)
   test-materialx-windows-release:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
-    if: needs.filter.outputs.should-run == 'true' && github.event_name == 'pull_request'
+    if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/materialx-test.yml
     with:
       os: windows
@@ -299,12 +299,13 @@ jobs:
   #
   # The build jobs must be listed in `needs` even though every test job
   # already depends on a build job: when a needed job fails, GitHub
-  # Actions marks the dependent jobs "skipped" (not "failed"). Requiring
-  # every needed job to succeed ensures skipped jobs cannot hide a failed
-  # dependency (see #11553).
+  # Actions marks the dependent jobs "skipped" (not "failed"). Once the
+  # filter says CI should run, requiring every needed job to succeed
+  # ensures skipped jobs cannot hide a failed dependency (see #11553).
   check-ci:
     needs:
       [
+        filter,
         build-linux-debug-gcc-x86_64,
         build-linux-release-gcc-x86_64,
         build-linux-release-gcc-wasm,
@@ -333,9 +334,18 @@ jobs:
       - name: Check CI Results
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          FILTER_RESULT: ${{ needs.filter.result }}
+          SHOULD_RUN: ${{ needs.filter.outputs.should-run }}
         run: |
           echo "=== CI Results Summary ==="
           echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+
+          # If the filter succeeded and determined CI is unnecessary,
+          # skipped build/test jobs are expected for a docs-only change.
+          if [[ "$FILTER_RESULT" == "success" && "$SHOULD_RUN" != "true" ]]; then
+            echo "Filter determined CI is unnecessary; skipped jobs are expected."
+            exit 0
+          fi
 
           # Require every needed job to succeed. Checking the generic
           # `needs` JSON (rather than enumerating each job) means any job


### PR DESCRIPTION
## Motivation

The aggregate `check-ci` job is the branch-protection gate for CI. It currently accepts both `success` and `skipped` results from jobs listed in `needs`. That means a skipped needed job can still satisfy the gate, even though a skipped result may represent work that never actually ran.

A concrete example is the dependency pattern documented in `.github/workflows/ci.yml`: when a build job fails, GitHub Actions marks downstream jobs that needed that build as `skipped`. The aggregate gate should require the build and every listed test job to report `success` rather than treating those skipped downstream jobs as acceptable.

## Proposed solution

Make `check-ci` require every entry in the `needs` JSON to have `result == "success"` once the `filter` job says CI should run. This keeps the aggregate gate tied directly to GitHub Actions' recorded result for each required job, while preserving the existing docs-only fast path as an explicit exception guarded by a successful `filter` result.

## Change summary

- `.github/workflows/ci.yml`: updates the `check-ci` comment to describe the stricter requirement that skipped jobs cannot hide failed dependencies.
- `.github/workflows/ci.yml`: adds `filter` to `check-ci.needs`, lets `check-ci` succeed for docs-only changes only when `filter` succeeds with `should-run != true`, and otherwise selects every needed job whose result is not `success`.
- `.github/workflows/ci.yml`: makes `test-materialx-windows-release` follow the same `should-run` condition as the rest of the jobs gated by `check-ci`, so it is not an intentional skip on merge-queue or manual CI runs.

## Concepts and vocabulary

- `check-ci`: the aggregate CI job that branch protection and the merge queue can require instead of requiring every individual build and test job directly.
- `filter`: the job that decides whether a change requires CI, using the `should-run` output to skip build and test work for docs-only changes.
- `needs`: the GitHub Actions dependency map available to a job, where each dependency has a `result` such as `success`, `failure`, `cancelled`, or `skipped`.

## Process report

The previous `Check CI Results` step in `.github/workflows/ci.yml` inspected `toJSON(needs)` but only selected jobs whose result was `failure` or `cancelled`. That made `skipped` an allowed terminal state. Because GitHub Actions reports downstream jobs as `skipped` when a dependency fails, the aggregate gate could pass without every listed job actually succeeding.

The fix keeps the check at the aggregate gate layer, where the complete `needs` map is already available. The `jq` predicate now selects `.value.result != "success"`, so the gate fails for `failure`, `cancelled`, `skipped`, or any other non-success result GitHub Actions may report after `filter` says CI is required. This is the right layer for the policy because the input shape is valid: `needs` is GitHub Actions' authoritative dependency-result summary, and the workflow intentionally centralizes branch-protection decisions in `check-ci`.

The docs-only path is handled before the strict check. `filter` is now listed in `check-ci.needs`, and the step exits successfully only when `needs.filter.result` is `success` and `needs.filter.outputs.should-run` is not `true`. That input shape is correct and principled because docs-only skipping is produced by this workflow's own filter job, not by a failed dependency. If `filter` fails, or if it says CI should run, the strict non-success check still applies to every needed job.

`test-materialx-windows-release` previously had an additional `github.event_name == 'pull_request'` condition while still being listed in `check-ci.needs`. Under the stricter gate, that would make merge-queue and manual CI runs fail because the MaterialX job was intentionally skipped. The job now uses the same `should-run` condition as the other gated jobs, so every job listed in `check-ci.needs` is expected to run and succeed whenever CI is required.

The surrounding comments and success message were updated to match the new policy. They no longer describe skipped jobs as generally acceptable, and they document that every needed job must succeed once CI is required.
