### PR TITLE
Keep serialization test outputs ignored

### DIFF
--- a/tests/serialization/std-lib-serialize.slang
+++ b/tests/serialization/std-lib-serialize.slang
@@ -1,7 +1,7 @@
-//TEST:COMPILE: -save-core-module slang-core-module.zip
-//TEST:COMPILE: -load-core-module slang-core-module.zip -save-glsl-module-bin-source slang-glsl-module-generated.h
-//TEST:COMPILE: -save-core-module-bin-source slang-core-module-generated.h
-//TEST:COMPARE_COMPUTE: -compile-arg -load-core-module -compile-arg slang-core-module.zip -shaderobj
+//TEST:COMPILE: -save-core-module tests/serialization/slang-core-module.zip
+//TEST:COMPILE: -load-core-module tests/serialization/slang-core-module.zip -save-glsl-module-bin-source tests/serialization/slang-glsl-module-generated.actual
+//TEST:COMPILE: -save-core-module-bin-source tests/serialization/slang-core-module-generated.actual
+//TEST:COMPARE_COMPUTE: -compile-arg -load-core-module -compile-arg tests/serialization/slang-core-module.zip -shaderobj
 
 struct A
 {


### PR DESCRIPTION
## Motivation

After PR #11721, `tests/serialization/std-lib-serialize.slang` started exercising `-save-glsl-module-bin-source` and `-save-core-module-bin-source`. Those directives used bare output names such as `slang-glsl-module-generated.h`, so running the test from the repository root wrote generated header files into the root checkout. The sibling `slang-core-module.zip` artifact was already hidden by the global `*.zip` ignore rule, which made the new header artifacts stand out as untracked files after otherwise normal test runs.

## Proposed solution

Keep the serialization coverage from PR #11721, but make the test outputs follow the same pattern as other serialization tests: write them under `tests/serialization/` and use extensions that are already treated as transient test artifacts. The saved core archive now lives at `tests/serialization/slang-core-module.zip`, and the source-byte outputs use `.actual`, which is already ignored by the test-runner artifact rules.

## Change summary

`tests/serialization/std-lib-serialize.slang:1` now saves the temporary core archive as `tests/serialization/slang-core-module.zip`.

`tests/serialization/std-lib-serialize.slang:2` loads that archive from the test directory and writes the GLSL bin-source output as `tests/serialization/slang-glsl-module-generated.actual`.

`tests/serialization/std-lib-serialize.slang:3` writes the core bin-source output as `tests/serialization/slang-core-module-generated.actual`.

`tests/serialization/std-lib-serialize.slang:4` updates the compute comparison's `-load-core-module` argument to use the moved archive path.

## Concepts and vocabulary

A bin-source output is the C-array text produced by `-save-*-module-bin-source`; this test only needs to prove the option flow can produce that data, not that the file has a C/C++ header extension.

A `.actual` file is a transient test artifact extension already covered by the repository ignore rules.

## Process report

The important input shape is a test directive, not a compiler representation. `slang-test` forwards each `COMPILE` directive's arguments to `slangc`, and `slangc` writes the path passed to `-save-core-module`, `-save-core-module-bin-source`, or `-save-glsl-module-bin-source`. Because the old directives passed bare filenames, the outputs were relative to the process working directory. In the common root-from-repo test run, that meant root-level generated headers.

The fix keeps the producer behavior unchanged and changes only the test-owned output paths. `tests/serialization/std-lib-serialize.slang` already owns the temporary `slang-core-module.zip` dependency between directives, so placing the archive and both bin-source outputs in `tests/serialization/` keeps all artifacts beside the test that creates and consumes them. Using `.actual` for the source-byte outputs is intentional: the test validates option sequencing and module serialization, and the extension does not participate in compiler behavior for these options.
