### PR TITLE
Support SM 6.10 in gfx D3D12 shader model table; prefer NVAPI HitObject over DXR 1.3 native

### DIFF
--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1848,17 +1848,17 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
             auto nvapiCapabilitySet = CapabilitySet(CapabilityName::hlsl_nvapi);
             auto sm69CapabilitySet = CapabilitySet(CapabilityName::_sm_6_9);
 
-            if (targetCaps.implies(sm69CapabilitySet))
+            if (targetCaps.implies(nvapiCapabilitySet))
             {
-                // DXR 1.3 native: use dx::HitObject namespace
-                m_writer->emit("dx::HitObject");
-            }
-            else if (targetCaps.implies(nvapiCapabilitySet))
-            {
-                // NVAPI extension: use NvHitObject
+                // NVAPI extension: use NvHitObject (matches `case hlsl_nvapi:` calls)
                 m_writer->emit("NvHitObject");
                 // Ensure NVAPI header is included when using NvHitObject type
                 m_extensionTracker->m_requiresNVAPI = true;
+            }
+            else if (targetCaps.implies(sm69CapabilitySet))
+            {
+                // DXR 1.3 native: use dx::HitObject namespace
+                m_writer->emit("dx::HitObject");
             }
             else
             {

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -57,9 +57,33 @@ static ShaderModelInfo kKnownShaderModels[] = {
     }
     SHADER_MODEL_INFO_DXBC(5, 1),
 #undef SHADER_MODEL_INFO_DXBC
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                    \
-    {                                                                           \
-        (D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor \
+// Minor versions >= 10 must be encoded as a hex digit (D3D_SHADER_MODEL_6_10 == 0x6a),
+// so we run the minor through a lookup table before token-pasting. Two-level indirection
+// is required because `##` does not expand its operands.
+#define _SM_HEX_DIGIT_0 0
+#define _SM_HEX_DIGIT_1 1
+#define _SM_HEX_DIGIT_2 2
+#define _SM_HEX_DIGIT_3 3
+#define _SM_HEX_DIGIT_4 4
+#define _SM_HEX_DIGIT_5 5
+#define _SM_HEX_DIGIT_6 6
+#define _SM_HEX_DIGIT_7 7
+#define _SM_HEX_DIGIT_8 8
+#define _SM_HEX_DIGIT_9 9
+#define _SM_HEX_DIGIT_10 a
+#define _SM_HEX_DIGIT_11 b
+#define _SM_HEX_DIGIT_12 c
+#define _SM_HEX_DIGIT_13 d
+#define _SM_HEX_DIGIT_14 e
+#define _SM_HEX_DIGIT_15 f
+#define _SM_HEX_DIGIT_INDIRECT(x) _SM_HEX_DIGIT_##x
+#define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
+#define _SM_CONCAT_PASTE(a, b, c) a##b##c
+#define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                          \
+    {                                                                                 \
+        (D3D_SHADER_MODEL)_SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)),                \
+            SLANG_DXIL, "sm_" #major "_" #minor                                       \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
@@ -70,7 +94,8 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 6),
     SHADER_MODEL_INFO_DXIL(6, 7),
     SHADER_MODEL_INFO_DXIL(6, 8),
-    SHADER_MODEL_INFO_DXIL(6, 9)
+    SHADER_MODEL_INFO_DXIL(6, 9),
+    SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
 };
 

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -97,6 +97,26 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 9),
     SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
