### PR TITLE
Verify slangc in CMake option builds

### DIFF
--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -147,6 +147,42 @@ jobs:
           ASAN_OPTIONS: detect_leaks=0
         run: cmake --build build --config "$cmake_config"
 
+      - name: Verify slangc version (${{ matrix.option }})
+        if: matrix.windows_only != 'true'
+        run: |
+          slangc_enabled=$(
+            sed -n 's/^SLANG_ENABLE_SLANGC:[^=]*=//p' build/CMakeCache.txt \
+            | tr '[:upper:]' '[:lower:]'
+          )
+          case "$slangc_enabled" in
+            on|true|1|yes) ;;
+            off|false|0|no)
+              echo "SLANG_ENABLE_SLANGC is ${slangc_enabled}; skipping slangc runtime check."
+              exit 0
+              ;;
+            *)
+              echo "ERROR: could not determine SLANG_ENABLE_SLANGC from build/CMakeCache.txt"
+              exit 1
+              ;;
+          esac
+
+          slangc_path="build/$cmake_config/bin/slangc"
+          bin_dir="$PWD/build/$cmake_config/bin"
+          lib_dir="$PWD/build/$cmake_config/lib"
+
+          if [[ ! -f "$slangc_path" ]]; then
+            echo "ERROR: expected slangc at $slangc_path"
+            ls -la "$bin_dir" || true
+            exit 1
+          fi
+
+          export PATH="$bin_dir:$PATH"
+          if [[ -d "$lib_dir" ]]; then
+            export LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}"
+          fi
+
+          "$slangc_path" -v
+
       # Exercise `cmake --install` and a `find_package(slang)` consumer for
       # entries that opt in via install_test. The static-lib build
       # (SLANG_LIB_TYPE=STATIC) used to skip the install(EXPORT ...) step

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -191,6 +191,48 @@ jobs:
         if: (matrix.linux_only != 'true' || inputs.os == 'linux') && (matrix.windows_only != 'true' || inputs.os == 'windows') && matrix.container_only != 'true' && (matrix.skip_linux_aarch64 != 'true' || inputs.os != 'linux' || inputs.platform != 'aarch64')
         run: cmake --build build --config "$cmake_config"
 
+      - name: Verify slangc version (${{ matrix.option }})
+        if: (matrix.linux_only != 'true' || inputs.os == 'linux') && (matrix.windows_only != 'true' || inputs.os == 'windows') && matrix.container_only != 'true' && (matrix.skip_linux_aarch64 != 'true' || inputs.os != 'linux' || inputs.platform != 'aarch64') && !(inputs.os == 'windows' && inputs.arch != '')
+        run: |
+          slangc_enabled=$(
+            sed -n 's/^SLANG_ENABLE_SLANGC:[^=]*=//p' build/CMakeCache.txt \
+            | tr '[:upper:]' '[:lower:]'
+          )
+          case "$slangc_enabled" in
+            on|true|1|yes) ;;
+            off|false|0|no)
+              echo "SLANG_ENABLE_SLANGC is ${slangc_enabled}; skipping slangc runtime check."
+              exit 0
+              ;;
+            *)
+              echo "ERROR: could not determine SLANG_ENABLE_SLANGC from build/CMakeCache.txt"
+              exit 1
+              ;;
+          esac
+
+          if [[ "${{ inputs.os }}" == "windows" ]]; then
+            slangc_path="$bin_dir/slangc.exe"
+          else
+            slangc_path="$bin_dir/slangc"
+          fi
+
+          if [[ ! -f "$slangc_path" ]]; then
+            echo "ERROR: expected slangc at $slangc_path"
+            ls -la "$bin_dir" || true
+            exit 1
+          fi
+
+          export PATH="$bin_dir:$PATH"
+          if [[ -d "$lib_dir" ]]; then
+            if [[ "${{ inputs.os }}" == "macos" ]]; then
+              export DYLD_LIBRARY_PATH="$lib_dir:${DYLD_LIBRARY_PATH:-}"
+            else
+              export LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}"
+            fi
+          fi
+
+          "$slangc_path" -v
+
       # Exercise `cmake --install` and a `find_package(slang)` consumer for
       # entries that opt in via install_test. The static-lib build
       # (SLANG_LIB_TYPE=STATIC) used to skip the install(EXPORT ...) step


### PR DESCRIPTION
## Motivation

The CMake option workflows already configure and build each option combination, but a
successful build does not prove that the produced `slangc` executable can start with the
libraries from that same build tree. Consider an option entry that keeps
`SLANG_ENABLE_SLANGC` enabled: `cmake --build` can complete while CI still misses a
runtime loader or packaging issue in `build/$cmake_config/bin/slangc`.

## Proposed solution

Add a post-build workflow step that reads `SLANG_ENABLE_SLANGC` from
`build/CMakeCache.txt`. When `slangc` is disabled, the step reports the cache value and
skips the runtime check. When it is enabled, the step verifies that the expected
executable exists, adds the build `bin` and `lib` directories to the runtime lookup
environment, and runs `slangc -v`.

This keeps the check tied to the configured build output. The non-container workflow
handles Windows `slangc.exe`, macOS `DYLD_LIBRARY_PATH`, and skips Windows cross-arch
entries whose binaries cannot be executed on the current host. The container workflow
uses the Linux build layout and `LD_LIBRARY_PATH`.

## Change summary

- `.github/workflows/cmake-options-build-container.yml:150` adds a Linux/container
  `Verify slangc version` step immediately after the build step.
- `.github/workflows/cmake-options-build.yml:194` adds the same post-build check for
  the non-container matrix, with OS-specific executable and library-path handling.

## Concepts and vocabulary

`SLANG_ENABLE_SLANGC` is the CMake cache option that determines whether the matrix entry
is expected to produce the `slangc` executable.

`cmake_config` is the workflow configuration name used to locate the build output under
`build/$cmake_config/bin` and `build/$cmake_config/lib`.

## Process report

The check belongs after `cmake --build` because the input shape under test is the built
tool output, not an internal compiler representation. The producer is the configure step
earlier in each workflow, which writes `SLANG_ENABLE_SLANGC` into `build/CMakeCache.txt`.
The new post-build step consumes that cache value as the source of truth before deciding
whether `slangc` should exist.

If the cache says `slangc` is disabled, the step exits successfully because the missing
executable is intentional for that option combination. If the cache entry is missing or
uses an unexpected value, the step fails because the workflow can no longer distinguish
an intentional omission from a broken build. When `slangc` is enabled, the step verifies
the executable path derived from the existing workflow variables, exposes the matching
build output directories through `PATH`, `LD_LIBRARY_PATH`, or `DYLD_LIBRARY_PATH`, and
runs `slangc -v`. That makes CI catch the concrete failure mode where a configured option
builds successfully but produces a `slangc` that cannot be launched.
