### PR TITLE
Print skip-list info in slang-test

### DIFF
--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -746,8 +746,7 @@ static bool _isSubCommand(const char* arg)
         }
     }
 
-    if (optionsOut->verbosity >= VerbosityLevel::Info &&
-        optionsOut->skipListFiles.getCount() > 0)
+    if (optionsOut->verbosity >= VerbosityLevel::Info && optionsOut->skipListFiles.getCount() > 0)
     {
         stdOut.print("Skip lists:\n");
         for (const auto& fileInfo : optionsOut->skipListFiles)

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -575,7 +575,7 @@ static bool _isSubCommand(const char* arg)
                     fileEntryCount++;
                 }
             }
-            Options::ExpectedFailureFileInfo fileInfo;
+            Options::TestListFileInfo fileInfo;
             fileInfo.fileName = fileName;
             fileInfo.count = fileEntryCount;
             optionsOut->expectedFailureFiles.add(fileInfo);
@@ -593,6 +593,7 @@ static bool _isSubCommand(const char* arg)
             File::readAllText(fileName, text);
             List<UnownedStringSlice> lines;
             StringUtil::split(text.getUnownedSlice(), '\n', lines);
+            int fileEntryCount = 0;
             for (auto line : lines)
             {
                 // Remove comments (everything after '#' character)
@@ -610,8 +611,13 @@ static bool _isSubCommand(const char* arg)
                     Slang::StringBuilder sb;
                     Slang::Path::simplify(trimmedLine, Slang::Path::SimplifyStyle::NoRoot, sb);
                     optionsOut->skipList.add(sb);
+                    fileEntryCount++;
                 }
             }
+            Options::TestListFileInfo fileInfo;
+            fileInfo.fileName = fileName;
+            fileInfo.count = fileEntryCount;
+            optionsOut->skipListFiles.add(fileInfo);
         }
         else if (strcmp(arg, "-test-dir") == 0)
         {
@@ -737,6 +743,16 @@ static bool _isSubCommand(const char* arg)
         for (const auto& fileInfo : optionsOut->expectedFailureFiles)
         {
             stdOut.print(" - %s : %d tests\n", fileInfo.fileName.getBuffer(), fileInfo.count);
+        }
+    }
+
+    if (optionsOut->verbosity >= VerbosityLevel::Info &&
+        optionsOut->skipListFiles.getCount() > 0)
+    {
+        stdOut.print("Skip lists:\n");
+        for (const auto& fileInfo : optionsOut->skipListFiles)
+        {
+            stdOut.print(" - %s : %d entries\n", fileInfo.fileName.getBuffer(), fileInfo.count);
         }
     }
 

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -142,15 +142,16 @@ struct Options
     Slang::HashSet<Slang::String> capabilities;
     Slang::HashSet<Slang::String> expectedFailureList;
 
-    // Per-file info for expected failure lists: (fileName, count) pairs, in order added.
-    struct ExpectedFailureFileInfo
+    // Per-file info for loaded test list files: (fileName, count) pairs, in order added.
+    struct TestListFileInfo
     {
         Slang::String fileName;
         int count;
     };
-    Slang::List<ExpectedFailureFileInfo> expectedFailureFiles;
+    Slang::List<TestListFileInfo> expectedFailureFiles;
 
     Slang::List<Slang::String> skipList;
+    Slang::List<TestListFileInfo> skipListFiles;
 
     /// Parse the args, report any errors into stdError, and write the results into optionsOut
     static SlangResult parse(


### PR DESCRIPTION
## Motivation

A `slang-test` invocation can load both skip lists and expected-failure lists, for example:

```text
slang-test -skip-list tests/skip-list-gpu-t4.txt -expected-failure-list tests/expected-failure-github.txt
```

Before this change, `Options::parse` printed the expected-failure list files and parsed counts, but it did not print the skip-list files. That made CI logs show one part of the test-selection policy while hiding another equally important part.

## Proposed solution

Keep the reporting at the option-parsing boundary, where the command line file names and parsed entry counts are both available. `Options::parse` now records per-file skip-list metadata while it parses each `-skip-list` file, using the same comment stripping, whitespace trimming, and empty-line filtering rules that feed `Options::skipList`. The output reports skip-list counts as `entries` because a skip-list line is a path prefix and may match more than one test.

## Change summary

- `tools/slang-test/options.h:145` replaces the expected-failure-specific metadata struct with `TestListFileInfo` and adds `skipListFiles` beside the existing `skipList` prefixes.
- `tools/slang-test/options.cpp:591` counts parsed skip-list entries while preserving the existing normalized-prefix population of `Options::skipList`.
- `tools/slang-test/options.cpp:749` prints a `Skip lists:` section at info verbosity, matching the existing expected-failure list reporting style.

## Concepts and vocabulary

An expected-failure list names tests whose failures should be classified as expected failures. A skip list contains path prefixes that prevent matching tests from running at all. Because one skip-list prefix can cover a directory of tests, the reported skip-list count is an entry count rather than a discovered-test count.

## Process report

Consider the GPU CI command that loads `tests/skip-list-gpu-t4.txt` together with `tests/expected-failure-github.txt`. The expected-failure path in `Options::parse` already stores a per-file count after it removes `#` comments, trims each line, ignores empty lines, and adds the remaining entries to `expectedFailureList`. Later in the same function it prints `Expected failure lists:` from that metadata.

The skip-list path immediately below it was already parsing the same kind of line-oriented file, but it only stored the normalized prefixes in `skipList`. The skip decision in `shouldRunTest` then uses those prefixes with `filePath.startsWith(skipEntry)`, so a skip-list line is intentionally a valid prefix shape rather than a malformed test name. This change records the count at the producer of that shape, while the original file name is still in hand, and leaves the downstream matcher unchanged.

The shared `TestListFileInfo` keeps this as one small piece of list-file metadata instead of introducing a parallel skip-list-only representation. The new print block mirrors the existing info-level expected-failure output, but says `entries` to preserve the invariant that skip-list files contain prefixes, not exact discovered tests.