+#undef _SM_CONCAT
+#undef _SM_CONCAT_PASTE
+#undef _SM_HEX_DIGIT
+#undef _SM_HEX_DIGIT_INDIRECT
+#undef _SM_HEX_DIGIT_15
+#undef _SM_HEX_DIGIT_14
+#undef _SM_HEX_DIGIT_13
+#undef _SM_HEX_DIGIT_12
+#undef _SM_HEX_DIGIT_11
+#undef _SM_HEX_DIGIT_10
+#undef _SM_HEX_DIGIT_9
+#undef _SM_HEX_DIGIT_8
+#undef _SM_HEX_DIGIT_7
+#undef _SM_HEX_DIGIT_6
+#undef _SM_HEX_DIGIT_5
+#undef _SM_HEX_DIGIT_4
+#undef _SM_HEX_DIGIT_3
+#undef _SM_HEX_DIGIT_2
+#undef _SM_HEX_DIGIT_1
+#undef _SM_HEX_DIGIT_0
 };
 
 Result DeviceImpl::createBuffer(

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -60,30 +60,30 @@ static ShaderModelInfo kKnownShaderModels[] = {
 // Minor versions >= 10 must be encoded as a hex digit (D3D_SHADER_MODEL_6_10 == 0x6a),
 // so we run the minor through a lookup table before token-pasting. Two-level indirection
 // is required because `##` does not expand its operands.
-#define _SM_HEX_DIGIT_0 0
-#define _SM_HEX_DIGIT_1 1
-#define _SM_HEX_DIGIT_2 2
-#define _SM_HEX_DIGIT_3 3
-#define _SM_HEX_DIGIT_4 4
-#define _SM_HEX_DIGIT_5 5
-#define _SM_HEX_DIGIT_6 6
-#define _SM_HEX_DIGIT_7 7
-#define _SM_HEX_DIGIT_8 8
-#define _SM_HEX_DIGIT_9 9
-#define _SM_HEX_DIGIT_10 a
-#define _SM_HEX_DIGIT_11 b
-#define _SM_HEX_DIGIT_12 c
-#define _SM_HEX_DIGIT_13 d
-#define _SM_HEX_DIGIT_14 e
-#define _SM_HEX_DIGIT_15 f
-#define _SM_HEX_DIGIT_INDIRECT(x) _SM_HEX_DIGIT_##x
-#define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
-#define _SM_CONCAT_PASTE(a, b, c) a##b##c
-#define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                        \
-    {                                                                               \
-        (D3D_SHADER_MODEL) _SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)), SLANG_DXIL, \
-            "sm_" #major "_" #minor                                                 \
+#define SM_HEX_DIGIT_0 0
+#define SM_HEX_DIGIT_1 1
+#define SM_HEX_DIGIT_2 2
+#define SM_HEX_DIGIT_3 3
+#define SM_HEX_DIGIT_4 4
+#define SM_HEX_DIGIT_5 5
+#define SM_HEX_DIGIT_6 6
+#define SM_HEX_DIGIT_7 7
+#define SM_HEX_DIGIT_8 8
+#define SM_HEX_DIGIT_9 9
+#define SM_HEX_DIGIT_10 a
+#define SM_HEX_DIGIT_11 b
+#define SM_HEX_DIGIT_12 c
+#define SM_HEX_DIGIT_13 d
+#define SM_HEX_DIGIT_14 e
+#define SM_HEX_DIGIT_15 f
+#define SM_HEX_DIGIT_INDIRECT(x) SM_HEX_DIGIT_##x
+#define SM_HEX_DIGIT(x) SM_HEX_DIGIT_INDIRECT(x)
+#define SM_CONCAT_PASTE(a, b, c) a##b##c
+#define SM_CONCAT(a, b, c) SM_CONCAT_PASTE(a, b, c)
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                      \
+    {                                                                             \
+        (D3D_SHADER_MODEL) SM_CONCAT(0x, major, SM_HEX_DIGIT(minor)), SLANG_DXIL, \
+            "sm_" #major "_" #minor                                               \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
@@ -97,26 +97,26 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 9),
     SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
-#undef _SM_CONCAT
-#undef _SM_CONCAT_PASTE
-#undef _SM_HEX_DIGIT
-#undef _SM_HEX_DIGIT_INDIRECT
-#undef _SM_HEX_DIGIT_15
-#undef _SM_HEX_DIGIT_14
-#undef _SM_HEX_DIGIT_13
-#undef _SM_HEX_DIGIT_12
-#undef _SM_HEX_DIGIT_11
-#undef _SM_HEX_DIGIT_10
-#undef _SM_HEX_DIGIT_9
-#undef _SM_HEX_DIGIT_8
-#undef _SM_HEX_DIGIT_7
-#undef _SM_HEX_DIGIT_6
-#undef _SM_HEX_DIGIT_5
-#undef _SM_HEX_DIGIT_4
-#undef _SM_HEX_DIGIT_3
-#undef _SM_HEX_DIGIT_2
-#undef _SM_HEX_DIGIT_1
-#undef _SM_HEX_DIGIT_0
+#undef SM_CONCAT
+#undef SM_CONCAT_PASTE
+#undef SM_HEX_DIGIT
+#undef SM_HEX_DIGIT_INDIRECT
+#undef SM_HEX_DIGIT_15
+#undef SM_HEX_DIGIT_14
+#undef SM_HEX_DIGIT_13
+#undef SM_HEX_DIGIT_12
+#undef SM_HEX_DIGIT_11
+#undef SM_HEX_DIGIT_10
+#undef SM_HEX_DIGIT_9
+#undef SM_HEX_DIGIT_8
+#undef SM_HEX_DIGIT_7
+#undef SM_HEX_DIGIT_6
+#undef SM_HEX_DIGIT_5
+#undef SM_HEX_DIGIT_4
+#undef SM_HEX_DIGIT_3
+#undef SM_HEX_DIGIT_2
+#undef SM_HEX_DIGIT_1
+#undef SM_HEX_DIGIT_0
 };
 
 Result DeviceImpl::createBuffer(

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -80,10 +80,10 @@ static ShaderModelInfo kKnownShaderModels[] = {
 #define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
 #define _SM_CONCAT_PASTE(a, b, c) a##b##c
 #define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                          \
-    {                                                                                 \
-        (D3D_SHADER_MODEL)_SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)),                \
-            SLANG_DXIL, "sm_" #major "_" #minor                                       \
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                        \
+    {                                                                               \
+        (D3D_SHADER_MODEL) _SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)), SLANG_DXIL, \
+            "sm_" #major "_" #minor                                                 \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),


### PR DESCRIPTION
## Summary of the problem from the end user perspective

The gfx D3D12 backend's shader-model table did not recognize Shader Model 6.10, and HLSL emission preferred the DXR 1.3 native `dx::HitObject` path over the NVAPI `NvHitObject` path even when both capabilities were present, which does not match how the `HitObject` intrinsics themselves dispatch.

## Root cause

`SHADER_MODEL_INFO_DXIL` built the `D3D_SHADER_MODEL` enum value by directly token-pasting `0x##major##minor`, which only works for single-digit minor versions; it cannot represent SM 6.10's `0x6a` encoding. Separately, `HLSLSourceEmitter::emitSimpleTypeImpl` checked the SM 6.9 capability before the NVAPI capability when emitting `HitObjectType`, while the corresponding `HitObject` intrinsics in `hlsl.meta.slang` dispatch on `case hlsl_nvapi:` first.

## Solution in this PR

Added a two-level macro lookup table so `SHADER_MODEL_INFO_DXIL` can encode minor versions >= 10 as a hex digit, and registered SM 6.10 in `kKnownShaderModels`. Swapped the capability checks in `emitSimpleTypeImpl` so NVAPI is checked first, matching the `hlsl_nvapi` dispatch order used elsewhere.

### Notes to the reviewers; where to focus on

The new `_SM_HEX_DIGIT_*`/`_SM_CONCAT*` helper macros in `tools/gfx/d3d12/d3d12-device.cpp` are `#undef`'d right after use, consistent with the existing `SHADER_MODEL_INFO_DXBC`/`DXIL` macros in the same block.
